### PR TITLE
Fix issue with tooltip not showing

### DIFF
--- a/frontend/src/app/organizations/widgets/org-details-info-card/org-details-info-card.widget.html
+++ b/frontend/src/app/organizations/widgets/org-details-info-card/org-details-info-card.widget.html
@@ -6,7 +6,7 @@
             <img mat-card-image src={{organization!.logo}} class="logo">
         </div>
         <div class="right-header-info">
-            <!-- Organization Name, Social Media, and Star -->
+            <!-- Organization Name and Social Media -->
             <div class="organization-top-header-group">
                 <!-- Organization Name -->
                 <div class="organization-name-section">
@@ -26,12 +26,6 @@
                             *ngIf='organization!.linked_in != ""' />
                         <social-media-icon [svgIcon]='"youtube"' [href]='organization!.youtube'
                             *ngIf='organization!.youtube != ""' />
-
-                        <!-- Join button -->
-                        <!-- <button *ngIf="profile && profile.first_name" mat-icon-button color="basic"
-                            (click)="starClicked()">
-                            <mat-icon>{{profilePermission >= 0 ? "person_off" : "person_add"}}</mat-icon>
-                        </button> -->
                     </div>
                 </div>
             </div>

--- a/frontend/src/app/organizations/widgets/org-details-info-card/org-details-info-card.widget.ts
+++ b/frontend/src/app/organizations/widgets/org-details-info-card/org-details-info-card.widget.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { Organization } from '../../organizations.service';
 import { Profile } from 'src/app/profile/profile.service';
 
@@ -11,14 +11,8 @@ export class OrgDetailsInfoCard {
 
     @Input() organization?: Organization;
     @Input() profile?: Profile;
-    // @Input() profilePermission!: number;
     // @Input() isAdmin: boolean = false;
-    // @Output() onStarClicked = new EventEmitter<number>();
 
     constructor() {}
-
-    // starClicked() {
-    //     this.onStarClicked.emit(this.organization!.id!);
-    // }
 }
 

--- a/frontend/src/app/organizations/widgets/organization-card/organization-card.widget.css
+++ b/frontend/src/app/organizations/widgets/organization-card/organization-card.widget.css
@@ -44,7 +44,6 @@ mat-card {
     font-weight: 500;
     line-height: 2.5rem;
     overflow: hidden;
-    text-overflow: ellipsis;
     display: -webkit-box;
     -webkit-line-clamp: 1;
     line-clamp: 1;
@@ -63,7 +62,6 @@ mat-card {
     height: 40px;
     margin: 0;
     overflow: hidden;
-    text-overflow: ellipsis;
     display: -webkit-box;
     -webkit-line-clamp: 2;
     line-clamp: 2;

--- a/frontend/src/app/organizations/widgets/organization-card/organization-card.widget.html
+++ b/frontend/src/app/organizations/widgets/organization-card/organization-card.widget.html
@@ -9,8 +9,8 @@
             <img mat-card-image src={{organization.logo}} class="logo">
             <!-- Organization Name -->
             <mat-card-title class="name" [matTooltip]='organization.name' matTooltipPosition="above"
-                [matTooltipDisabled]="organization.name.length < 20">
-                {{organization.name.length < 20 ? organization.name : organization.slug}} </mat-card-title>
+                [matTooltipDisabled]="organization.name.length < 25">
+                {{organization.name.length < 25 ? organization.name : organization.slug}} </mat-card-title>
         </div>
 
         <!-- Organization Join Button button -->
@@ -24,7 +24,7 @@
     <!-- Organization Description -->
     <mat-card-content class="description">
         <p [matTooltip]='organization.short_description'
-            [matTooltipDisabled]='organization.short_description.length < 85'>
+            [matTooltipDisabled]="isTooltipDisabled(organizationDescription)" #organizationDescription>
             {{organization.short_description}}
         </p>
     </mat-card-content>

--- a/frontend/src/app/organizations/widgets/organization-card/organization-card.widget.ts
+++ b/frontend/src/app/organizations/widgets/organization-card/organization-card.widget.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { Organization } from '../../organizations.service';
 import { Profile } from 'src/app/profile/profile.service';
 
@@ -12,13 +12,8 @@ export class OrganizationCard {
     @Input() organization!: Organization
     @Input() profile?: Profile
     @Input() profilePermissions!: Map<number, number>
-    //@Output() onStarClicked = new EventEmitter<number>();
 
     constructor() { }
-
-    // starClicked() {
-    //     this.onStarClicked.emit(this.organization!.id!);
-    // }
 
     isTooltipDisabled(element: HTMLElement) {
         return element.scrollHeight <= element.clientHeight;

--- a/frontend/src/app/organizations/widgets/organization-card/organization-card.widget.ts
+++ b/frontend/src/app/organizations/widgets/organization-card/organization-card.widget.ts
@@ -19,6 +19,10 @@ export class OrganizationCard {
     // starClicked() {
     //     this.onStarClicked.emit(this.organization!.id!);
     // }
+
+    isTooltipDisabled(element: HTMLElement) {
+        return element.scrollHeight <= element.clientHeight;
+    }
 }
 
 


### PR DESCRIPTION
Fixed the following bug: On the organizations page, sometimes the tooltip would not show because of the way it was hard-coded to the length of characters in the description.

## Major Changes
- Added a function that checks whether or not the description height has been clipped, which is a more accurate indication of whether or not the tooltip should be shown
- Removed some unnecessary CSS

## Testing
Ran `honcho start`, made sure the tooltip showed up for all descriptions with ellipses.

> *This PR resolves issue #56 *