### PR TITLE
Make Organization, Event, and About Page Public

### DIFF
--- a/frontend/src/app/navigation/navigation.component.html
+++ b/frontend/src/app/navigation/navigation.component.html
@@ -48,6 +48,9 @@
         <a mat-list-item (click)="auth.signOut()">Sign out</a>
       </div>
       <ng-template #unauthenticated>
+        <a mat-list-item routerLink="/organizations">Organizations</a>
+        <a mat-list-item routerLink="/events">Events</a>
+        <a mat-list-item routerLink="/about">About the XL</a>
         <a mat-list-item href="/auth?continue_to={{ router.url }}">Sign in</a>
       </ng-template>
     </mat-nav-list>


### PR DESCRIPTION
This minor pull request makes the `Organization`, `Event`, and `About the XL` pages public to members who are not authenticated.

*This PR resolves #145*.