### PR TITLE
Fix Organization List HTML Update After Delete

### DIFF
--- a/frontend/src/app/admin/organization/list/admin-organization-list.component.ts
+++ b/frontend/src/app/admin/organization/list/admin-organization-list.component.ts
@@ -61,7 +61,8 @@ export class AdminOrganizationListComponent {
         let confirmDelete = this.snackBar.open("Are you sure you want to delete this organization?", "Delete");
         confirmDelete.onAction().subscribe(() => {
             this.adminOrganizationService.deleteOrganization(slug).subscribe(() => {
-            this.snackBar.open("This organization has been deleted.", "", { duration: 2000 });
+                this.organizations = this.organizations.filter(o => o.slug !== slug);
+                this.snackBar.open("This organization has been deleted.", "", { duration: 2000 });
           })
         });
     }


### PR DESCRIPTION
This PR implements a quick fix to ensure that the HTML updates after an organization is deleted on the organization admin page.

## Major Changes
- Added a line in the subscription to deleteOrganization() to filter out the organization from the component's organizations array.

## Testing
All changes were tested on the local server after running `honcho start`.

## Developer Notes
This is a temporary fix (modeled after how the admin roles list is updated). This will be changed if the code is refactored to use RXJS objects throughout the application.