### PR TITLE
Migrate Organization Admin Page

### DIFF
--- a/frontend/src/app/admin/organization/list/admin-organization-list.component.css
+++ b/frontend/src/app/admin/organization/list/admin-organization-list.component.css
@@ -23,9 +23,8 @@
     justify-content: space-between;
 }
 
-.org_row {
+.row {
     display: flex;
-    flex-direction: row;
-    align-items: center;
     justify-content: space-between;
+    align-items: center;
 }

--- a/frontend/src/app/admin/organization/list/admin-organization-list.component.html
+++ b/frontend/src/app/admin/organization/list/admin-organization-list.component.html
@@ -5,12 +5,18 @@
             <th mat-header-cell *matHeaderCellDef>
                 <div class="header">
                     Organizations
+                    <button mat-stroked-button (click)="createOrganization()">Create</button>
                 </div>
             </th>
-            <td mat-cell *matCellDef="let element">{{element.name}}</td>
+            <td mat-cell *matCellDef="let element">
+                <div class="row">
+                    <p>{{element.name}}</p>
+                    <button mat-stroked-button (click)="deleteOrganization(element.id)">Delete</button>
+                </div>
+            </td>
         </ng-container>
 
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-        <tr mat-row *matRowDef="let row; columns: displayedColumns;" (click)="onClick(row)"></tr>
+        <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
     </table>
 </div>

--- a/frontend/src/app/admin/organization/list/admin-organization-list.component.ts
+++ b/frontend/src/app/admin/organization/list/admin-organization-list.component.ts
@@ -1,12 +1,13 @@
 /** Constructs the Admin Organization List page and stores/retrieves any necessary data for it. */
 
-import { ChangeDetectorRef, Component, inject } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ChangeDetectorRef, Component } from '@angular/core';
+import { Router } from '@angular/router';
 import { permissionGuard } from 'src/app/permission.guard';
 import { OrganizationAdminService } from '/workspace/frontend/src/app/admin/organization/organization-admin.service';
 import { Organization } from 'src/app/organization/organization.service';
 import { Observable } from 'rxjs';
 import { MatTableDataSource } from '@angular/material/table';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
     selector: 'app-admin-organization-list',
@@ -33,7 +34,8 @@ export class AdminOrganizationListComponent {
     constructor(
         private router: Router,
         private organizationAdminService: OrganizationAdminService,
-        private _cd: ChangeDetectorRef
+        private _cd: ChangeDetectorRef,
+        private snackBar: MatSnackBar
     ) {
         this.organizations$ = organizationAdminService.list();
 
@@ -42,12 +44,23 @@ export class AdminOrganizationListComponent {
             this._cd.detectChanges();
         });
     }
+    
+    /** Event handler to open the Organization Editor to create a new organization */
+    createOrganization = () => {
+        // Navigate to the org editor for a new organization (slug = create)
+        this.router.navigate(['organizations', 'new', 'edit']);
+    }
 
-    /** Event handler for opening the Admin Organization Details for the given organization
-     * @param organization: a valid Organization model
+    /** Delete an organization object from the backend database table using the backend HTTP post request. 
+     * @param organization_id: unique number representing the updated organization
+     * @returns void
      */
-    onClick = (organization: Organization) => {
-        // Navigate to the organization's detail page
-        this.router.navigate(['admin', 'organizations', organization.id]);
+    deleteOrganization = (organization_id: number) => {
+        let confirmDelete = this.snackBar.open("Are you sure you want to delete this organization?", "Delete");
+        confirmDelete.onAction().subscribe(() => {
+            this.organizationAdminService.deleteOrganization(organization_id).subscribe(() => {
+            this.snackBar.open("This organization has been deleted.", "", { duration: 2000 });
+          })
+        });
     }
 }

--- a/frontend/src/app/admin/organization/organization-admin.service.ts
+++ b/frontend/src/app/admin/organization/organization-admin.service.ts
@@ -23,10 +23,10 @@ export class OrganizationAdminService {
     }
 
     /** Deletes an organization
-     * @param org_id: id of the organization object to delete
+     * @param organization_id: id of the organization object to delete
      * @returns {Observable<Organization>}
      */
-    deleteOrganization = (org_id: number) => {
-        return this.http.delete<Organization>(`/api/organizations/${org_id}`);
+    deleteOrganization = (organization_id: number) => {
+        return this.http.delete<Organization>(`/api/organizations/${organization_id}`);
     }
 }

--- a/frontend/src/app/organization/organization-editor/organization-editor.component.css
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.css
@@ -1,0 +1,14 @@
+.mat-mdc-card {
+    margin: 1em;
+    max-width: 640px;
+  }
+  
+  .mat-mdc-form-field {
+    width: stretch;
+    /* margin-left: 1em; */
+  }
+  
+  .mat-mdc-card-actions .mdc-button {
+    margin-left: 8px;
+    margin-bottom: 8px;
+  }

--- a/frontend/src/app/organization/organization-editor/organization-editor.component.html
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.html
@@ -1,0 +1,80 @@
+<!-- HTML Structure of Profile Page -->
+
+<!-- Update Organization Form -->
+<form [formGroup]="organizationForm" (ngSubmit)="onSubmit()" *ngIf="adminPermission">
+    <!-- Update Organization Card -->
+    <mat-card>
+        <mat-card-header>
+            <mat-card-title>Create Organization</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+            <!-- Organization Name Field -->
+            <mat-form-field appearance="fill" color="accent">
+                <mat-label>Organization Name</mat-label>
+                <input matInput placeholder="" formControlName="name" name="name" required>
+            </mat-form-field>
+            <!-- Slug Field -->
+            <mat-form-field appearance="fill" color="accent">
+                <mat-label>Slug</mat-label>
+                <input matInput placeholder="" formControlName="slug" name="slug" required>
+            </mat-form-field>
+            <!-- Logo Field -->
+            <mat-form-field appearance="fill" color="accent">
+                <mat-label>Logo</mat-label>
+                <input matInput placeholder="" formControlName="logo" name="logo" required>
+            </mat-form-field>
+            <!-- Short Description Field -->
+            <mat-form-field appearance="fill" color="accent">
+                <mat-label>Short Description</mat-label>
+                <input matInput placeholder="Enter short description here." formControlName="short_description"
+                    name="short_description">
+            </mat-form-field>
+            <!-- Long Description Field -->
+            <mat-form-field appearance="fill" color="accent">
+                <mat-label>Long Description</mat-label>
+                <input matInput placeholder="Enter long description here." formControlName="long_description"
+                    name="long_description">
+            </mat-form-field>
+            <!-- Website Field -->
+            <mat-form-field appearance="fill" color="accent">
+                <mat-label>Website</mat-label>
+                <input matInput placeholder="" formControlName="website" name="website">
+            </mat-form-field>
+            <!-- Email Field -->
+            <mat-form-field appearance="fill" color="accent">
+                <mat-label>Email</mat-label>
+                <input matInput placeholder="" formControlName="email" name="email">
+            </mat-form-field>
+            <!-- Instagram Field -->
+            <mat-form-field appearance="fill" color="accent">
+                <mat-label>Instagram</mat-label>
+                <input matInput placeholder="" formControlName="instagram" name="instagram">
+            </mat-form-field>
+            <!-- LinkedIn Field -->
+            <mat-form-field appearance="fill" color="accent">
+                <mat-label>LinkedIn</mat-label>
+                <input matInput placeholder="" formControlName="linked_in" name="linked_in">
+            </mat-form-field>
+            <!-- YouTube Field -->
+            <mat-form-field appearance="fill" color="accent">
+                <mat-label>YouTube</mat-label>
+                <input matInput placeholder="" formControlName="youtube" name="youtube">
+            </mat-form-field>
+            <!-- HeelLife Field -->
+            <mat-form-field appearance="fill" color="accent">
+                <mat-label>HeelLife</mat-label>
+                <input matInput placeholder="" formControlName="heel_life" name="heel_life">
+            </mat-form-field>
+            <!-- Public Field -->
+            <p><mat-checkbox formControlName="public">Allow anyone to join your organization.</mat-checkbox></p>
+
+        </mat-card-content>
+        <mat-card-actions>
+            <!-- Submit Button -->
+            <button mat-raised-button type="submit" [disabled]="organizationForm.invalid">SAVE</button>
+        </mat-card-actions>
+    </mat-card>
+</form>
+
+<!-- Message for Non-Authenicated Users -->
+<p *ngIf="!adminPermission">You do not have permission to view this page.</p>

--- a/frontend/src/app/organization/organization-editor/organization-editor.component.html
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.html
@@ -65,9 +65,6 @@
                 <mat-label>HeelLife</mat-label>
                 <input matInput placeholder="" formControlName="heel_life" name="heel_life">
             </mat-form-field>
-            <!-- Public Field -->
-            <p><mat-checkbox formControlName="public">Allow anyone to join your organization.</mat-checkbox></p>
-
         </mat-card-content>
         <mat-card-actions>
             <!-- Submit Button -->

--- a/frontend/src/app/organization/organization-editor/organization-editor.component.spec.ts
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OrganizationEditorComponent } from './organization-editor.component';
+
+describe('OrganizationEditorComponent', () => {
+  let component: OrganizationEditorComponent;
+  let fixture: ComponentFixture<OrganizationEditorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ OrganizationEditorComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(OrganizationEditorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/organization/organization-editor/organization-editor.component.ts
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.ts
@@ -1,0 +1,136 @@
+/**
+ * The Organization Editor Component allows organization managers to edit information
+ * about their organization which is publically displayed on the organizations page.
+ * 
+ * @author Ajay Gandecha, Jade Keegan, Brianna Ta, Audrey Toney
+ * @copyright 2023
+ * @license MIT
+ */
+
+import { Component } from '@angular/core';
+import { ActivatedRoute, Route, Router } from '@angular/router';
+import { FormBuilder, Validators } from '@angular/forms';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Observable } from 'rxjs';
+import { profileResolver } from 'src/app/profile/profile.resolver';
+import { PermissionService } from 'src/app/permission.service';
+import { Organization, OrganizationService } from '../organization.service';
+import { Profile } from 'src/app/profile/profile.service';
+
+@Component({
+  selector: 'app-organization-editor',
+  templateUrl: './organization-editor.component.html',
+  styleUrls: ['./organization-editor.component.css']
+})
+export class OrganizationEditorComponent {
+  public static Route: Route = {
+    path: ':slug/edit',
+    component: OrganizationEditorComponent,
+    title: 'Organization Editor',
+    resolve: { profile: profileResolver }
+  };
+
+  /** Store the organization and its observable.  */
+  public organization$: Observable<Organization> | null = null;
+  public organization: Organization;
+
+  /** Store the currently-logged-in user's profile.  */
+  public profile: Profile | null = null;
+
+  /** Stores whether the user has admin permission over the current organization. */
+  public adminPermission: boolean = false;
+
+  /** Store the organization id. */
+  organization_slug: string = 'new';
+
+  /** Organization Editor Form */
+  public organizationForm = this.formBuilder.group({
+    name: "",
+    slug: "",
+    logo: "",
+    short_description: "",
+    long_description: "",
+    email: "",
+    website: "",
+    instagram: "",
+    linked_in: "",
+    youtube: "",
+    heel_life: "",
+    public: false
+  });
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    protected formBuilder: FormBuilder,
+    protected snackBar: MatSnackBar,
+    private organizationService: OrganizationService,
+    private permission: PermissionService) {
+    /** Add validators to the form */
+    const form = this.organizationForm;
+    form.get('name')?.addValidators(Validators.required);
+    form.get('logo')?.addValidators(Validators.required);
+    form.get('short_description')?.addValidators(Validators.required);
+
+    /** Get currently-logged-in user. */
+    const data = this.route.snapshot.data as { profile: Profile };
+    this.profile = data.profile;
+
+    /** Get id from the url */
+    let organization_slug = this.route.snapshot.params['slug'];
+    this.organization_slug = organization_slug;
+
+    /** Set permission value if profile exists */
+    if (this.organization_slug == 'new') {
+      this.permission.check('admin.view', 'admin/').subscribe((perm) => this.adminPermission = perm)
+    }
+
+    /** Initialize organization */
+    this.organization = {
+      id: null,
+      name: "",
+      slug: "",
+      logo: "",
+      short_description: "",
+      long_description: "",
+      email: "",
+      website: "",
+      instagram: "",
+      linked_in: "",
+      youtube: "",
+      heel_life: "",
+      public: false
+    };
+  }
+
+  /** Event handler to handle submitting the Update Organization Form.
+   * @returns {void}
+   */
+  onSubmit = () => {
+    if (this.organizationForm.valid) {
+      Object.assign(this.organization, this.organizationForm.value)
+      this.organizationService.createOrganization(this.organization).subscribe(
+        {
+          next: (organization) => this.onSuccess(organization),
+          error: (err) => this.onError(err)
+        }
+      );
+    }
+  }
+
+  /** Opens a confirmation snackbar when an organization is successfully updated.
+   * @returns {void}
+   */
+  private onSuccess = (organization: Organization) => {
+    this.router.navigate(['/organizations/', organization.slug]);
+    this.snackBar.open("Organization Created", "", { duration: 2000 })
+  }
+
+  /** Opens a snackbar when there is an error updating an organization.
+   * @returns {void}
+   */
+  private onError = (err: any) => {
+    console.error("Error: Organization Not Created");
+    this.snackBar.open("Error: Organization Not Created", "", { duration: 2000 })
+  }
+}

--- a/frontend/src/app/organization/organization-routing.module.ts
+++ b/frontend/src/app/organization/organization-routing.module.ts
@@ -2,10 +2,12 @@ import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { OrganizationPageComponent } from './organization-page/organization-page.component';
 import { OrganizationDetailsComponent } from './organization-details/organization-details.component';
+import { OrganizationEditorComponent } from '/workspace/frontend/src/app/organization/organization-editor/organization-editor.component'
 
 const routes: Routes = [
   OrganizationPageComponent.Route,
-  OrganizationDetailsComponent.Route
+  OrganizationDetailsComponent.Route,
+  OrganizationEditorComponent.Route
 ];
 
 @NgModule({

--- a/frontend/src/app/organization/organization.module.ts
+++ b/frontend/src/app/organization/organization.module.ts
@@ -29,11 +29,13 @@ import { OrganizationCard } from './widgets/organization-card/organization-card.
 import { RouterModule } from '@angular/router';
 import { SharedModule } from '../shared/shared.module';
 import { OrganizationDetailsInfoCard } from './widgets/organization-details-info-card/organization-details-info-card.widget';
+import { OrganizationEditorComponent } from '/workspace/frontend/src/app/organization/organization-editor/organization-editor.component';
 
 @NgModule({
   declarations: [
     OrganizationPageComponent,
     OrganizationDetailsComponent,
+    OrganizationEditorComponent,
 
     // Pipes
     OrganizationFilterPipe,

--- a/frontend/src/app/organization/organization.service.ts
+++ b/frontend/src/app/organization/organization.service.ts
@@ -62,4 +62,12 @@ export class OrganizationService {
     return this.http.get<Organization>("/api/organizations/" + id);
   }
 
+  /** Returns the new organization object from the backend database table using the backend HTTP post request. 
+   * @param org: OrganizationSummary representing the updated organization
+   * @returns {Observable<Organization>}
+   */
+    createOrganization = (organization: Organization) => {
+      return this.http.post<Organization>("/api/organizations", organization);
+    }
+
 }


### PR DESCRIPTION
This PR updates the frontend to include a tab for "Organizations" on the admin page as well as an organization creation form. These two features allow for the creation, deletion, and viewing of organizations in the database.

## Major Changes
- Added relevant TS, HTML, and CSS files for the Organization Admin page.
- Added relevant TS, HTML, and CSS files for the Organization Editor page.
- Modified modules/routing to accommodate for the new components.

## Testing
These changes were thoroughly tested on the local server by running `honcho start`.

> *This PR resolves issue #52*