### PR TITLE
Fix failing permission service test

### DIFF
--- a/backend/services/permission.py
+++ b/backend/services/permission.py
@@ -56,10 +56,9 @@ class PermissionService:
         permission_entity = self._session.get(PermissionEntity, permission.id)
         if permission_entity is None:
             return False
-        elif not self.enforce(revoker, 'permission.revoke', f'permission/{permission_entity.id}'):
-            return False
-        elif not self.enforce(revoker, permission_entity.action, permission_entity.resource):
-            return False
+
+        self.enforce(revoker, 'permission.revoke', f'permission/{permission_entity.id}')
+        self.enforce(revoker, permission_entity.action, permission_entity.resource)
 
         self._session.delete(permission_entity)
         self._session.commit()


### PR DESCRIPTION
The API has changed slightly and we are now raising permission errors. Additional tests should be added in the future enforcing these checks.