### PR TITLE
Update OrganizationEntity and Add alembic migration script for Organization table

### DIFF
--- a/backend/entities/organization_entity.py
+++ b/backend/entities/organization_entity.py
@@ -18,9 +18,9 @@ class OrganizationEntity(EntityBase):
     # Unique ID for the organization
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     # Name of the organization
-    name: Mapped[str] = mapped_column(String)
+    name: Mapped[str] = mapped_column(String, nullable=False, default="")
     # Slug of the organization
-    slug: Mapped[str] = mapped_column(String)
+    slug: Mapped[str] = mapped_column(String, nullable=False, unique=True)
     # Logo of the organization
     logo: Mapped[str] = mapped_column(String)
     # Short description of the organization
@@ -40,7 +40,7 @@ class OrganizationEntity(EntityBase):
     # Heel Life for the organization
     heel_life: Mapped[str] = mapped_column(String)
     # Whether the organization can be joined by anyone or not
-    public: Mapped[bool] = mapped_column(Boolean)
+    public: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
 
     @classmethod

--- a/backend/migrations/versions/f7ad0c30eb78_add_organization_table.py
+++ b/backend/migrations/versions/f7ad0c30eb78_add_organization_table.py
@@ -1,0 +1,40 @@
+"""Add Organization Table
+
+Revision ID: f7ad0c30eb78
+Revises: 48c0ecafd25a
+Create Date: 2023-09-12 10:28:16.426542
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'f7ad0c30eb78'
+down_revision = '48c0ecafd25a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'organization',
+        sa.Column('id', sa.Integer(), nullable=False, autoincrement=True),
+        sa.Column('name', sa.String(), nullable=False),
+        sa.Column('slug', sa.String(), nullable=False, unique=True),
+        sa.Column('logo', sa.String(), nullable=True),
+        sa.Column('short_description', sa.String(), nullable=True),
+        sa.Column('long_description', sa.String(), nullable=True),
+        sa.Column('website', sa.String(), nullable=True),
+        sa.Column('email', sa.String(), nullable=True),
+        sa.Column('instagram', sa.String(), nullable=True),
+        sa.Column('linked_in', sa.String(), nullable=True),
+        sa.Column('youtube', sa.String(), nullable=True),
+        sa.Column('heel_life', sa.String(), nullable=True),
+        sa.Column('public', sa.Boolean(), nullable=False, default=True),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("organization")


### PR DESCRIPTION
This PR introduces two changes:

1. More concretely specifies a few of the properties of OrganizationEntity to enforce schema level constraints. Specifically:
- name is not nullable and defaults to empty string
- slug is not nullable and is enforced unique at the schema level
- public is not nullable and defaults to true
2. Adds an alembic upgrade/downgrade script in preparation for production deployment