### PR TITLE
Update Functionality in Organization Editor

### DIFF
--- a/frontend/src/app/organization/organization-editor/organization-editor.component.html
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.html
@@ -1,7 +1,7 @@
 <!-- HTML Structure of Profile Page -->
 
 <!-- Update Organization Form -->
-<form [formGroup]="organizationForm" (ngSubmit)="onSubmit()" *ngIf="adminPermission">
+<form [formGroup]="organizationForm" (ngSubmit)="onSubmit()" *ngIf="adminPermission$ | async">
     <!-- Update Organization Card -->
     <mat-card>
         <mat-card-header>
@@ -80,4 +80,4 @@
 </form>
 
 <!-- Message for Non-Authenicated Users -->
-<p *ngIf="!adminPermission">You do not have permission to view this page.</p>
+<p *ngIf="!(adminPermission$ | async)">You do not have permission to view this page.</p>

--- a/frontend/src/app/organization/organization-editor/organization-editor.component.html
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.html
@@ -78,6 +78,3 @@
         </mat-card-actions>
     </mat-card>
 </form>
-
-<!-- Message for Non-Authenicated Users -->
-<p *ngIf="!(adminPermission$ | async)">You do not have permission to view this page.</p>

--- a/frontend/src/app/organization/organization-editor/organization-editor.component.ts
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.ts
@@ -17,6 +17,7 @@ import { PermissionService } from 'src/app/permission.service';
 import { Organization, OrganizationService } from '../organization.service';
 import { Profile } from 'src/app/profile/profile.service';
 import { permissionGuard } from 'src/app/permission.guard';
+import { organizationDetailResolver } from '/workspace/frontend/src/app/organization/organization.resolver'
 
 @Component({
   selector: 'app-organization-editor',
@@ -29,25 +30,24 @@ export class OrganizationEditorComponent {
     component: OrganizationEditorComponent,
     title: 'Organization Editor',
     canActivate: [permissionGuard('admin.view', 'admin/')],
-    resolve: { profile: profileResolver }
+    resolve: { profile: profileResolver, organization: organizationDetailResolver },
   };
 
-  /** Store the organization and its observable.  */
-  public organization$: Observable<Organization> | null = null;
+  /** Store the organization.  */
   public organization: Organization;
 
   /** Store the currently-logged-in user's profile.  */
   public profile: Profile | null = null;
 
   /** Stores whether the user has admin permission over the current organization. */
-  public adminPermission: boolean = false;
+  public adminPermission$: Observable<boolean>;
 
   /** Store the organization id. */
   organization_slug: string = 'new';
 
   /** Add validators to the form */
   name = new FormControl('', [Validators.required]);
-  slug = new FormControl('', [Validators.required, Validators.pattern('^[a-z0-9-]+$')]);
+  slug = new FormControl('', [Validators.required, Validators.pattern('^(?!new$)[a-z0-9-]+$')]);
   logo = new FormControl('', [Validators.required]);
   email = new FormControl('', [Validators.email]);
   shortDescription = new FormControl('', [Validators.required, Validators.maxLength(150)]);
@@ -82,36 +82,36 @@ export class OrganizationEditorComponent {
     private organizationService: OrganizationService,
     private permission: PermissionService) {
 
-    /** Get currently-logged-in user. */
-    const data = this.route.snapshot.data as { profile: Profile };
+    /** Get currently-logged-in user and and organization. */
+    const data = this.route.snapshot.data as { profile: Profile, organization: Organization };
     this.profile = data.profile;
+
+    /** Initialize organization */
+    this.organization = data.organization;
+
+    /** Set organization form data */
+    this.organizationForm.setValue({
+      name: this.organization.name,
+      slug: this.organization.slug,
+      shorthand: this.organization.shorthand,
+      logo: this.organization.logo,
+      short_description: this.organization.short_description,
+      long_description: this.organization.long_description,
+      email: this.organization.email,
+      website: this.organization.website,
+      instagram: this.organization.instagram,
+      linked_in: this.organization.linked_in,
+      youtube: this.organization.youtube,
+      heel_life: this.organization.heel_life,
+      public: this.organization.public
+    })
 
     /** Get id from the url */
     let organization_slug = this.route.snapshot.params['slug'];
     this.organization_slug = organization_slug;
 
-    /** Set permission value if profile exists */
-    if (this.organization_slug == 'new') {
-      this.permission.check('admin.view', 'admin/').subscribe((perm) => this.adminPermission = perm)
-    }
-
-    /** Initialize organization */
-    this.organization = {
-      id: null,
-      name: "",
-      shorthand: "",
-      slug: "",
-      logo: "",
-      short_description: "",
-      long_description: "",
-      email: "",
-      website: "",
-      instagram: "",
-      linked_in: "",
-      youtube: "",
-      heel_life: "",
-      public: false
-    };
+    /** Set permission value */
+    this.adminPermission$ = this.permission.check('admin.view', 'admin/');    
   }
 
   /** Event handler to handle submitting the Update Organization Form.
@@ -120,12 +120,22 @@ export class OrganizationEditorComponent {
   onSubmit(): void {
     if (this.organizationForm.valid) {
       Object.assign(this.organization, this.organizationForm.value)
-      this.organizationService.createOrganization(this.organization).subscribe(
-        {
-          next: (organization) => this.onSuccess(organization),
-          error: (err) => this.onError(err)
-        }
-      );
+      if(this.organization_slug == "new") {
+        this.organizationService.createOrganization(this.organization).subscribe(
+          {
+            next: (organization) => this.onSuccess(organization),
+            error: (err) => this.onError(err)
+          }
+        );
+      }
+      else {
+        this.organizationService.updateOrganization(this.organization).subscribe(
+          {
+            next: (organization) => this.onSuccess(organization),
+            error: (err) => this.onError(err)
+          }
+        );
+      }
     }
   }
 

--- a/frontend/src/app/organization/organization.resolver.ts
+++ b/frontend/src/app/organization/organization.resolver.ts
@@ -16,5 +16,25 @@ export const organizationResolver: ResolveFn<Organization[] | undefined> = (rout
 };
 
 export const organizationDetailResolver: ResolveFn<Organization | undefined> = (route, state) => {
-    return inject(OrganizationService).getOrganization(route.paramMap.get('slug')!);
+    if(route.paramMap.get('slug')! != "new") {
+        return inject(OrganizationService).getOrganization(route.paramMap.get('slug')!);
+    }
+    else {
+        return {
+            id: null,
+            name: "",
+            shorthand: "",
+            slug: "",
+            logo: "",
+            short_description: "",
+            long_description: "",
+            email: "",
+            website: "",
+            instagram: "",
+            linked_in: "",
+            youtube: "",
+            heel_life: "",
+            public: false
+          };
+    }
 };

--- a/frontend/src/app/organization/organization.service.ts
+++ b/frontend/src/app/organization/organization.service.ts
@@ -56,11 +56,19 @@ export class OrganizationService {
   }
 
   /** Returns the new organization object from the backend database table using the backend HTTP post request. 
-   * @param org: OrganizationSummary representing the updated organization
+   * @param organization: OrganizationSummary representing the new organization
    * @returns {Observable<Organization>}
    */
     createOrganization(organization: Organization): Observable<Organization> {
       return this.http.post<Organization>("/api/organizations", organization);
     }
+  
+    /** Returns the updated organization object from the backend database table using the backend HTTP put request. 
+    * @param organization: OrganizationSummary representing the updated organization
+    * @returns {Observable<Organization>}
+    */
+     updateOrganization(organization: Organization): Observable<Organization> {
+       return this.http.put<Organization>("/api/organizations", organization);
+     }
 
 }

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.html
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.html
@@ -29,9 +29,9 @@
                             *ngIf='organization!.linked_in != ""' />
                         <social-media-icon [svgIcon]='"youtube"' [href]='organization!.youtube'
                             *ngIf='organization!.youtube != ""' />
-                        <a [routerLink]="['/organizations', organization!.slug, 'edit']">
+                        <a [routerLink]="['/organizations', organization!.slug, 'edit']" *ngIf="adminPermission$ | async">
                             <button mat-icon-button color="basic">
-                                <mat-icon *ngIf="adminPermission$ | async">edit</mat-icon>
+                                <mat-icon>edit</mat-icon>
                             </button>
                         </a> 
                     </div>
@@ -56,15 +56,14 @@
                         *ngIf='organization!.linked_in != ""' />
                     <social-media-icon [svgIcon]='"youtube"' [href]='organization!.youtube'
                         *ngIf='organization!.youtube != ""' />
-                    <a [routerLink]="['/organizations', organization!.slug, 'edit']">
+                    <!-- Link to Organization Editor -->
+                    <a [routerLink]="['/organizations', organization!.slug, 'edit']" *ngIf="adminPermission$ | async">
                         <button mat-icon-button color="basic">
-                            <mat-icon *ngIf="adminPermission$ | async">edit</mat-icon>
+                            <mat-icon>edit</mat-icon>
                         </button>
                     </a> 
                 </div>
-            </div>
-
-            <!-- Link to Organization Editor -->
+            </div> 
         </div>
     </mat-card-header>
 </mat-card>

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.html
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.html
@@ -29,6 +29,11 @@
                             *ngIf='organization!.linked_in != ""' />
                         <social-media-icon [svgIcon]='"youtube"' [href]='organization!.youtube'
                             *ngIf='organization!.youtube != ""' />
+                        <a [routerLink]="['/organizations', organization!.slug, 'edit']">
+                            <button mat-icon-button color="basic">
+                                <mat-icon *ngIf="adminPermission$ | async">edit</mat-icon>
+                            </button>
+                        </a> 
                     </div>
                 </div>
             </div>
@@ -51,6 +56,11 @@
                         *ngIf='organization!.linked_in != ""' />
                     <social-media-icon [svgIcon]='"youtube"' [href]='organization!.youtube'
                         *ngIf='organization!.youtube != ""' />
+                    <a [routerLink]="['/organizations', organization!.slug, 'edit']">
+                        <button mat-icon-button color="basic">
+                            <mat-icon *ngIf="adminPermission$ | async">edit</mat-icon>
+                        </button>
+                    </a> 
                 </div>
             </div>
 

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.ts
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.ts
@@ -4,6 +4,8 @@ import { Subscription } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { Organization } from '../../organization.service';
 import { Profile } from 'src/app/profile/profile.service';
+import { PermissionService } from 'src/app/permission.service';
+import { Observable } from 'rxjs';
 
 @Component({
     selector: 'organization-details-info-card',
@@ -21,7 +23,12 @@ export class OrganizationDetailsInfoCard implements OnInit, OnDestroy {
     public isTablet: boolean = false;
     private isTabletSubscription!: Subscription;
 
-    constructor(private breakpointObserver: BreakpointObserver) {}
+    /** Stores whether the user has admin permission over the current organization. */
+    public adminPermission$: Observable<boolean>;
+
+    constructor(private breakpointObserver: BreakpointObserver, private permission: PermissionService) {
+        this.adminPermission$ = this.permission.check('admin.view', 'admin/');
+    }
 
     ngOnInit(): void {
         this.isHandsetSubscription = this.initHandset();


### PR DESCRIPTION
This PR gives admins the ability to update organizations. The edit button is on the details page for each organization and is currently shown if the current user is a website admin (will be changed to organization permissions once we establish the organization to user relationship table).

# Major Changes
- Organization editor uses `organizationResolver` to grab the current organization's data
- `organizationResolver` returns an empty organization if the slug is `new`
- Organization editor is connected to the organization details page and can update organizations

# Testing
- Run honcho start
- If you sign in as an unauthorized user, there should be no edit button the organization details page and trying to go to `organizations/slug/edit` should take you back to the home page
- If you are signed in as an admin, you should be able to see the edit button next to the icons on the organization details page
- The organization editor should pull the current organization's data if you are updating and not creating
- `new` is not allowed as a slug in the editor