### PR TITLE
Link GitHub accounts with CSXL accounts

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,110 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts
+script_location = backend/migrations
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.
+prepend_sys_path = .
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python-dateutil library that can be
+# installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to dateutil.tz.gettz()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the
+# "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to backend/migrations/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "version_path_separator" below.
+# version_locations = %(here)s/bar:%(here)s/bat:backend/migrations/versions
+
+# version path separator; As mentioned above, this is the character used to split
+# version_locations. The default within new alembic.ini files is "os", which uses os.pathsep.
+# If this key is omitted entirely, it falls back to the legacy behavior of splitting on spaces and/or commas.
+# Valid values for version_path_separator are:
+#
+# version_path_separator = :
+# version_path_separator = ;
+# version_path_separator = space
+version_path_separator = os  # Use os.pathsep. Default configuration used for new projects.
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# Logging configuration
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/backend/entities/user_entity.py
+++ b/backend/entities/user_entity.py
@@ -29,6 +29,12 @@ class UserEntity(EntityBase):
         String(64), nullable=False, default='')
     pronouns: Mapped[str] = mapped_column(
         String(32), nullable=False, default='')
+    github: Mapped[str] = mapped_column(
+        String(32), nullable=False, default='')
+    github_id: Mapped[int] = mapped_column(
+        Integer, nullable=True)
+    github_avatar: Mapped[str] = mapped_column(
+        String(), nullable=True)
 
     roles: Mapped[list['RoleEntity']] = relationship(secondary=user_role_table, back_populates='users')
     permissions: Mapped['PermissionEntity'] = relationship(back_populates='user')
@@ -43,6 +49,9 @@ class UserEntity(EntityBase):
             first_name=model.first_name,
             last_name=model.last_name,
             pronouns=model.pronouns,
+            github=model.github,
+            github_id=model.github_id,
+            github_avatar=model.github_avatar,
         )
 
     def to_model(self) -> User:
@@ -53,6 +62,9 @@ class UserEntity(EntityBase):
             email=self.email,
             first_name=self.first_name,
             last_name=self.last_name,
+            github=self.github,
+            github_id=self.github_id,
+            github_avatar=self.github_avatar,
             pronouns=self.pronouns,
         )
 
@@ -61,3 +73,6 @@ class UserEntity(EntityBase):
         self.first_name = model.first_name
         self.last_name = model.last_name
         self.pronouns = model.pronouns
+        self.github = model.github
+        self.github_id = model.github_id
+        self.github_avatar = model.github_avatar

--- a/backend/migrations/README
+++ b/backend/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/backend/migrations/env.py
+++ b/backend/migrations/env.py
@@ -1,0 +1,83 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+
+from alembic import context
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Use our project's environment variables for the connection string:
+from backend import database
+config.set_main_option('sqlalchemy.url', database._engine_str())
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+from backend.entities import EntityBase
+target_metadata = EntityBase.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/backend/migrations/script.py.mako
+++ b/backend/migrations/script.py.mako
@@ -1,0 +1,24 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/backend/migrations/versions/48c0ecafd25a_add_github_columns_to_user_table.py
+++ b/backend/migrations/versions/48c0ecafd25a_add_github_columns_to_user_table.py
@@ -1,0 +1,31 @@
+"""Add GitHub integration columns to user table
+
+Revision ID: 48c0ecafd25a
+Revises: 
+Create Date: 2023-04-01 09:28:21.368072
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '48c0ecafd25a'
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('user', sa.Column(
+        'github', sa.String(length=32), nullable=False, server_default=""))
+    op.add_column('user', sa.Column(
+        'github_id', sa.Integer(), nullable=True))
+    op.add_column('user', sa.Column(
+        'github_avatar', sa.String, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('user', 'github')
+    op.drop_column('user', 'github_id')
+    op.drop_column('user', 'github_avatar')

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -16,6 +16,9 @@ class User(BaseModel):
     last_name: str = ""
     email: str = ""
     pronouns: str = ""
+    github: str = ""
+    github_id: int | None = None
+    github_avatar: str | None = None
     permissions: list['Permission'] = []
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,5 @@ pytest >=7.2.1, <7.3.0
 python-dotenv >=1.0.0, <1.1.0
 requests >=2.28.2, <2.29.0
 sqlalchemy >=2.0.4, <2.1.0
+alembic >=1.10.2, <1.11.0
+pygithub >=1.58.0, <1.59.0

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,3 +1,4 @@
 from .user import UserService
 from .permission import PermissionService, UserPermissionError
 from .role import RoleService
+from .github import GitHubService

--- a/backend/services/github.py
+++ b/backend/services/github.py
@@ -1,0 +1,57 @@
+"""GitHub user authentication service."""
+
+import requests
+import uuid
+from fastapi import Depends
+from github import Github
+from ..database import Session, db_session
+from ..models import User
+from .user import UserService
+from ..env import getenv
+
+
+class GitHubService:
+    _session: Session
+    _user_svc: UserService
+
+    def __init__(self, session: Session = Depends(db_session), user_svc: UserService = Depends(UserService)):
+        self._session = session
+        self._user_svc = user_svc
+
+    def link_with_user(self, subject: User, oauth_code: str, redirect_uri: str):
+        """Authenticate a user via GitHub OAuth2."""
+        try:
+            token = self._get_github_oauth_token(oauth_code, redirect_uri)
+            github = Github(token)
+            github_user = github.get_user()
+            subject.github = github_user.login
+            subject.github_id = github_user.id
+            subject.github_avatar = github_user.avatar_url
+            self._user_svc.update(subject, subject)
+            return True
+        except:
+            return False
+
+    def remove_association(self, subject: User):
+        """Remove the GitHub association for a user."""
+        subject.github = ""
+        self._user_svc.update(subject, subject)
+
+    def get_oauth_login_url(self, redirect_uri: str) -> str:
+        """Get the GitHub OAuth2 link for a user."""
+        client_id = getenv('GITHUB_CLIENT_ID')
+        random_string = uuid.uuid4().hex  # Random String to prevent CSRF
+        uri = f'https://github.com/login/oauth/authorize?client_id={client_id}&redirect_uri={redirect_uri}&state={random_string}'
+        return uri
+
+    def _get_github_oauth_token(self, oauth_code: str, redirect_uri: str) -> str:
+        result = requests.post('https://github.com/login/oauth/access_token', data={
+            'client_id': getenv('GITHUB_CLIENT_ID'),
+            'client_secret': getenv('GITHUB_CLIENT_SECRET'),
+            'code': oauth_code,
+            'redirect_uri': redirect_uri,
+        }, headers={'Accept': 'application/json'})
+
+        json = result.json()
+        token = json['access_token']
+        return token

--- a/docs/github_integration.md
+++ b/docs/github_integration.md
@@ -1,0 +1,61 @@
+# GitHub Integration
+
+## Overview
+
+CSXL accounts can be linked with GitHub accounts for two interesting purposes:
+
+1. To enable GitHub avatars to serve as a user's CSXL profile picture. This allows us to avoid the need to host user profile pictures on our own servers, and also allows users to change their profile picture by changing their GitHub profile picture.
+2. To enable future extensions which integrate with GitHub, including:
+    * Login via GitHub rather than UNC SSO (this would give a path toward alumni and industry partners using the CSXL without a UNC SSO account)
+    * Public CSXL profiles that link to GitHub projects
+    * Course integrations, notably COMP423 sprint tracking, etc.
+
+## Implementation Notes
+
+Three fields were added to UserEntity:
+
+* `github` - the GitHub username of the user
+* `github_avatar_url` - the URL of the user's GitHub avatar
+* `github_id` - the GitHub user ID of the user
+
+Routes were added to `api/authentication.py` to handle the GitHub OAuth flow.
+
+1. `GET /auth/github_oauth_login_url` - This produces the URL the client is redirected to in order to initiate the GitHub OAuth flow. The URL is constructed using the `GITHUB_CLIENT_ID` environment variable.
+2. `GET /auth/github` - Upon return from GitHub, the user is redirected to this route with a code. This page produces some HTML to bootstrap the linkage of the CSXL account with the GitHub account. This is necessary due to the CSXL JWT bearer token stored in localStorage.
+3. `POST /auth/github` - The bootstrapped HTML initiates a POST request to this route, which completes the linkage of the CSXL account with the GitHub account.
+4. `DELETE /auth/github` - This route unlinks the CSXL account from the GitHub account.
+
+From the user interface, a user can visit their profile to manage the link / unlink with their GitHub account.
+
+## Development Concerns
+
+To utilize the GitHub integration in development, you will need to create a GitHub OAuth app on your personal account and add the appropriate environment variables to your `.env` file, as follows.
+
+1. Go to GitHub > Settings > Developer Settings > Oauth Apps > New OAuth App
+
+2. Fill out the form as follows:
+
+    * Application name: CSXL
+    * Homepage URL: `https://csxl.unc.edu`
+    * Authorization callback URL: `http://localhost:1560/auth/github`
+    * After creating the app, copy the client secret
+
+3. In `backend/.env`, add the following environment variables, with the information from the GitHub OAuth app:
+
+* `GITHUB_CLIENT_ID`
+* `GITHUB_CLIENT_SECRET`
+
+4. Finally, you will need to either reset the database or run `alembic upgrade head` to add the fields to `user`.
+
+## Deployment Concerns
+
+In production, the official CSXL GitHub OAuth app's Client ID and secret need to be added to the environment of the deployment:
+
+* `GITHUB_CLIENT_ID`
+* `GITHUB_CLIENT_SECRET`
+
+Additionally, the migration 48c0e needs to be run against on the production database: `alembic upgrade head`.
+
+## Future Work
+
+For deeper GitHub integration, we will need to store each user's GitHub OAuth token in some kind of store (ephemeral/redis or the database). This will require caution to avoid token leakage through the API.

--- a/frontend/src/app/profile/profile-editor/profile-editor.component.css
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.css
@@ -12,3 +12,7 @@
     margin-left: 8px;
     margin-bottom: 8px;
 }
+
+.mat-mdc-card-title a, .mat-mdc-card-title a:hover, .mat-mdc-card-title a:visited {
+    color: #fff;
+}

--- a/frontend/src/app/profile/profile-editor/profile-editor.component.html
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.html
@@ -36,3 +36,23 @@
         </mat-card-actions>
     </mat-card>
 </form>
+
+<mat-card *ngIf="profile.id">
+    <div *ngIf="profile.github !== ''; else associate_github">
+        <mat-card-header>
+            <img mat-card-avatar [src]="profile.github_avatar">
+            <mat-card-title>GitHub / <a href="https://github.com/{{profile.github}}" target="_blank">{{ profile.github }}</a></mat-card-title>
+        </mat-card-header>
+        <mat-card-actions>
+            <button mat-raised-button (click)="unlinkGitHub()">Unlink GitHub</button>
+        </mat-card-actions>
+    </div>
+    <ng-template #associate_github>
+        <mat-card-header>
+            <mat-card-title>Link Your GitHub Account</mat-card-title>
+        </mat-card-header>
+        <mat-card-actions>
+            <button mat-raised-button (click)="linkWithGitHub()">Link with GitHub</button>
+        </mat-card-actions>
+    </ng-template>
+</mat-card>

--- a/frontend/src/app/profile/profile-editor/profile-editor.component.ts
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.ts
@@ -72,4 +72,16 @@ export class ProfileEditorComponent implements OnInit {
     console.error("How to handle this?");
   }
 
+  linkWithGitHub(): void {
+    this.profileService.getGitHubOAuthLoginURL().subscribe((url) => {
+      window.location.href = url;
+    });
+  }
+
+  unlinkGitHub() {
+    this.profileService.unlinkGitHub().subscribe({
+      next: () => this.profile.github = '',
+    });
+  }
+
 }

--- a/frontend/src/app/profile/profile.service.ts
+++ b/frontend/src/app/profile/profile.service.ts
@@ -17,6 +17,9 @@ export interface Profile {
   last_name: string | null;
   email: string | null;
   pronouns: string | null;
+  github: string | null;
+  github_id: number | null;
+  github_avatar: string | null;
   registered: boolean;
   role: number;
   permissions: Permission[];
@@ -27,9 +30,13 @@ export interface Profile {
 })
 export class ProfileService {
 
-  public profile$: Observable<Profile | undefined>;
+  public profile$!: Observable<Profile | undefined>;
 
   constructor(protected http: HttpClient, protected auth: AuthenticationService) {
+    this.refreshProfile();
+  }
+
+  private refreshProfile() {
     this.profile$ = this.auth.isAuthenticated$.pipe(
       mergeMap(isAuthenticated => {
         if (isAuthenticated) {
@@ -49,6 +56,14 @@ export class ProfileService {
   search(query: string) {
     let encodedQuery = encodeURIComponent(query);
     return this.http.get<Profile[]>(`/api/user?q=${encodedQuery}`);
+  }
+
+  getGitHubOAuthLoginURL(): Observable<string> {
+    return this.http.get<string>("/auth/github_oauth_login_url");
+  }
+
+  unlinkGitHub() {
+    return this.http.delete("/auth/github");
   }
 
 }


### PR DESCRIPTION
With this commit, users can navigate to the profile page and link/unlink their GitHub account. This stores their username, avatar, and id in the `user` table. Having an avatar will serve many other site features.

Development and feature notes are found in `docs/github_integration.md` Additional environment variables and development app setup at GitHub is needed for this feature to work in development.

This is the first commit to land in production following relaunch, so I am adding migration scripts via alembic. Migration scripts will be needed moving forward to avoid clobbering data in production. Ahead of merging into production, be prepared to carry out the migration with documentation found in `docs/github_integration.md`.

This PR closes #33.