### PR TITLE
Fix bundle size limitation in build

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -34,13 +34,13 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumWarning": "1.5mb",
+                  "maximumError": "2mb"
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumWarning": "4kb",
+                  "maximumError": "8kb"
                 }
               ],
               "outputHashing": "all"


### PR DESCRIPTION
This is a hot fix to avoid a limitation of bundle size to unblock deployment.