### PR TITLE
Feature Permissions Document

### DIFF
--- a/docs/admin_permissions.md
+++ b/docs/admin_permissions.md
@@ -8,7 +8,7 @@ This document specifies the permissions to be added for the various actions with
 
 Each permission consists of an _action_ and a _resource_, both of which are strings. The action consists of the name of the corresponding feature service followed by an action such as create/view/update/delete (such as `organizations.create`). The resource specifies the path of the API route being operated on.
 
-For more comprehensive information about how permissions work within the backend code, please refer to the document titled [auth.md](./auth.md).
+For more comprehensive information about how permissions work within the backend and frontend code, please refer to the document titled [auth.md](./auth.md).
 
 ## Organizations
 

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -112,4 +112,4 @@ For administrative permission rule authorization, the [PermissionService](../fro
 1. [The permission is initialized in the constructor via `PermissionService`'s `check` method.](https://github.com/unc-csxl/csxl.unc.edu/blob/e349bd727f5525a07dc85ed602916470b285e24f/frontend/src/app/navigation/navigation.component.ts#L41)
 2. [The permission is checked in the HTML template using an async pipe.](https://github.com/unc-csxl/csxl.unc.edu/blob/main/frontend/src/app/navigation/navigation.component.html#L13)
 
-For a list of existing administrative permissions, please see the [Administrative Permissions of CSXL Services](./feature_permissions.md) documentation.
+For a list of existing administrative permissions, please see the [Administrative Permissions of CSXL Services](./admin_permissions.md) documentation.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -17,7 +17,7 @@ This document is for CSXL Developers who need authentication and authorization i
 
 ## Authentication
 
-Authentication in `csxl.unc.edu` is integrated with UNC's Single Sign-on (SSO) Shibboleth service. This allows username, password, and UNC affinity to be handled by UNC ITS and our application takes a dependency upon it. For more information on SSO, see ITS' [official documentation](https://its.unc.edu/2017/07/24/shibboleth/). For the implementation details on *how* authentication works in this application, see [backend/api/authentication.py](backend/api/authentication.py).
+Authentication in `csxl.unc.edu` is integrated with UNC's Single Sign-on (SSO) Shibboleth service. This allows username, password, and UNC affinity to be handled by UNC ITS and our application takes a dependency upon it. For more information on SSO, see ITS' [official documentation](https://its.unc.edu/2017/07/24/shibboleth/). For the implementation details on *how* authentication works in this application, see [backend/api/authentication.py](../backend/api/authentication.py).
 
 Authentication is verifying *who* the "subject" accessing a system is. The term "subject" is chosen intentionally in the security lexicon. A subject may be a person, but alternatively an automated program accessing a system on behalf of a person, group, or organization. The CSXL application is, for now, foremost a user-facing application that serves the people of the computer science department at UNC. Thus, a "subject" is a person and user of the CSXL application for our concerns.
 
@@ -33,7 +33,7 @@ When a feature of the website, via one or more of its models, is related to one 
 
 The logic for enforcing feature-specific concerns should be specified in the feature's backend service layer methods. Developers are encouraged to factor out this logic into reusable helper functions; it is likely many service methods will rely upon the same logic.
 
-All backend service layer methods with authorization concerns should accept a `subject: User` as their first parameter. This represents the user attempting to carry out the action and whose authorization needs verification. If your backend service layer method determines the subject does not have permission to carry out the operation, raise a [`backend.services.permission.UserPermissionException`](backend/services/permission.py). Example usage of this exception:
+All backend service layer methods with authorization concerns should accept a `subject: User` as their first parameter. This represents the user attempting to carry out the action and whose authorization needs verification. If your backend service layer method determines the subject does not have permission to carry out the operation, raise a [`backend.services.permission.UserPermissionException`](../backend/services/permission.py). Example usage of this exception:
 
 ```python
 raise UserPermissionException('workshops.update', f'workshops/{workshop.id}`)
@@ -59,7 +59,7 @@ To see how administrative permissions are managed in the app, in the development
 
 ### Backend Routes Requiring a Registered User
 
-Thanks to FastAPI's dependency injection system and the `registered_user` helper function in [backend/api/authentication.py], adding authentication to a route is as easy as adding a parameter. For example, [backend/api/roles.py]'s `list_roles` function is defined as:
+Thanks to FastAPI's dependency injection system and the `registered_user` helper function in [../backend/api/authentication.py], adding authentication to a route is as easy as adding a parameter. For example, [../backend/api/roles.py]'s `list_roles` function is defined as:
 
 ```python
 @api.get("", tags=["Roles"])
@@ -89,7 +89,7 @@ In the OpenAPI user interface found at `/docs`, look for the Green Authorize but
 
 Backend service methods are _the most important place_ to correctly verify authorization. Failing to properly verify authorization here means users will be able to take actions they should not have permission to.
 
-As an example, consider _updating a user's profile details_. The "feature" is a user's profile. The feature-specific rule is _a user can update their own profile_. This verification is implemented in [backend/services/user.py](https://github.com/unc-csxl/csxl.unc.edu/blob/e349bd727f5525a07dc85ed602916470b285e24f/backend/services/user.py#L145). Notice the negation of the rule is specified in the `if` such that if the rule is `True` (the user is the subject), execution carries on into the method. However, if the feature-specific rule does not hold, we then call the [`PermissionService`](backend/services/permission.py)'s `enforce` method, giving it the `subject` user, action string (`user.update`), and resource (`user/{id}`). This method handles the logic for checking whether `subject` has administrative access to carry out this action on the resource. If the `subject` does, this procedure returns nothing. If they do not, it raises a `UserPermissionException` for you. This demonstrates an idiomatic way of verifying the `subject` is authorized.
+As an example, consider _updating a user's profile details_. The "feature" is a user's profile. The feature-specific rule is _a user can update their own profile_. This verification is implemented in [backend/services/user.py](https://github.com/unc-csxl/csxl.unc.edu/blob/e349bd727f5525a07dc85ed602916470b285e24f/backend/services/user.py#L145). Notice the negation of the rule is specified in the `if` such that if the rule is `True` (the user is the subject), execution carries on into the method. However, if the feature-specific rule does not hold, we then call the [`PermissionService`](../backend/services/permission.py)'s `enforce` method, giving it the `subject` user, action string (`user.update`), and resource (`user/{id}`). This method handles the logic for checking whether `subject` has administrative access to carry out this action on the resource. If the `subject` does, this procedure returns nothing. If they do not, it raises a `UserPermissionException` for you. This demonstrates an idiomatic way of verifying the `subject` is authorized.
 
 If your feature-specific rules are more involved than a simple equality check, you should refactor these rules out into a method of its own with a well chosen name. This will help keep your service's methods easier to read and reason through. Additionally, it makes it easier to write unit tests specifically targetting your feature-specific rule logic.
 
@@ -105,9 +105,11 @@ As an example of this, consider [`NavigationComponent`](frontend/src/app/navigat
 
 ### Frontend Features Requiring Authorization
 
-For feature-specific rule authorization, the alpha version of the CSXL web app that COMP590 Spring 2023 is starting from does not yet have an idiomatic example in the frontend. As a feature developer, you will need to come up with a solution of how your frontend UI will handle feature-specific authorization concerns.
+For feature-specific rule authorization, the beta version of the CSXL web app that COMP590 Fall 2023 is starting from does not yet have an idiomatic example in the frontend. As a feature developer, you will need to come up with a solution of how your frontend UI will handle feature-specific authorization concerns.
 
-For administrative permission rule authorization, the [PermissionService](frontend/src/app/permission.service.ts) provides helper methods for verifying administrative permissions. For an idiomatic example use case for administrative permission checking, see [`NavigationComponent`](frontend/src/app/navigation)'s `adminPermission$` `Observable<boolean>`:
+For administrative permission rule authorization, the [PermissionService](../frontend/src/app/permission.service.ts) provides helper methods for verifying administrative permissions. For an idiomatic example use case for administrative permission checking, see [`NavigationComponent`](../frontend/src/app/navigation)'s `adminPermission$` `Observable<boolean>`:
 
 1. [The permission is initialized in the constructor via `PermissionService`'s `check` method.](https://github.com/unc-csxl/csxl.unc.edu/blob/e349bd727f5525a07dc85ed602916470b285e24f/frontend/src/app/navigation/navigation.component.ts#L41)
 2. [The permission is checked in the HTML template using an async pipe.](https://github.com/unc-csxl/csxl.unc.edu/blob/main/frontend/src/app/navigation/navigation.component.html#L13)
+
+For a list of existing administrative permissions, please see the [Administrative Permissions of CSXL Services](./feature_permissions.md) documentation.

--- a/docs/feature_permissions.md
+++ b/docs/feature_permissions.md
@@ -43,4 +43,9 @@ _\*Note that we use "\*" as a wild card character to encompass all of the action
 
 ## Coworking
 
-[TBA]
+| Action                           | Resource                                       | Permission |
+| -------------------------------- | ---------------------------------------------- | ---------- |
+| coworking.operating_hours.create | coworking/operating_hours                      |            |
+| coworking.operating_hours.delete | coworking/operating_hours/{operating_hours.id} |            |
+| coworking.reservation.read       | user/{user.id}                                 |            |
+| coworking.reservation.manage     | user/{user.id}                                 |            |

--- a/docs/feature_permissions.md
+++ b/docs/feature_permissions.md
@@ -1,6 +1,6 @@
 # Feature Permissions
 
-> Written by Jade Keegan for the CSXL Web Application.<br> > _Last Updated: 11/3/2023_
+> Written by Jade Keegan for the CSXL Web Application.<br> _Last Updated: 11/6/2023_
 
 ## Introduction
 

--- a/docs/feature_permissions.md
+++ b/docs/feature_permissions.md
@@ -1,0 +1,44 @@
+# Feature Permissions
+
+> Written by Jade Keegan for the CSXL Web Application.<br> > _Last Updated: 11/3/2023_
+
+## Introduction
+
+This document specifies the permissions to be added for the various actions within the application that require special authorization. In the frontend of the application, these permissions may be added on the `Admin Role Details` page.
+
+Each permission consists of an _action_ and a _resource_, both of which are strings. The action consists of the name of the corresponding feature service followed by an action such as create/view/update/delete (such as `organizations.create`). The resource specifies the path of the API route being operated on.
+
+For more comprehensive information about how permissions work within the backend code, please refer to the document titled [auth.md](./auth.md).
+
+## Organizations
+
+| Action              | Resource                       | Permission                                          |
+| ------------------- | ------------------------------ | --------------------------------------------------- |
+| organization.create | organization                   | Create an organization to be added to the database. |
+| organization.delete | organization                   | Delete an existing organization from the database.  |
+| organization.update | organization/{organization_id} | Update information about an existing organization.  |
+
+The table above defines permissions for the Organizations feature of the application. _Note that these are not fully implemented yet in the backend and frontend._
+
+The `organization.create` and `organization.delete` permissions may be added to any Role in the application, but this should be done with caution, especially since deleting an organization will permanently delete it and its corresponding events from the database.
+
+The `organization.update` permission should be added under a role for a particular organization with some `organization_id` corresponding to that organization. Roles for organizations are specified as follows: "Org: [*Organization Name/Slug*]".The resource must include the `organization_id` to ensure that only members of the organization have the ability to update it.
+
+As an example, to add the `organization.update` permission to leaders of HackNC (which has an organization ID of 29), first find/create a role with the name _Org: HackNC_. On the role details page, input `organization.update` as the action for a new permission and `organization/29` as the resource and click **Grant**. Now, any user added to the _Org:HackNC_ role will have the ability to update HackNC's organization information!
+
+## Events
+
+| Action                     | Resource                       | Permission                                   |
+| -------------------------- | ------------------------------ | -------------------------------------------- |
+| organization.events.create | organization/{organization_id} | Create an event to be added to the database. |
+| organization.events.delete | organization/{organization_id} | Delete an existing event from the database.  |
+| organization.events.update | organization/{organization_id} | Update information about an existing event.  |
+
+The table above defines permissions for the Events feature of the application.
+
+These permissions require the `organization_id` in the resource string in order to ensure that a user may only alter events for the organization(s) they have permissions for. Similar to the `organization.update` permission, these permissions should be added under the Role for a specific Organization, and the `organization_id` in the resource string should correspond to that organization.
+
+For example, to add all of these event management permissions to leaders of HackNC (which has an organization ID of 29), first find/create a role with the name _Org: HackNC_. On the role details page, input `organization.events.*` as the action for a new permission and `organization/29` as the resource and click **Grant**. Now, any user added to the _Org:HackNC_ role will have the ability to manage HackNC's events!
+_\*Note that we use "\*" as a wild card character to encompass all of the actions (create/delete/update) since the leader of an organization should have full management permissions for the organization's events._
+
+##

--- a/docs/feature_permissions.md
+++ b/docs/feature_permissions.md
@@ -41,4 +41,6 @@ These permissions require the `organization_id` in the resource string in order 
 For example, to add all of these event management permissions to leaders of HackNC (which has an organization ID of 29), first find/create a role with the name _Org: HackNC_. On the role details page, input `organization.events.*` as the action for a new permission and `organization/29` as the resource and click **Grant**. Now, any user added to the _Org:HackNC_ role will have the ability to manage HackNC's events!
 _\*Note that we use "\*" as a wild card character to encompass all of the actions (create/delete/update) since the leader of an organization should have full management permissions for the organization's events._
 
-##
+## Coworking
+
+[TBA]

--- a/docs/feature_permissions.md
+++ b/docs/feature_permissions.md
@@ -1,4 +1,4 @@
-# Feature Permissions
+# Administrative Permissions of CSXL Services
 
 > Written by Jade Keegan for the CSXL Web Application.<br> _Last Updated: 11/6/2023_
 
@@ -45,7 +45,9 @@ _\*Note that we use "\*" as a wild card character to encompass all of the action
 
 | Action                           | Resource                                       | Permission |
 | -------------------------------- | ---------------------------------------------- | ---------- |
-| coworking.operating_hours.create | coworking/operating_hours                      |            |
-| coworking.operating_hours.delete | coworking/operating_hours/{operating_hours.id} |            |
-| coworking.reservation.read       | user/{user.id}                                 |            |
-| coworking.reservation.manage     | user/{user.id}                                 |            |
+| coworking.operating_hours.create | coworking/operating_hours                      | Add new operating hours to the XL |
+| coworking.operating_hours.delete | coworking/operating_hours/{operating_hours.id} | Delete operating hours from the XL  |
+| coworking.reservation.read       | user/{user.id}                                 | Read the reservations of a specific user |
+| coworking.reservation.manage     | user/{user.id}                                 | Manage (create/update/delete) the reservations of a specific user |
+
+The administrative permissions of coworking are under development as this feature is being worked on by many groups in COMP590 this Fall. As these features land, more permissions will likely need to be added to this list.


### PR DESCRIPTION
This PR adds the Feature Permissions Document to the docs directory. This document defines the standard permissions for each feature in the application to serve as a reference when adding permissions to roles, as well for creating new feature permissions.

## Developer Notes
Descriptions of the feature permissions for the Coworking feature have not been added yet!