### PR TITLE
Add alembic migration to add shorthand column

### DIFF
--- a/backend/migrations/versions/fe326bad2907_add_shorthand_to_organization.py
+++ b/backend/migrations/versions/fe326bad2907_add_shorthand_to_organization.py
@@ -1,0 +1,28 @@
+"""Add shorthand to organization
+
+Revision ID: fe326bad2907
+Revises: f7ad0c30eb78
+Create Date: 2023-09-30 16:47:32.931411
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = 'fe326bad2907'
+down_revision = 'f7ad0c30eb78'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('organization', sa.Column('shorthand', sa.String()))
+    # Default the shorthand of an org to name. Can be edited in admin later.
+    op.execute(text("UPDATE organization SET shorthand = name"))
+    op.alter_column('organization', 'shorthand', nullable=False)
+
+
+def downgrade() -> None:
+    op.drop_column('organization', 'shorthand')


### PR DESCRIPTION
Here's the migration to add the shorthand column to the production database. The one implementation decision of note is that because this table already exists with populated data, the upgrade process is:

1. Add column (without non-null constraint)
2. Copy over the name column to the shorthand column (for now)
3. Add the non-null constraint

This means for orgs whose shorthand is different from their name, we'll need to either edit them via admin panel or write a separate post-deploy script if admin panel isn't ready and we really need different shorthands.