### PR TITLE
Refactor backend user service to be idiomatic and documented (#24)

### DIFF
--- a/backend/api/profile.py
+++ b/backend/api/profile.py
@@ -1,15 +1,29 @@
+"""Profile API
+
+This API is used to retrieve and update a user's profile."""
+
 from fastapi import APIRouter, Depends
 from .authentication import authenticated_pid
 from ..services import UserService
 from ..models import User, NewUser, ProfileForm
+
+__authors__ = ['Kris Jordan']
+__copyright__ = 'Copyright 2023'
+__license__ = 'MIT'
 
 api = APIRouter(prefix="/api/profile")
 
 PID = 0
 ONYEN = 1
 
+
 @api.get("", response_model=User | NewUser, tags=['profile'])
 def read_profile(pid_onyen: tuple[int, str] = Depends(authenticated_pid), user_svc: UserService = Depends()):
+    """Retrieve a user's profile. If the user does not exist, return a NewUser.
+
+    To handle new users, we rely only on the authenticated_pid dependency rather than
+    registered_user.
+    """
     pid, onyen = pid_onyen
     user = user_svc.get(pid)
     if user:
@@ -24,6 +38,15 @@ def update_profile(
     pid_onyen: tuple[int, str] = Depends(authenticated_pid),
     user_svc: UserService = Depends()
 ):
+    """Update a user's profile. If the user does not exist, create a new user.
+
+    Since the user is authenticated, we can trust the pid and onyen. However,
+    since the user may not be registered, we depend on authenticated_pid rather
+    than registered_user.
+
+    ProfileForm is used here, rather than User, for similar registration-specific
+    purposes. Importantly, ProfileForm doesn't contain an ID field.
+    """
     pid, onyen = pid_onyen
     user = user_svc.get(pid)
     if user is None:
@@ -35,11 +58,12 @@ def update_profile(
             email=profile.email,
             pronouns=profile.pronouns,
         )
+        user = user_svc.create(user, user)
     else:
         user.first_name = profile.first_name
         user.last_name = profile.last_name
         user.email = profile.email
         user.pronouns = profile.pronouns
         user.onyen = onyen
-    user_svc.save(user)
+        user = user_svc.update(user, user)
     return user


### PR DESCRIPTION
Factored out separate create vs. update methods.

Made the signature of create and update in the user service idiomatic (subject first, user model second) and improved permission check to have both feature-specific rule (a user can edit their own profile), as well as administrative permission check.