### PR TITLE
Fix redirect bug in production authentication

### DIFF
--- a/backend/api/authentication.py
+++ b/backend/api/authentication.py
@@ -193,7 +193,7 @@ def _handle_auth_in_production(
         if origin == 'localhost':
             target = 'http://localhost:1560/auth'  # TODO: Make this port an env variable
         else:
-            target = f'https://{HOST}/auth'
+            target = f'https://{origin}/auth'
         return RedirectResponse(
             f'{target}?token={token}&continue_to={continue_to}',
             headers={'Cache-Control': 'no-cache'},


### PR DESCRIPTION
When performing delegated authentication, the origin host is passed
as a query parameter. This is then used to redirect the user back to
the correct page after authentication. However, in production, the
origin host was not being passed correctly, and the user was being
redirected back to the production hostname.