### PR TITLE
Fix Organization Detail Page Crash

### DIFF
--- a/frontend/src/app/event/event.model.ts
+++ b/frontend/src/app/event/event.model.ts
@@ -1,7 +1,7 @@
 /**
  * The Event Model defines the shape of Event data retrieved from
  * the Event Service and the API.
- * 
+ *
  * @author Ajay Gandecha, Jade Keegan, Brianna Ta, Audrey Toney
  * @copyright 2023
  * @license MIT
@@ -11,14 +11,14 @@ import { Organization } from '../organization/organization.model';
 
 /** Interface for Event Type (used on frontend for event detail) */
 export interface Event {
-    id: number | null;
-    name: string;
-    time: Date;
-    location: string;
-    description: string;
-    public: boolean;
-    organization_id: number | null;
-    organization: Organization | null;
+  id: number | null;
+  name: string;
+  time: Date;
+  location: string;
+  description: string;
+  public: boolean;
+  organization_id: number | null;
+  organization: Organization | null;
 }
 
 /** Interface for the Event JSON Response model
@@ -27,14 +27,14 @@ export interface Event {
  *  the job of the `parseEventJson` function to convert it to the `Event` type
  */
 export interface EventJson {
-    id: number | null;
-    name: string;
-    time: string;
-    location: string;
-    description: string;
-    public: boolean;
-    organization_id: number | null;
-    organization: Organization | null;
+  id: number | null;
+  name: string;
+  time: string;
+  location: string;
+  description: string;
+  public: boolean;
+  organization_id: number | null;
+  organization: Organization | null;
 }
 
 /** Function that converts an EventJSON response model to an Event model.
@@ -43,5 +43,5 @@ export interface EventJson {
  *  TypeScript objects ourselves.
  */
 export const parseEventJson = (eventJson: EventJson): Event => {
-    return Object.assign({}, eventJson, { time: new Date(eventJson.time) })
-}
+  return Object.assign({}, eventJson, { time: new Date(eventJson.time) });
+};

--- a/frontend/src/app/event/event.service.ts
+++ b/frontend/src/app/event/event.service.ts
@@ -1,7 +1,7 @@
 /**
  * The Event Service abstracts HTTP requests to the backend
  * from the components.
- * 
+ *
  * @author Ajay Gandecha, Jade Keegan, Brianna Ta, Audrey Toney
  * @copyright 2023
  * @license MIT
@@ -18,46 +18,55 @@ import { EventFilterPipe } from './event-filter/event-filter.pipe';
   providedIn: 'root'
 })
 export class EventService {
+  constructor(
+    protected http: HttpClient,
+    public datePipe: DatePipe,
+    public eventFilterPipe: EventFilterPipe
+  ) {}
 
-  constructor(protected http: HttpClient, public datePipe: DatePipe, public eventFilterPipe: EventFilterPipe) { }
-
-  /** Returns all event entries from the backend database table using the backend HTTP get request. 
+  /** Returns all event entries from the backend database table using the backend HTTP get request.
    * @returns {Observable<Event[]>}
    */
   getEvents(): Observable<Event[]> {
-    return this.http.get<EventJson[]>("/api/events").pipe(map(eventJsons => eventJsons.map(parseEventJson)));
+    return this.http
+      .get<EventJson[]>('/api/events')
+      .pipe(map((eventJsons) => eventJsons.map(parseEventJson)));
   }
 
-  /** Returns the event object from the backend database table using the backend HTTP get request. 
+  /** Returns the event object from the backend database table using the backend HTTP get request.
    * @param id: ID of the event to retrieve
    * @returns {Observable<Event>}
    */
   getEvent(id: number): Observable<Event> {
-    return this.http.get<EventJson>("/api/events/" + id).pipe(map(eventJson => parseEventJson(eventJson)));
+    return this.http
+      .get<EventJson>('/api/events/' + id)
+      .pipe(map((eventJson) => parseEventJson(eventJson)));
   }
 
-  /** Returns the event object from the backend database table using the backend HTTP get request. 
-  * @param id: ID of the organization to retrieve
-  * @returns {Observable<Event[]>}
-  */
+  /** Returns the event object from the backend database table using the backend HTTP get request.
+   * @param id: ID of the organization to retrieve
+   * @returns {Observable<Event[]>}
+   */
   getEventsByOrganization(id: number): Observable<Event[]> {
-    return this.http.get<EventJson[]>("/api/events/organization/" + id).pipe(map(eventJsons => eventJsons.map(parseEventJson)));
+    return this.http
+      .get<EventJson[]>('/api/events/organization/' + id)
+      .pipe(map((eventJsons) => eventJsons.map(parseEventJson)));
   }
 
-  /** Returns the new event object from the backend database table using the backend HTTP get request. 
+  /** Returns the new event object from the backend database table using the backend HTTP get request.
    * @param event: model of the event to be created
    * @returns {Observable<Event>}
    */
   createEvent(event: Event): Observable<Event> {
-    return this.http.post<Event>("/api/events", event);
+    return this.http.post<Event>('/api/events', event);
   }
 
-  /** Returns the updated event object from the backend database table using the backend HTTP put request. 
+  /** Returns the updated event object from the backend database table using the backend HTTP put request.
    * @param event: Event representing the updated event
    * @returns {Observable<Event>}
    */
   updateEvent(event: Event): Observable<Event> {
-    return this.http.put<Event>("/api/events", event);
+    return this.http.put<Event>('/api/events', event);
   }
 
   /** Delete the given event object using the backend HTTP delete request. W
@@ -65,32 +74,30 @@ export class EventService {
    * @returns void
    */
   deleteEvent(event: Event): Observable<Event> {
-    return this.http.delete<Event>("/api/events/" + event.id);
+    return this.http.delete<Event>('/api/events/' + event.id);
   }
 
   /** Helper function to group a list of events by date,
- * filtered based on the input query string.
- * @param events: List of the input events
- * @param query: Search bar query to filter the items
- */
-  groupEventsByDate(events: Event[], query: string = ""): [string, Event[]][] {
-
+   * filtered based on the input query string.
+   * @param events: List of the input events
+   * @param query: Search bar query to filter the items
+   */
+  groupEventsByDate(events: Event[], query: string = ''): [string, Event[]][] {
     // Initialize an empty map
     let groups: Map<string, Event[]> = new Map();
 
     // Transform the list of events based on the event filter pipe and query
-    this.eventFilterPipe
-      .transform(events, query)
-      .forEach((event) => {
-        // Find the date to group by
-        let dateString = this.datePipe.transform(event.time, 'EEEE, MMMM d, y') ?? ""
-        // Add the event
-        let newEventsList = groups.get(dateString) ?? []
-        newEventsList.push(event)
-        groups.set(dateString, newEventsList)
-      })
+    this.eventFilterPipe.transform(events, query).forEach((event) => {
+      // Find the date to group by
+      let dateString =
+        this.datePipe.transform(event.time, 'EEEE, MMMM d, y') ?? '';
+      // Add the event
+      let newEventsList = groups.get(dateString) ?? [];
+      newEventsList.push(event);
+      groups.set(dateString, newEventsList);
+    });
 
     // Return the groups
-    return [...groups.entries()]
+    return [...groups.entries()];
   }
 }


### PR DESCRIPTION
This PR fixes a critical bug preventing the Organization Detail page from loading.

Specifically, it creates a new resolver for event data to receive that directly from the API rather than through the Organization object.