### PR TITLE
Fix Sorting Bug for Events Page

### DIFF
--- a/frontend/src/app/event/event-filter/event-filter.pipe.ts
+++ b/frontend/src/app/event/event-filter/event-filter.pipe.ts
@@ -25,8 +25,6 @@ export class EventFilterPipe implements PipeTransform {
       return a.time.getTime() - b.time.getTime()
     })
 
-    // Remove past events
-
     // If a search query is provided, return the events that start with the search query.
     if (searchQuery) {
       return events.filter(events =>

--- a/frontend/src/app/event/event-filter/event-filter.pipe.ts
+++ b/frontend/src/app/event/event-filter/event-filter.pipe.ts
@@ -20,9 +20,9 @@ export class EventFilterPipe implements PipeTransform {
    * @returns {Observable<Event[]>}
    */
   transform(events: Event[], searchQuery: String): Event[] {
-    // Sort the events list alphabetically by name
+    // Sort the events list by date
     events = events.sort((a: Event, b: Event) => {
-      return a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+      return a.time.getTime() - b.time.getTime()
     })
 
     // Remove past events

--- a/frontend/src/app/event/event.model.ts
+++ b/frontend/src/app/event/event.model.ts
@@ -20,3 +20,18 @@ export interface Event {
     organization_id: number | null;
     organization: Organization | null;
 }
+
+export interface EventJson {
+    id: number | null;
+    name: string;
+    time: string;
+    location: string;
+    description: string;
+    public: boolean;
+    organization_id: number | null;
+    organization: Organization | null;
+}
+
+export const parseEventJson = (eventJson: EventJson[]): Event[] => {
+    return eventJson.map((json) => Object.assign({}, json, { time: new Date(json.time) }));
+};

--- a/frontend/src/app/event/event.model.ts
+++ b/frontend/src/app/event/event.model.ts
@@ -21,6 +21,11 @@ export interface Event {
     organization: Organization | null;
 }
 
+/** Interface for the Event JSON Response model
+ *  Note: The API returns object data, such as `Date`s, as strings. So,
+ *  this interface models the data directly received from the API. It is
+ *  the job of the `parseEventJson` function to convert it to the `Event` type
+ */
 export interface EventJson {
     id: number | null;
     name: string;
@@ -32,6 +37,11 @@ export interface EventJson {
     organization: Organization | null;
 }
 
-export const parseEventJson = (eventJson: EventJson[]): Event[] => {
-    return eventJson.map((json) => Object.assign({}, json, { time: new Date(json.time) }));
-};
+/** Function that converts an EventJSON response model to an Event model.
+ *  This function is needed because the API response will return certain
+ *  objects (such as `Date`s) as strings. We need to convert this to
+ *  TypeScript objects ourselves.
+ */
+export const parseEventJson = (eventJson: EventJson): Event => {
+    return Object.assign({}, eventJson, { time: new Date(eventJson.time) })
+}

--- a/frontend/src/app/event/event.service.ts
+++ b/frontend/src/app/event/event.service.ts
@@ -9,8 +9,8 @@
 
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
-import { Event } from './event.model';
+import { Observable, map } from 'rxjs';
+import { Event, EventJson, parseEventJson } from './event.model';
 import { DatePipe } from '@angular/common';
 import { EventFilterPipe } from './event-filter/event-filter.pipe';
 
@@ -25,7 +25,7 @@ export class EventService {
    * @returns {Observable<Event[]>}
    */
   getEvents(): Observable<Event[]> {
-    return this.http.get<Event[]>("/api/events");
+    return this.http.get<EventJson[]>("/api/events").pipe(map(parseEventJson));
   }
 
   /** Returns the event object from the backend database table using the backend HTTP get request. 
@@ -78,7 +78,8 @@ export class EventService {
     let groups: Map<string, Event[]> = new Map();
 
     // Transform the list of events based on the event filter pipe and query
-    this.eventFilterPipe.transform(events, query)
+    this.eventFilterPipe
+      .transform(events, query)
       .forEach((event) => {
         // Find the date to group by
         let dateString = this.datePipe.transform(event.time, 'EEEE, MMMM d, y') ?? ""

--- a/frontend/src/app/event/event.service.ts
+++ b/frontend/src/app/event/event.service.ts
@@ -25,7 +25,7 @@ export class EventService {
    * @returns {Observable<Event[]>}
    */
   getEvents(): Observable<Event[]> {
-    return this.http.get<EventJson[]>("/api/events").pipe(map(parseEventJson));
+    return this.http.get<EventJson[]>("/api/events").pipe(map(eventJsons => eventJsons.map(parseEventJson)));
   }
 
   /** Returns the event object from the backend database table using the backend HTTP get request. 
@@ -33,7 +33,7 @@ export class EventService {
    * @returns {Observable<Event>}
    */
   getEvent(id: number): Observable<Event> {
-    return this.http.get<Event>("/api/events/" + id);
+    return this.http.get<EventJson>("/api/events/" + id).pipe(map(eventJson => parseEventJson(eventJson)));
   }
 
   /** Returns the event object from the backend database table using the backend HTTP get request. 
@@ -41,7 +41,7 @@ export class EventService {
   * @returns {Observable<Event[]>}
   */
   getEventsByOrganization(id: number): Observable<Event[]> {
-    return this.http.get<Event[]>("/api/events/organization/" + id);
+    return this.http.get<EventJson[]>("/api/events/organization/" + id).pipe(map(eventJsons => eventJsons.map(parseEventJson)));
   }
 
   /** Returns the new event object from the backend database table using the backend HTTP get request. 
@@ -74,6 +74,7 @@ export class EventService {
  * @param query: Search bar query to filter the items
  */
   groupEventsByDate(events: Event[], query: string = ""): [string, Event[]][] {
+
     // Initialize an empty map
     let groups: Map<string, Event[]> = new Map();
 


### PR DESCRIPTION
This PR fixes a major bug that prevented the events page from sorting correctly.

## Major Changes
- Reimplement date sorting into the `EventFilterPipe`.
- Create the `EventJson` model to represent the exact types of data retrieved from the API.
    This was needed because dates from the API are returned as strings and are not implicitly coerced
    into the `Date` type.
- Create the `parseEventJson` pipeable function to convert `EventJson` models to `Event` models.