### PR TITLE
Organization Test Fix for Refactor

### DIFF
--- a/backend/services/organization.py
+++ b/backend/services/organization.py
@@ -128,7 +128,7 @@ class OrganizationService:
 
         # If no role is found, raise an exception
         if len(org_roles) <= 0:
-            raise UserPermissionError("organization.update", f"organizations")
+            raise UserPermissionError("organization.update", f"organization")
 
         # Query the organization with matching id
         obj = self._session.query(OrganizationEntity).get(organization.id)
@@ -168,10 +168,12 @@ class OrganizationService:
             Exception if no organization is found with the corresponding slug
         """
         # Check if user has admin permissions
-        self._permission.enforce(subject, "organization.create", f"")
+        self._permission.enforce(subject, "organization.create", f"organization")
 
         # Find object to delete
-        obj = self._session.query(OrganizationEntity).get(slug)
+        obj = self._session.query(OrganizationEntity).filter(
+            OrganizationEntity.slug == slug
+        )[0]
 
         # Ensure object exists
         if obj:

--- a/backend/test/services/organization/organization_test.py
+++ b/backend/test/services/organization/organization_test.py
@@ -44,28 +44,14 @@ def test_get_all(organization_svc_integration: OrganizationService):
 # Test `OrganizationService.get_from_id()`
 
 
-def test_get_from_id(organization_svc_integration: OrganizationService):
+def test_get_from_slug(organization_svc_integration: OrganizationService):
     """Test that organizations can be retrieved based on their ID."""
-    fetched_organization = organization_svc_integration.get_from_id(cads.id)
+    fetched_organization = organization_svc_integration.get_from_slug(cads.slug)
     assert fetched_organization is not None
     assert isinstance(fetched_organization, Organization)
-    assert fetched_organization.id == cads.id
-
-
-# Test `OrganizationService.get_from_name()`
-
-
-def test_get_from_name(organization_svc_integration: OrganizationService):
-    """Test that organizations can be retrieved based on their name."""
-    for name in organization_names:
-        fetched_organization = organization_svc_integration.get_from_name(name)
-        assert fetched_organization is not None
-        assert isinstance(fetched_organization, Organization)
-        assert fetched_organization.name == name
-
+    assert fetched_organization.slug == cads.slug
 
 # Test `OrganizationService.create()`
-
 
 def test_create_enforces_permission(organization_svc_integration: OrganizationService):
     """Test that the service enforces permissions when attempting to create an organization."""
@@ -78,7 +64,7 @@ def test_create_enforces_permission(organization_svc_integration: OrganizationSe
     # Test permissions with root user (admin permission)
     organization_svc_integration.create(root, to_add)
     organization_svc_integration._permission.enforce.assert_called_with(
-        root, "organization.create", "organizations"
+        root, "organization.create", "organization"
     )
 
 
@@ -136,19 +122,18 @@ def test_delete_enforces_permission(organization_svc_integration: OrganizationSe
     )
 
     # Test permissions with root user (admin permission)
-    organization_svc_integration.delete(root, cads.id)
+    organization_svc_integration.delete(root, cads.slug)
     organization_svc_integration._permission.enforce.assert_called_with(
-        root, "organization.create", "organizations"
+        root, "organization.create", "organization"
     )
 
 
 def test_delete_organization_as_root(organization_svc_integration: OrganizationService):
     """Test that the root user is able to delete organizations."""
-    organization_svc_integration.delete(root, cads.id)
+    organization_svc_integration.delete(root, cads.slug)
 
     try:
-        organization_svc_integration.get_from_id(cads.id)
-        organization_svc_integration.get_from_name(cads.name)
+        organization_svc_integration.get_from_slug(cads.slug)
         pytest.fail()  # Fail test if no error was thrown above
     except:
         ...  # Test passes, because an error was thrown when we found no organization
@@ -157,7 +142,7 @@ def test_delete_organization_as_root(organization_svc_integration: OrganizationS
 def test_delete_organization_as_user(organization_svc_integration: OrganizationService):
     """Test that any user is *unable* to delete organizations."""
     try:
-        organization_svc_integration.delete(user, cads.id)
+        organization_svc_integration.delete(user, cads.slug)
         pytest.fail()  # Fail test if no error was thrown above
     except:
         ...  # Test passes, because a `UserPermissionError` was thrown as expected


### PR DESCRIPTION
This PR fixes test that were failing due to the slug refactor. Minor changes were needed here, as well as one leftover issue from a previous PR being merged in.