### PR TITLE
Improve Organization Retrieval for Organization Details Page

### DIFF
--- a/frontend/src/app/admin/organization/admin-organization.resolver.ts
+++ b/frontend/src/app/admin/organization/admin-organization.resolver.ts
@@ -1,0 +1,17 @@
+/**
+ * The Admin Organization Resolver allows the organizations to be injected into the routes
+ * of components.
+ * 
+ * @author Ajay Gandecha, Jade Keegan, Brianna Ta, Audrey Toney
+ * @copyright 2023
+ * @license MIT
+ */
+
+import { inject } from "@angular/core";
+import { ResolveFn } from "@angular/router";
+import { Organization } from "/workspace/frontend/src/app/organization/organization.service";
+import { AdminOrganizationService } from "./admin-organization.service"
+
+export const adminOrganizationResolver: ResolveFn<Organization[] | undefined> = (route, state) => {
+    return inject(AdminOrganizationService).list();
+};

--- a/frontend/src/app/admin/organization/admin-organization.service.ts
+++ b/frontend/src/app/admin/organization/admin-organization.service.ts
@@ -1,5 +1,5 @@
 /**
- * The Organization Admin Service abstracts backend calls from the
+ * The Admin Organization Service abstracts backend calls from the
  * Admin organization List Component.
  * 
  * @author Ajay Gandecha, Jade Keegan, Brianna Ta, Audrey Toney
@@ -9,11 +9,11 @@
 
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Organization } from 'src/app/organization/organization.service';
+import { Organization } from "/workspace/frontend/src/app/organization/organization.service";
 import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
-export class OrganizationAdminService {
+export class AdminOrganizationService {
 
     constructor(protected http: HttpClient) { }
 
@@ -40,3 +40,5 @@ export class OrganizationAdminService {
         return this.http.delete<Organization>(`/api/organizations/${slug}`);
     }
 }
+
+export { Organization };

--- a/frontend/src/app/admin/organization/list/admin-organization-list.component.html
+++ b/frontend/src/app/admin/organization/list/admin-organization-list.component.html
@@ -1,6 +1,6 @@
 <!-- HTML Structure of Admin Organizations List -->
 <div class="content">
-    <table mat-table [dataSource]="dataSource">
+    <table mat-table [dataSource]="organizations">
         <ng-container matColumnDef="name">
             <th mat-header-cell *matHeaderCellDef>
                 <div class="header">

--- a/frontend/src/app/organization/organization-details/organization-details.component.ts
+++ b/frontend/src/app/organization/organization-details/organization-details.component.ts
@@ -7,31 +7,19 @@
  * @license MIT
  */
 
-import { Component, inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { ActivatedRoute, ActivatedRouteSnapshot, ResolveFn, Route } from '@angular/router';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
-import { map } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { profileResolver } from '/workspace/frontend/src/app/profile/profile.resolver';
-import { Organization, OrganizationService } from '../organization.service';
+import { Organization } from '../organization.service';
 import { Profile } from '/workspace/frontend/src/app/profile/profile.service';
 import { organizationResolver } from '/workspace/frontend/src/app/organization/organization.resolver'
 
 let titleResolver: ResolveFn<string> = (route: ActivatedRouteSnapshot) => {
-  let organizationSlug = route.params['slug'];
-
-  let organizationDetailSvc = inject(OrganizationService);
-  let organization$ = organizationDetailSvc.getOrganization(organizationSlug);
-  return organization$.pipe(map(organization => {
-    if (organization) {
-      return `${organization.name}`;
-    }
-    else {
-      return "Organization Details"
-    }
-}));
-}
+  return route.parent!.data['organization'].name;
+};
 
 @Component({
   selector: 'app-organization-details',
@@ -42,8 +30,8 @@ export class OrganizationDetailsComponent {
   public static Route: Route = {
     path: ':slug',
     component: OrganizationDetailsComponent,
-    title: titleResolver,
     resolve: { profile: profileResolver, organization: organizationResolver },
+    children: [{ path: '', title: titleResolver, component: OrganizationDetailsComponent }]
   };
 
   /** Store the currently-logged-in user's profile.  */

--- a/frontend/src/app/organization/organization-details/organization-details.component.ts
+++ b/frontend/src/app/organization/organization-details/organization-details.component.ts
@@ -11,11 +11,12 @@ import { Component, inject } from '@angular/core';
 import { ActivatedRoute, ActivatedRouteSnapshot, ResolveFn, Route } from '@angular/router';
 import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
-import { Observable, map } from 'rxjs';
+import { map } from 'rxjs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { profileResolver } from '/workspace/frontend/src/app/profile/profile.resolver';
 import { Organization, OrganizationService } from '../organization.service';
-import { Profile, ProfileService } from '/workspace/frontend/src/app/profile/profile.service';
+import { Profile } from '/workspace/frontend/src/app/profile/profile.service';
+import { organizationResolver } from '/workspace/frontend/src/app/organization/organization.resolver'
 
 let titleResolver: ResolveFn<string> = (route: ActivatedRouteSnapshot) => {
   let organizationSlug = route.params['slug'];
@@ -42,18 +43,14 @@ export class OrganizationDetailsComponent {
     path: ':slug',
     component: OrganizationDetailsComponent,
     title: titleResolver,
-    resolve: { profile: profileResolver }
+    resolve: { profile: profileResolver, organization: organizationResolver },
   };
-
-  public organization$: Observable<Organization>;
-  public organization: Organization | undefined = undefined;
-  slug: string = '';
 
   /** Store the currently-logged-in user's profile.  */
   public profile: Profile;
+  public organization: Organization;
 
   constructor(
-    private orgService: OrganizationService,
     iconRegistry: MatIconRegistry,
     sanitizer: DomSanitizer,
     private route: ActivatedRoute,
@@ -65,15 +62,8 @@ export class OrganizationDetailsComponent {
     iconRegistry.addSvgIcon('youtube', sanitizer.bypassSecurityTrustResourceUrl('https://simpleicons.org/icons/youtube.svg'))
 
     /** Get currently-logged-in user. */
-    const data = route.snapshot.data as { profile: Profile };
+    const data = this.route.snapshot.data as { profile: Profile, organization: Organization };
     this.profile = data.profile;
-
-    /** Load current route slug */
-    this.route.params.subscribe(params => this.slug = params["slug"]);
-
-    /** Retrieve Organization using OrgDetailsService */
-    this.organization$ = this.orgService.getOrganization(this.slug);
-    this.organization$.subscribe(organization => this.organization = organization);
-
+    this.organization = data.organization;
   }
 }

--- a/frontend/src/app/organization/organization-details/organization-details.component.ts
+++ b/frontend/src/app/organization/organization-details/organization-details.component.ts
@@ -15,7 +15,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { profileResolver } from '/workspace/frontend/src/app/profile/profile.resolver';
 import { Organization } from '../organization.service';
 import { Profile } from '/workspace/frontend/src/app/profile/profile.service';
-import { organizationDetailResolver, organizationResolver } from '/workspace/frontend/src/app/organization/organization.resolver'
+import { organizationDetailResolver } from '/workspace/frontend/src/app/organization/organization.resolver'
 
 let titleResolver: ResolveFn<string> = (route: ActivatedRouteSnapshot) => {
   return route.parent!.data['organization'].name;

--- a/frontend/src/app/organization/organization-details/organization-details.component.ts
+++ b/frontend/src/app/organization/organization-details/organization-details.component.ts
@@ -15,7 +15,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { profileResolver } from '/workspace/frontend/src/app/profile/profile.resolver';
 import { Organization } from '../organization.service';
 import { Profile } from '/workspace/frontend/src/app/profile/profile.service';
-import { organizationResolver } from '/workspace/frontend/src/app/organization/organization.resolver'
+import { organizationDetailResolver, organizationResolver } from '/workspace/frontend/src/app/organization/organization.resolver'
 
 let titleResolver: ResolveFn<string> = (route: ActivatedRouteSnapshot) => {
   return route.parent!.data['organization'].name;
@@ -30,7 +30,7 @@ export class OrganizationDetailsComponent {
   public static Route: Route = {
     path: ':slug',
     component: OrganizationDetailsComponent,
-    resolve: { profile: profileResolver, organization: organizationResolver },
+    resolve: { profile: profileResolver, organization: organizationDetailResolver },
     children: [{ path: '', title: titleResolver, component: OrganizationDetailsComponent }]
   };
 

--- a/frontend/src/app/organization/organization-editor/organization-editor.component.ts
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.ts
@@ -7,7 +7,7 @@
  * @license MIT
  */
 
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ActivatedRoute, Route, Router } from '@angular/router';
 import { FormBuilder, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -27,7 +27,7 @@ export class OrganizationEditorComponent {
     path: ':slug/edit',
     component: OrganizationEditorComponent,
     title: 'Organization Editor',
-    resolve: { profile: profileResolver }
+    resolve: { profile: profileResolver}
   };
 
   /** Store the organization and its observable.  */

--- a/frontend/src/app/organization/organization-editor/organization-editor.component.ts
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.ts
@@ -16,6 +16,7 @@ import { profileResolver } from 'src/app/profile/profile.resolver';
 import { PermissionService } from 'src/app/permission.service';
 import { Organization, OrganizationService } from '../organization.service';
 import { Profile } from 'src/app/profile/profile.service';
+import { permissionGuard } from 'src/app/permission.guard';
 
 @Component({
   selector: 'app-organization-editor',
@@ -27,7 +28,8 @@ export class OrganizationEditorComponent {
     path: ':slug/edit',
     component: OrganizationEditorComponent,
     title: 'Organization Editor',
-    resolve: { profile: profileResolver}
+    resolve: { profile: profileResolver },
+    canActivate: [permissionGuard('admin.view', 'admin/')]
   };
 
   /** Store the organization and its observable.  */

--- a/frontend/src/app/organization/organization-editor/organization-editor.component.ts
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.ts
@@ -7,7 +7,7 @@
  * @license MIT
  */
 
-import { Component, inject } from '@angular/core';
+import { Component } from '@angular/core';
 import { ActivatedRoute, Route, Router } from '@angular/router';
 import { FormBuilder, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -28,8 +28,8 @@ export class OrganizationEditorComponent {
     path: ':slug/edit',
     component: OrganizationEditorComponent,
     title: 'Organization Editor',
-    resolve: { profile: profileResolver },
-    canActivate: [permissionGuard('admin.view', 'admin/')]
+    canActivate: [permissionGuard('admin.view', 'admin/')],
+    resolve: { profile: profileResolver }
   };
 
   /** Store the organization and its observable.  */

--- a/frontend/src/app/organization/organization-filter/organization-filter.pipe.ts
+++ b/frontend/src/app/organization/organization-filter/organization-filter.pipe.ts
@@ -21,22 +21,18 @@ export class OrganizationFilterPipe implements PipeTransform {
    * @param {String} searchQuery: input string to filter by
    * @returns {Observable<Organization[]>}
    */
-  transform(organizations: Observable<Organization[]>, searchQuery: String): Observable<Organization[]> {
+  transform(organizations: Organization[], searchQuery: String): Organization[] {
     // Sort the organizations list alphabetically by name
-    organizations = organizations.pipe(
-      map(orgs => orgs.sort((a: Organization, b: Organization) => {
-        return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
-      }))
-    )
+    organizations = organizations.sort((a: Organization, b: Organization) => {
+      return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+    })
 
     // If a search query is provided, return the organizations that start with the search query.
     if (searchQuery) {
-      return organizations.pipe(
-        map(organizations => organizations
-          .filter(organization =>
-            organization.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
-            organization.short_description.toLowerCase().includes(searchQuery.toLowerCase()) ||
-            organization.long_description.toLowerCase().includes(searchQuery.toLowerCase()))));
+      return organizations.filter(organization =>
+        organization.name.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        organization.short_description.toLowerCase().includes(searchQuery.toLowerCase()) ||
+        organization.long_description.toLowerCase().includes(searchQuery.toLowerCase()));
     } else {
       // Otherwise, return the original list.
       return organizations;

--- a/frontend/src/app/organization/organization-page/organization-page.component.html
+++ b/frontend/src/app/organization/organization-page/organization-page.component.html
@@ -9,6 +9,6 @@
         <!-- Display card for each organization, potentially filtered based on the search query. -->
         <organization-card class='card' [organization]='organization' [profile]='profile'
             [profilePermissions]='permValues'
-            *ngFor='let organization of (organizations$ | organizationFilter: searchBarQuery) | async' />
+            *ngFor='let organization of (organizations | organizationFilter: searchBarQuery)' />
     </div>
 </div>

--- a/frontend/src/app/organization/organization-page/organization-page.component.ts
+++ b/frontend/src/app/organization/organization-page/organization-page.component.ts
@@ -15,6 +15,7 @@ import { Organization, OrganizationService } from '../organization.service';
 import { ActivatedRoute } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Profile } from '/workspace/frontend/src/app/profile/profile.service';
+import { organizationResolver } from '../organization.resolver';
 
 @Component({
   selector: 'app-organization-page',
@@ -29,11 +30,11 @@ export class OrganizationPageComponent {
     title: 'CS Organizations',
     component: OrganizationPageComponent,
     canActivate: [],
-    resolve: { profile: profileResolver }
+    resolve: { profile: profileResolver, organizations: organizationResolver }
   }
 
   /** Store Observable list of Organizations */
-  public organizations$: Observable<Organization[]>;
+  public organizations: Organization[];
 
   /** Store searchBarQuery */
   public searchBarQuery = "";
@@ -51,10 +52,9 @@ export class OrganizationPageComponent {
   ) {
 
     /** Get currently-logged-in user. */
-    const data = this.route.snapshot.data as { profile: Profile };
+    const data = this.route.snapshot.data as { profile: Profile, organizations: Organization[] };
     this.profile = data.profile;
+    this.organizations = data.organizations;
 
-    /** Retrieve Organizations using OrganizationsService */
-    this.organizations$ = this.organizationService.getOrganizations();
   }
 }

--- a/frontend/src/app/organization/organization-page/organization-page.component.ts
+++ b/frontend/src/app/organization/organization-page/organization-page.component.ts
@@ -9,9 +9,8 @@
  */
 
 import { Component } from '@angular/core';
-import { Observable } from 'rxjs';
 import { profileResolver } from '/workspace/frontend/src/app/profile/profile.resolver';
-import { Organization, OrganizationService } from '../organization.service';
+import { Organization } from '../organization.service';
 import { ActivatedRoute } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Profile } from '/workspace/frontend/src/app/profile/profile.service';
@@ -46,7 +45,6 @@ export class OrganizationPageComponent {
   public permValues: Map<number, number> = new Map();
 
   constructor(
-    private organizationService: OrganizationService,
     private route: ActivatedRoute,
     protected snackBar: MatSnackBar,
   ) {

--- a/frontend/src/app/organization/organization.resolver.ts
+++ b/frontend/src/app/organization/organization.resolver.ts
@@ -14,6 +14,7 @@ import { Organization, OrganizationService } from "./organization.service"
 export const organizationResolver: ResolveFn<Organization[] | undefined> = (route, state) => {
     return inject(OrganizationService).getOrganizations();
 };
+
 export const organizationDetailResolver: ResolveFn<Organization | undefined> = (route, state) => {
     return inject(OrganizationService).getOrganization(route.paramMap.get('slug')!);
 };

--- a/frontend/src/app/organization/organization.resolver.ts
+++ b/frontend/src/app/organization/organization.resolver.ts
@@ -1,0 +1,16 @@
+/**
+ * The Organization Resolver allows the organization to be injected into the routes
+ * of components.
+ * 
+ * @author Ajay Gandecha, Jade Keegan, Brianna Ta, Audrey Toney
+ * @copyright 2023
+ * @license MIT
+ */
+
+import { inject } from "@angular/core";
+import { ResolveFn } from "@angular/router";
+import { Organization, OrganizationService } from "./organization.service"
+
+export const organizationResolver: ResolveFn<Organization | undefined> = (route, state) => {
+    return inject(OrganizationService).getOrganization(route.paramMap.get('slug')!);
+};

--- a/frontend/src/app/organization/organization.resolver.ts
+++ b/frontend/src/app/organization/organization.resolver.ts
@@ -11,6 +11,9 @@ import { inject } from "@angular/core";
 import { ResolveFn } from "@angular/router";
 import { Organization, OrganizationService } from "./organization.service"
 
-export const organizationResolver: ResolveFn<Organization | undefined> = (route, state) => {
+export const organizationResolver: ResolveFn<Organization[] | undefined> = (route, state) => {
+    return inject(OrganizationService).getOrganizations();
+};
+export const organizationDetailResolver: ResolveFn<Organization | undefined> = (route, state) => {
     return inject(OrganizationService).getOrganization(route.paramMap.get('slug')!);
 };

--- a/frontend/src/app/organization/organization.service.ts
+++ b/frontend/src/app/organization/organization.service.ts
@@ -1,12 +1,17 @@
-/** Abstracts HTTP request functionality for organizations away from the backend database */
+/**
+ * The Organization Service abstracts HTTP requests to the backend
+ * from the components.
+ * 
+ * @author Ajay Gandecha, Jade Keegan, Brianna Ta, Audrey Toney
+ * @copyright 2023
+ * @license MIT
+ */
 
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { AuthenticationService } from '../authentication.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Observable, mergeMap, of, shareReplay } from 'rxjs';
-import { Profile } from '../profile/profile.service';
-
+import { Observable } from 'rxjs';
 
 /** Interface for Organization Type (used on frontend for organization detail) */
 export interface Organization {
@@ -29,22 +34,9 @@ export interface Organization {
     providedIn: 'root'
 })
 export class OrganizationService {
-
-  /** Store profile observable*/
-  public profile$: Observable<Profile | undefined>;
-
-  constructor(protected http: HttpClient, protected auth: AuthenticationService, protected snackBar: MatSnackBar) {
-    /** If profile is authenticated, display profile page. */
-    this.profile$ = this.auth.isAuthenticated$.pipe(
-      mergeMap(isAuthenticated => {
-        if (isAuthenticated) {
-          return this.http.get<Profile>('/api/profile');
-        } else {
-          return of(undefined);
-        }
-      }),
-      shareReplay(1)
-    );
+  constructor(protected http: HttpClient, 
+              protected auth: AuthenticationService, 
+              protected snackBar: MatSnackBar) {
   }
 
   /** Returns all organization entries from the backend database table using the backend HTTP get request. 


### PR DESCRIPTION
This PR refactors the Organization Details page to use a route resolver to retrieve the organization and its data rather than subscribing to directly within the component. It also fixes the titleResolver so it uses the organization from the route instead of making its own HTTP request to get the organization name.

# Major Changes
- Updated the Organization Service to remove profile retrieval since the profile isn't actually used in that service.
- Added an Organization Resolver TS file to store the `organizationResolver` ResolveFn.
- Refactored the Organization Details Component to use the `organizationResolver` rather than directly calling the service and subscribing to the returned Observable.
- Changed the `title` in the route to be a child of the main route so it can inherit from the Organization Details Component parent route.
- Updated the `titleResolver` ResolveFn to use the parent data to get the organization.

# Testing
All changes were tested thoroughly on the local server by running `honcho start`.

# Developer Notes
Currently, the `titleResolver` function is in the Organization Details component. To match the other resolve functions, we could move it to its own TS file.