### PR TITLE
Refactor backend user service to be idiomatic

### DIFF
--- a/backend/api/profile.py
+++ b/backend/api/profile.py
@@ -45,7 +45,7 @@ def update_profile(
     than registered_user.
 
     ProfileForm is used here, rather than User, for similar registration-specific
-    purposes. Importantly, it does not include the ID.
+    purposes. Importantly, ProfileForm doesn't contain an ID field.
     """
     pid, onyen = pid_onyen
     user = user_svc.get(pid)

--- a/backend/api/profile.py
+++ b/backend/api/profile.py
@@ -1,15 +1,29 @@
+"""Profile API
+
+This API is used to retrieve and update a user's profile."""
+
 from fastapi import APIRouter, Depends
 from .authentication import authenticated_pid
 from ..services import UserService
 from ..models import User, NewUser, ProfileForm
+
+__authors__ = ['Kris Jordan']
+__copyright__ = 'Copyright 2023'
+__license__ = 'MIT'
 
 api = APIRouter(prefix="/api/profile")
 
 PID = 0
 ONYEN = 1
 
+
 @api.get("", response_model=User | NewUser, tags=['profile'])
 def read_profile(pid_onyen: tuple[int, str] = Depends(authenticated_pid), user_svc: UserService = Depends()):
+    """Retrieve a user's profile. If the user does not exist, return a NewUser.
+
+    To handle new users, we rely only on the authenticated_pid dependency rather than
+    registered_user.
+    """
     pid, onyen = pid_onyen
     user = user_svc.get(pid)
     if user:
@@ -24,6 +38,15 @@ def update_profile(
     pid_onyen: tuple[int, str] = Depends(authenticated_pid),
     user_svc: UserService = Depends()
 ):
+    """Update a user's profile. If the user does not exist, create a new user.
+
+    Since the user is authenticated, we can trust the pid and onyen. However,
+    since the user may not be registered, we depend on authenticated_pid rather
+    than registered_user.
+
+    ProfileForm is used here, rather than User, for similar registration-specific
+    purposes. Importantly, it does not include the ID.
+    """
     pid, onyen = pid_onyen
     user = user_svc.get(pid)
     if user is None:
@@ -35,11 +58,12 @@ def update_profile(
             email=profile.email,
             pronouns=profile.pronouns,
         )
+        user = user_svc.create(user, user)
     else:
         user.first_name = profile.first_name
         user.last_name = profile.last_name
         user.email = profile.email
         user.pronouns = profile.pronouns
         user.onyen = onyen
-    user_svc.save(user)
+        user = user_svc.update(user, user)
     return user


### PR DESCRIPTION
This PR aims to do two things:

1. Add documentation to the profile editing routes
2. Refactor the user service to be more idiomatic

The latter is toward the end of this service being used as an example for developers to use as reference. Whereas the profile service endpoints expect the authenticated user to be the same as the user being created/updated in the user service, this service is more useful if we make it work more generally and idiomatically. The _subject_ is the user attempting to carry out the action and the _user_ is the resource the action applies to. This is the more common case developers will experience in features: _subject_ and _resource_ as two separate concerns. When profile editing, it's a special edge case where they are the same.