### PR TITLE
Add and Delete Operating Hours from Coworking Database via API

### DIFF
--- a/backend/api/coworking/operating_hours.py
+++ b/backend/api/coworking/operating_hours.py
@@ -1,0 +1,33 @@
+"""Operating Hours API
+
+This API manages the Operating Hours of the XL."""
+
+from datetime import datetime, timedelta
+from typing import Sequence
+from fastapi import APIRouter, Depends
+from ..authentication import registered_user
+from ...models import User
+from ...models.coworking import OperatingHours, TimeRange
+from ...services.coworking import OperatingHoursService
+
+__authors__ = ["Kris Jordan"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+
+api = APIRouter(prefix="/api/coworking/operating_hours")
+openapi_tags = {
+    "name": "Coworking",
+    "description": "The XL's coworking operating hours are managed via these endpoints.",
+}
+
+
+@api.get("", response_model=Sequence[OperatingHours], tags=["Coworking"])
+def get_operating_hours(
+    start: datetime = datetime.now(),
+    end: datetime = datetime.now() + timedelta(weeks=1),
+    operating_hours_svc: OperatingHoursService = Depends(),
+):
+    """List operating hours over a given span of dates."""
+    time_range = TimeRange(start=start, end=end)
+    return operating_hours_svc.schedule(time_range)

--- a/backend/api/coworking/operating_hours.py
+++ b/backend/api/coworking/operating_hours.py
@@ -46,8 +46,12 @@ def new_operating_hours(
     return operating_hours_svc.create(subject, time_range)
 
 
-# @api.delete(":id", tags=["Coworking"])
-# def delete_operating_hours(
-#     id: int,
-
-# )
+@api.delete("/{id}", tags=["Coworking"])
+def delete_operating_hours(
+    id: int,
+    subject: User = Depends(registered_user),
+    operating_hours_svc: OperatingHoursService = Depends(),
+):
+    """Delete operating hours for the XL."""
+    operating_hours = operating_hours_svc.get_by_id(id)
+    return operating_hours_svc.delete(subject, operating_hours)

--- a/backend/api/coworking/operating_hours.py
+++ b/backend/api/coworking/operating_hours.py
@@ -31,3 +31,23 @@ def get_operating_hours(
     """List operating hours over a given span of dates."""
     time_range = TimeRange(start=start, end=end)
     return operating_hours_svc.schedule(time_range)
+
+
+@api.post("", response_model=OperatingHours, tags=["Coworking"])
+def new_operating_hours(
+    operating_hours_range: TimeRange,
+    subject: User = Depends(registered_user),
+    operating_hours_svc: OperatingHoursService = Depends(),
+):
+    """Create new opening hours for the XL."""
+    time_range = TimeRange(
+        start=operating_hours_range.start, end=operating_hours_range.end
+    )
+    return operating_hours_svc.create(subject, time_range)
+
+
+# @api.delete(":id", tags=["Coworking"])
+# def delete_operating_hours(
+#     id: int,
+
+# )

--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ from .api import (
     authentication,
     user,
 )
-from .api.coworking import status, reservation, ambassador
+from .api.coworking import status, reservation, ambassador, operating_hours
 from .api.admin import users as admin_users
 from .api.admin import roles as admin_roles
 from .services.exceptions import UserPermissionException, ResourceNotFoundException
@@ -47,6 +47,7 @@ app = FastAPI(
 feature_apis = [
     status,
     reservation,
+    operating_hours,
     events,
     user,
     profile,

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,7 +37,6 @@ app = FastAPI(
         organizations.openapi_tags,
         events.openapi_tags,
         reservation.openapi_tags,
-        reservation.openapi_tags,
         health.openapi_tags,
         admin_users.openapi_tags,
         admin_roles.openapi_tags,
@@ -63,7 +62,7 @@ for feature_api in feature_apis:
     app.include_router(feature_api.api)
 
 # Static file mount used for serving Angular front-end in production, as well as static assets
-app.mount("/", static_files.StaticFileMiddleware(directory="./static"))
+app.mount("/", static_files.StaticFileMiddleware(directory=Path("./static")))
 
 
 # Add application-wide exception handling middleware for commonly encountered API Exceptions
@@ -73,7 +72,9 @@ def permission_exception_handler(request: Request, e: UserPermissionException):
 
 
 @app.exception_handler(ResourceNotFoundException)
-def permission_exception_handler(request: Request, e: ResourceNotFoundException):
+def resource_not_found_exception_handler(
+    request: Request, e: ResourceNotFoundException
+):
     return JSONResponse(status_code=404, content={"message": str(e)})
 
 

--- a/backend/services/coworking/exceptions.py
+++ b/backend/services/coworking/exceptions.py
@@ -1,0 +1,3 @@
+class OperatingHoursCannotOverlapException(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)

--- a/backend/services/coworking/operating_hours.py
+++ b/backend/services/coworking/operating_hours.py
@@ -2,6 +2,9 @@
 
 from fastapi import Depends
 from sqlalchemy.orm import Session
+from .exceptions import OperatingHoursCannotOverlapException
+from ..permission import PermissionService
+from ...models import User
 from ...database import db_session
 from ...models.coworking import OperatingHours, TimeRange
 from ...entities.coworking import OperatingHoursEntity
@@ -14,13 +17,19 @@ __license__ = "MIT"
 class OperatingHoursService:
     """OperatingHoursService is the access layer to the operating hours data model."""
 
-    def __init__(self, session: Session = Depends(db_session)):
+    def __init__(
+        self,
+        session: Session = Depends(db_session),
+        permission_svc: PermissionService = Depends(),
+    ):
         """Initializes a new OperatingHoursService.
 
         Args:
             session (Session, optional): The database session to use, typically injected by FastAPI.
+            permission_svc (PermissionService, optional): The backend permission service, injected by FastAPI.
         """
         self._session = session
+        self._permission_svc = permission_svc
 
     def schedule(self, time_range: TimeRange) -> list[OperatingHours]:
         """Returns all operating hours of the XL for a given date range.
@@ -41,3 +50,27 @@ class OperatingHoursService:
             .all()
         )
         return [entity.to_model() for entity in entities]
+
+    def create(self, subject: User, time_range: TimeRange) -> OperatingHours:
+        """Create new, open Operating Hours for XL coworking.
+
+        Args:
+            time_range (TimeRange): The time which the XL is open for.
+
+        Returns:
+            OperatingHours: The persisted object.
+        """
+        self._permission_svc.enforce(
+            subject, "coworking.operating_hours.create", "coworking/operating_hours"
+        )
+
+        conflicts = self.schedule(time_range)
+        if len(conflicts) > 0:
+            raise OperatingHoursCannotOverlapException(
+                f"Conflicts in the range of {str(time_range)}"
+            )
+
+        entity = OperatingHoursEntity(start=time_range.start, end=time_range.end)
+        self._session.add(entity)
+        self._session.commit()
+        return entity.to_model()

--- a/backend/test/services/coworking/fixtures.py
+++ b/backend/test/services/coworking/fixtures.py
@@ -25,9 +25,9 @@ def permission_svc(session: Session):
 
 
 @pytest.fixture()
-def operating_hours_svc(session: Session):
+def operating_hours_svc(session: Session, permission_svc: PermissionService):
     """OperatingHoursService fixture."""
-    return OperatingHoursService(session)
+    return OperatingHoursService(session, permission_svc)
 
 
 @pytest.fixture()

--- a/backend/test/services/coworking/operating_hours_test.py
+++ b/backend/test/services/coworking/operating_hours_test.py
@@ -1,17 +1,24 @@
 """Tests for Coworking Operating Hours Service."""
 
+from unittest.mock import create_autospec, call
+
 from ....services.coworking import OperatingHoursService
 from ....models.coworking import OperatingHours, TimeRange
+from ....services.coworking.exceptions import OperatingHoursCannotOverlapException
+from ....services import PermissionService
+from ....services.exceptions import UserPermissionException
 
 # Imported fixtures provide dependencies injected for the tests as parameters.
-from .fixtures import operating_hours_svc
+from .fixtures import permission_svc, operating_hours_svc
 from .time import *
 
 # Insert fake data entities in database
-from .operating_hours_data import fake_data_fixture
+from ..core_data import setup_insert_data_fixture as insert_order_0
+from .operating_hours_data import fake_data_fixture as insert_order_1
 
 # Import the fake model data in a namespace for test assertions
 from . import operating_hours_data
+from ..core_data import user_data
 
 __authors__ = ["Kris Jordan"]
 __copyright__ = "Copyright 2023"
@@ -46,3 +53,43 @@ def test_schedule_multiple_match(
     assert len(result) == 2
     assert result[0].id == operating_hours_data.tomorrow.id
     assert result[1].id == operating_hours_data.future.id
+
+
+def test_create(operating_hours_svc: OperatingHoursService, time: dict[str, datetime]):
+    """Creating an Operating Hours entity expected case."""
+    time_range = TimeRange(
+        start=time[TOMORROW] + timedelta(days=5),
+        end=time[TOMORROW] + timedelta(days=5, hours=2),
+    )
+    result: OperatingHours = operating_hours_svc.create(user_data.root, time_range)
+    assert result.id is not None
+
+
+def test_create_overlap(operating_hours_svc: OperatingHoursService):
+    """Creating an Operating Hours entity that overlaps with another raises OperatingHoursCannotOverlapException"""
+    with pytest.raises(OperatingHoursCannotOverlapException):
+        operating_hours_svc.create(
+            user_data.root,
+            TimeRange(
+                start=operating_hours_data.future.start + timedelta(minutes=30),
+                end=operating_hours_data.future.end + timedelta(minutes=30),
+            ),
+        )
+
+
+def test_create_enforces_permission(
+    operating_hours_svc: OperatingHoursService, time: dict[str, datetime]
+):
+    """Ensure we are enforcing coworking.operating_hours.create on coworking/operating_hours"""
+    permission_svc = create_autospec(PermissionService)
+    operating_hours_svc._permission_svc = permission_svc
+    time_range = TimeRange(
+        start=time[TOMORROW] + timedelta(days=5),
+        end=time[TOMORROW] + timedelta(days=5, hours=2),
+    )
+    operating_hours_svc.create(user_data.user, time_range)
+    permission_svc.enforce.assert_called_with(
+        user_data.user,
+        "coworking.operating_hours.create",
+        "coworking/operating_hours",
+    )


### PR DESCRIPTION
This PR lands the ability to add and delete Operating Hours from the Coworking feature of the XL.

The following changes are included in this PR:

* OperatingHours specific API endpoints
* New Service Methods for `get_by_id`, `create` and `delete`
* Tests for service methods

Validated by writing unit tests with 100% coverage of the `OperatingHoursService`.