### PR TITLE
Add Right Padding to Org Details Event List

### DIFF
--- a/frontend/src/app/organization/organization-details/organization-details.component.css
+++ b/frontend/src/app/organization/organization-details/organization-details.component.css
@@ -8,4 +8,5 @@
 
 .event-listing-container {
   padding-left: 16px;
+  padding-right: 16px;
 }


### PR DESCRIPTION
This commit adds right padding to the Organization Details Event List to make padding on mobile devices a bit more even.