### PR TITLE
Add ability to create roles as an Admin

### DIFF
--- a/backend/api/admin/roles.py
+++ b/backend/api/admin/roles.py
@@ -29,6 +29,15 @@ def list_roles(
         raise HTTPException(status_code=403, detail=str(e))
 
 
+@api.post("", tags=["(Admin) Roles"])
+def create_role(
+    role: Role,
+    subject: User = Depends(registered_user),
+    role_service: RoleService = Depends(),
+) -> Role:
+    return role_service.create(subject, role.name)
+
+
 @api.get("/{id}", tags=["(Admin) Roles"])
 def role_details(
     id: int,

--- a/backend/services/role.py
+++ b/backend/services/role.py
@@ -37,6 +37,21 @@ class RoleService:
         role_entities = self._session.execute(stmt).scalars()
         return [role_entity.to_model() for role_entity in role_entities]
 
+    def create(self, subject: User, name: str) -> Role:
+        """Create a new role in the system.
+        
+        Args:
+            subject (User): The user making the request.
+            name (str): The name of the new role.
+            
+        Returns:
+            Role: the newly created role with an ID"""
+        self._permission.enforce(subject, 'role.create', 'role/')
+        role_entity = RoleEntity(name=name)
+        self._session.add(role_entity)
+        self._session.commit()
+        return role_entity.to_model()
+
     def details(self, subject: User, id: int) -> RoleDetails:
         """Get details about a specific role in the system for administrators.
 

--- a/backend/test/services/role_test.py
+++ b/backend/test/services/role_test.py
@@ -1,7 +1,7 @@
 """Tests for the RoleService class."""
 
 # Tested Dependencies
-from ...models import Permission
+from ...models import Permission, Role
 from ...services import RoleService, PermissionService
 
 # Data Setup and Injected Service Fixtures
@@ -30,6 +30,21 @@ def test_list_enforces_permission(
 ):
     roles = role_svc.list(root)
     permission_svc_mock.enforce.assert_called_once_with(root, "role.list", "role/")
+
+
+def test_create(role_svc: RoleService):
+    role = role_svc.create(root, "Club XL")
+    assert role.id is not None
+    assert role.id > 0
+    persisted = role_svc.details(root, role.id)
+    assert role.name == persisted.name
+
+
+def test_create_enforces_permission(
+    role_svc: RoleService, permission_svc_mock: PermissionService
+):
+    role = role_svc.create(root, "Test")
+    permission_svc_mock.enforce.assert_called_once_with(root, "role.create", "role/")
 
 
 def test_details(role_svc: RoleService):

--- a/frontend/src/app/admin/roles/list/admin-roles-list.component.html
+++ b/frontend/src/app/admin/roles/list/admin-roles-list.component.html
@@ -1,7 +1,9 @@
 <div class="content">
     <table mat-table [dataSource]="roles">
         <ng-container matColumnDef="name">
-            <th mat-header-cell *matHeaderCellDef>Role</th>
+            <th mat-header-cell *matHeaderCellDef>Role <button mat-button style="float:right;"
+                    (click)="onClickAddRole()">Create New Role</button>
+            </th>
             <td mat-cell *matCellDef="let element">{{element.name}}</td>
         </ng-container>
 

--- a/frontend/src/app/admin/roles/list/admin-roles-list.component.ts
+++ b/frontend/src/app/admin/roles/list/admin-roles-list.component.ts
@@ -2,8 +2,8 @@ import { Component, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { permissionGuard } from 'src/app/permission.guard';
 import { Role } from 'src/app/role';
-import { AdminRoleDetailsComponent } from '../details/admin-role-details.component';
 import { RoleAdminService } from '../role-admin.service';
+import { NavigationService } from 'src/app/navigation/navigation.service';
 
 @Component({
     selector: 'app-admin-roles-list',
@@ -25,6 +25,8 @@ export class AdminRolesListComponent {
     }
 
     constructor(
+        private roleService: RoleAdminService,
+        private navService: NavigationService,
         private router: Router,
         route: ActivatedRoute,
     ) {
@@ -34,6 +36,16 @@ export class AdminRolesListComponent {
 
     onClick(role: Role) {
         this.router.navigate(['admin', 'roles', role.id]);
+    }
+
+    onClickAddRole() {
+        let name = window.prompt("What is the name of the role?");
+        if (name) {
+            this.roleService.create(name).subscribe({
+                next: (role) => this.router.navigate(['admin', 'roles', role.id]),
+                error: (err) => this.navService.error(err)
+            });
+        }
     }
 
 }

--- a/frontend/src/app/admin/roles/role-admin.service.ts
+++ b/frontend/src/app/admin/roles/role-admin.service.ts
@@ -13,6 +13,10 @@ export class RoleAdminService {
         return this.http.get<Role[]>("/api/admin/roles");
     }
 
+    create(name: string): Observable<Role> {
+        return this.http.post<Role>(`/api/admin/roles`, { name });
+    }
+
     details(id: number) {
         return this.http.get<RoleDetails>(`/api/admin/roles/${id}`);
     }


### PR DESCRIPTION
Add the ability for administrators to create new roles in the backend User Admin UI.

A new button is added to the Roles Table:

<img width="482" alt="image" src="https://github.com/unc-csxl/csxl.unc.edu/assets/31329/82f32303-6b96-47fb-a5ea-0bd574576732">

We use system prompt widget to gather the name of the new role. Upon providing a name, the new role is created and the user is redirected to the role editor page.