### PR TITLE
Update DevContainer Dockerfile to latest Node dist

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,11 +10,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update \
 	&& apt-get install --yes \
         apt-transport-https \
+        ca-certificates \
 	    curl \
         debian-keyring \
         debian-archive-keyring \
 	    git \
-        fonts-powerline \
+        gnupg \
         postgresql-client \
         software-properties-common \
         sudo \
@@ -30,9 +31,12 @@ RUN curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | gpg --de
     && apt install caddy
 
 # Install Node.js 18 from https://github.com/nodesource
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+ENV NODE_MAJOR 18
+RUN mkdir -p /etc/apt/keyrings \ 
+    && curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | sudo tee /etc/apt/sources.list.d/nodesource.list \
     && apt-get update \
-    && apt-get install --yes nodejs \
+    && apt-get install nodejs -y \
     && npm install -g npm@latest \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The previous installation mechanism was deprecated which caused a minute-long pause in the install unnecessarily. The Dockerfile is now updated to reflect preferred Node Source installation method for Node v18.