### PR TITLE
Organization Page Styling

### DIFF
--- a/frontend/src/app/organization/widgets/organization-card/organization-card.widget.css
+++ b/frontend/src/app/organization/widgets/organization-card/organization-card.widget.css
@@ -74,6 +74,7 @@ mat-card {
     flex-direction: row;
     width: 100%;
     justify-content: space-between;
+    padding-bottom: 14px;
 }
 
 .link-icons {

--- a/frontend/src/app/organization/widgets/organization-card/organization-card.widget.css
+++ b/frontend/src/app/organization/widgets/organization-card/organization-card.widget.css
@@ -59,7 +59,8 @@ mat-card {
 
 .description p {
     width: 100%;
-    height: 40px;
+    height: 2.5rem;
+    line-height: 1.25rem;
     margin: 0;
     overflow: hidden;
     display: -webkit-box;

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
@@ -159,6 +159,12 @@ a {
     }
 }
 
+@media only screen and (max-device-width: 1280px) {
+    .right-header-info {
+        width: 100%;
+    }
+}
+
 /** Make card name and description larger for monitors */
 @media only screen and (min-device-width: 2000px) {
     

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
@@ -14,11 +14,11 @@
     display: flex;
     align-items: flex-start;
     justify-content: space-between;
-    margin-bottom: 0.5rem;
+    padding-bottom: 16px;
 }
 
 .left-header-info {
-    padding-top: 0.75rem;
+    padding-top: 0.5rem;
     width: 10%;
 }
 
@@ -31,6 +31,8 @@
 .organization-top-header-group {
     display: flex;
     flex-direction: row;
+    align-items: center;
+    justify-content: center;
 }
 
 .organization-name-section {
@@ -46,7 +48,7 @@
     display: flex;
     flex-direction: row-reverse;
     width: 50%;
-    height: 48px;
+    height: 5vh;
 }
 
 mat-card-footer {
@@ -97,10 +99,11 @@ mat-card-footer {
 
 .organization-description {
     font-size: 1rem;
+    margin-top: 0;
 }
 
 .logo {
-    width: 80px;
+    width: 85%;
     border-radius: 50% !important;
 }
 
@@ -109,11 +112,11 @@ a {
 }
 
 /** Make cards display in one column, with the event card appearing last */
-@media only screen and (max-device-width: 1000px) {
+@media only screen and (max-device-width: 1180px) {
 
-    .left-header-info {}
-
-    .right-header-info {}
+    .right-header-info {
+        width: 100%;
+    }
 
     .organization-card {
         display: flex;
@@ -140,6 +143,7 @@ a {
 
     .organization-icons-section {
         width: 100%;
+        height: 100%;
     }
 
     button {
@@ -153,4 +157,22 @@ a {
     .edit-organization-button {
         margin-left: 0;
     }
+}
+
+/** Make card name and description larger for monitors */
+@media only screen and (min-device-width: 2000px) {
+    
+    .organization-description {
+        font-size: 1.5rem;
+    }
+
+    .user-name {
+        font-size: 2rem;
+        line-height: 2.5rem;
+    }
+
+    .organization-name-section {
+        height: 5vh;
+    }
+    
 }

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
@@ -31,7 +31,7 @@
 .organization-top-header-group {
     display: flex;
     flex-direction: row;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
 }
 
@@ -112,7 +112,7 @@ a {
 }
 
 /** Make cards display in one column, with the event card appearing last */
-@media only screen and (max-device-width: 1180px) {
+@media only screen and (max-width: 1180px) {
 
     .right-header-info {
         width: 100%;
@@ -143,7 +143,7 @@ a {
 
     .organization-icons-section {
         width: 100%;
-        height: 100%;
+        height: 100% !important;
     }
 
     button {
@@ -159,14 +159,14 @@ a {
     }
 }
 
-@media only screen and (max-device-width: 1280px) {
+@media only screen and (max-width: 1280px) {
     .right-header-info {
         width: 100%;
     }
 }
 
 /** Make card name and description larger for monitors */
-@media only screen and (min-device-width: 2000px) {
+@media only screen and (min-width: 2000px) {
     
     .organization-description {
         font-size: 1.5rem;

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
@@ -97,7 +97,7 @@ mat-card-footer {
 }
 
 .organization-description {
-    font-size: 1.15em;
+    font-size: 1rem;
 }
 
 .logo {

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
@@ -12,14 +12,13 @@
 
 .organization-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: space-between;
     margin-bottom: 0.5rem;
 }
 
 .left-header-info {
-    display: flex;
-    flex-direction: row;
+    /* padding-top: 0.75rem; */
     width: 10%;
 }
 

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
@@ -18,7 +18,7 @@
 }
 
 .left-header-info {
-    /* padding-top: 0.75rem; */
+    padding-top: 0.75rem;
     width: 10%;
 }
 

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.html
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.html
@@ -1,19 +1,21 @@
 <mat-card class="organization-card">
     <!-- Organization Card Header (Image, Name, Description) -->
     <mat-card-header class="organization-header">
-        <div class="left-header-info">
-            <!-- Organization Logo -->
+        <div class="left-header-info" *ngIf="!isTablet && !isHandset">
+            <!-- Organization Logo (Laptops/Monitors) -->
             <img mat-card-image src={{organization!.logo}} class="logo">
         </div>
         <div class="right-header-info">
-            <!-- Organization Name and Social Media -->
+            <!-- Organization Name, Logo, and Social Media -->
             <div class="organization-top-header-group">
+                <!-- Organization Logo (Tablets/Phones) -->
+                <img mat-card-image src={{organization!.logo}} class="logo" *ngIf="isTablet || isHandset" [ngStyle]="{'width': '32px', 'height': '32px', 'margin-right':'16px'}">
                 <!-- Organization Name -->
                 <div class="organization-name-section">
                     <mat-card-title class="user-name">{{organization!.name}}</mat-card-title>
                 </div>
-                <!-- Organization Icons -->
-                <div class="organization-icons-section">
+                <!-- Organization Icons (Laptops/Monitors/Tablets)-->
+                <div class="organization-icons-section" *ngIf="!isHandset">
                     <div class="link-icons">
 
                         <social-media-icon [fontIcon]='"link"' [href]='organization!.website'
@@ -32,6 +34,23 @@
 
             <!-- Organization Description -->
             <p class="organization-description">{{organization!.long_description}}</p>
+
+            <!-- Organization Icons (Phones)-->
+            <div class="organization-icons-section" *ngIf="isHandset" [ngStyle]="{'flex-direction': 'row'}">
+                <div class="link-icons">
+
+                    <social-media-icon [fontIcon]='"link"' [href]='organization!.website'
+                        *ngIf='organization!.website != ""' />
+                    <social-media-icon [fontIcon]='"mail"' [href]='"mailto:" + organization!.email'
+                        *ngIf='organization!.email != ""' />
+                    <social-media-icon [svgIcon]='"instagram"' [href]='organization!.instagram'
+                        *ngIf='organization!.instagram != ""' />
+                    <social-media-icon [svgIcon]='"linkedin"' [href]='organization!.linked_in'
+                        *ngIf='organization!.linked_in != ""' />
+                    <social-media-icon [svgIcon]='"youtube"' [href]='organization!.youtube'
+                        *ngIf='organization!.youtube != ""' />
+                </div>
+            </div>
 
             <!-- Link to Organization Editor -->
         </div>

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.ts
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.ts
@@ -1,4 +1,7 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
+import { Observable, Subscription } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { Organization } from '../../organization.service';
 import { Profile } from 'src/app/profile/profile.service';
 
@@ -7,12 +10,42 @@ import { Profile } from 'src/app/profile/profile.service';
     templateUrl: './organization-details-info-card.widget.html',
     styleUrls: ['./organization-details-info-card.widget.css']
 })
-export class OrganizationDetailsInfoCard {
+export class OrganizationDetailsInfoCard implements OnInit, OnDestroy {
 
     @Input() organization?: Organization;
     @Input() profile?: Profile;
 
-    constructor() {}
+    public isHandset: boolean = false;
+    private isHandsetSubscription!: Subscription;
+
+    public isTablet: boolean = false;
+    private isTabletSubscription!: Subscription;
+
+    constructor(private breakpointObserver: BreakpointObserver) {}
+
+    ngOnInit(): void {
+        this.isHandsetSubscription = this.initHandset();
+        this.isTabletSubscription = this.initTablet();
+    }
+
+    ngOnDestroy(): void {
+        this.isHandsetSubscription.unsubscribe();
+        this.isTabletSubscription.unsubscribe();
+    }
+
+    private initHandset() {
+        return this.breakpointObserver
+            .observe([Breakpoints.Handset, Breakpoints.TabletPortrait])
+            .pipe(map(result => result.matches))
+            .subscribe(isHandset => this.isHandset = isHandset);
+    }
+
+    private initTablet() {
+        return this.breakpointObserver
+            .observe(Breakpoints.TabletLandscape)
+            .pipe(map(result => result.matches))
+            .subscribe(isTablet => this.isTablet = isTablet);
+    }
 
 }
 


### PR DESCRIPTION
This pull request edits the CSS and styling of the organizations and organization details pages.

## Major Changes
- Set line height to two times the font size plus a little extra for the space between each line
 - Fix the bottom margin of the card so the spacing is consistent with the top part of the card
 - Reduce the font size on the Organization Details page and restyle the main card accordingly
 - Align the organization logo to the top left of the card
 - Response styling on the organization details page (for phones, tablets, laptops, and monitors)

## Testing
These changes were thoroughly tested on the local server by running `honcho start` and with various screen sizes.

Original Laptop View
<img src="https://github.com/unc-csxl/csxl.unc.edu/assets/37271052/a3e79b7f-2286-4308-9f1c-32832b3b8c42" width="300">

Monitor View
<img src="https://github.com/unc-csxl/csxl.unc.edu/assets/37271052/66d2cb48-988f-4ad9-9f67-767785afa1f6" width="300">

Tablet Views (Portrait and Landscape)
<img src="https://github.com/unc-csxl/csxl.unc.edu/assets/37271052/2471a6a8-3474-4d7d-924a-ef80752a9c89" width="300"><img src="https://github.com/unc-csxl/csxl.unc.edu/assets/37271052/eeb5b030-9336-41a3-9a05-6307ce546013" width="300">

Phone Views (Portrait and Landscape)
<img src="https://github.com/unc-csxl/csxl.unc.edu/assets/37271052/77a50a53-26f3-4031-9965-8109366625f2" width="300"> <img src="https://github.com/unc-csxl/csxl.unc.edu/assets/37271052/4354c852-7168-4257-bd56-ec1ce59aded33" width="300">

Please provide feedback on some of the styling decisions in the comments below. I would also appreciate any feedback on the CSS and styling since I only tested this on my personal laptop and don't know what it'll look like on other screens.

> *This PR resolves #48*