### PR TITLE
Improve UX When Navigating to an Invalid Organization

### DIFF
--- a/frontend/src/app/organization/organization-details/organization-details.component.html
+++ b/frontend/src/app/organization/organization-details/organization-details.component.html
@@ -8,7 +8,7 @@
 </div>
 </div> -->
 
-<div>
+<div *ngIf="organization != undefined">
   <organization-details-info-card
     [organization]="organization"
     [profile]="profile" />

--- a/frontend/src/app/organization/organization-details/organization-details.component.html
+++ b/frontend/src/app/organization/organization-details/organization-details.component.html
@@ -8,9 +8,9 @@
 </div>
 </div> -->
 
-<organization-not-found-card *ngIf="organization == undefined"/>
+<organization-not-found-card *ngIf="organization == undefined; else eventDetails"/>
 
-<div *ngIf="organization != undefined">
+<ng-template #eventDetails>
   <organization-details-info-card
     [organization]="organization"
     [profile]="profile" />
@@ -24,4 +24,4 @@
       [showHeader]="true"
       [showCreateButton]="(eventCreationPermission$ | async)!" />
   </div>
-</div>
+</ng-template>

--- a/frontend/src/app/organization/organization-details/organization-details.component.html
+++ b/frontend/src/app/organization/organization-details/organization-details.component.html
@@ -8,6 +8,8 @@
 </div>
 </div> -->
 
+<organization-not-found-card *ngIf="organization == undefined"/>
+
 <div *ngIf="organization != undefined">
   <organization-details-info-card
     [organization]="organization"

--- a/frontend/src/app/organization/organization-details/organization-details.component.ts
+++ b/frontend/src/app/organization/organization-details/organization-details.component.ts
@@ -29,7 +29,7 @@ import { PermissionService } from 'src/app/permission.service';
 
 /** Injects the organization's name to adjust the title. */
 let titleResolver: ResolveFn<string> = (route: ActivatedRouteSnapshot) => {
-  return route.parent!.data['organization'].name;
+  return route.parent!.data['organization']?.name ?? "Organization Not Found";
 };
 
 @Component({
@@ -86,7 +86,7 @@ export class OrganizationDetailsComponent {
     this.eventsPerDay = eventService.groupEventsByDate(data.events ?? []);
     this.eventCreationPermission$ = this.permission.check(
       'organization.events.manage',
-      `organization/${this.organization!.id}`
+      `organization/${this.organization?.id ?? -1}`
     );
   }
 }

--- a/frontend/src/app/organization/organization.module.ts
+++ b/frontend/src/app/organization/organization.module.ts
@@ -42,6 +42,7 @@ import { SharedModule } from '../shared/shared.module';
 import { OrganizationDetailsInfoCard } from './widgets/organization-details-info-card/organization-details-info-card.widget';
 import { OrganizationEditorComponent } from '/workspace/frontend/src/app/organization/organization-editor/organization-editor.component';
 import { EventFilterPipe } from '../event/event-filter/event-filter.pipe';
+import { OrganizationNotFoundCard } from './widgets/organization-not-found-card/organization-not-found-card.widget';
 
 @NgModule({
   declarations: [
@@ -54,7 +55,8 @@ import { EventFilterPipe } from '../event/event-filter/event-filter.pipe';
 
     // UI Widgets
     OrganizationCard,
-    OrganizationDetailsInfoCard
+    OrganizationDetailsInfoCard,
+    OrganizationNotFoundCard
   ],
   imports: [
     CommonModule,

--- a/frontend/src/app/organization/organization.resolver.ts
+++ b/frontend/src/app/organization/organization.resolver.ts
@@ -13,6 +13,7 @@ import { Organization } from './organization.model';
 import { OrganizationService } from './organization.service';
 import { EventService } from '../event/event.service';
 import { Event } from '../event/event.model';
+import { catchError, map, of } from 'rxjs';
 
 /** This resolver injects the list of organizations into the organization component. */
 export const organizationResolver: ResolveFn<Organization[] | undefined> = (
@@ -23,15 +24,10 @@ export const organizationResolver: ResolveFn<Organization[] | undefined> = (
 };
 
 /** This resolver injects an organization into the organization detail component. */
-export const organizationDetailResolver: ResolveFn<Organization | undefined> = (
-  route,
-  state
-) => {
-  if (route.paramMap.get('slug')! != 'new') {
-    return inject(OrganizationService).getOrganization(
-      route.paramMap.get('slug')!
-    );
-  } else {
+export const organizationDetailResolver: ResolveFn<Organization | undefined> = (route, state) => {
+
+  // If the organization is new, return a blank one
+  if (route.paramMap.get('slug')! == 'new') {
     return {
       id: null,
       name: '',
@@ -48,8 +44,17 @@ export const organizationDetailResolver: ResolveFn<Organization | undefined> = (
       heel_life: '',
       public: false,
       events: null
-    };
+    }
   }
+
+  // Otherwise, return the organization.
+  // If there is an error, return undefined
+  return inject(OrganizationService).getOrganization(route.paramMap.get('slug')!)
+      .pipe(catchError((error) => {
+        console.log(error)
+        return of(undefined)
+      }))
+
 };
 
 /** This resolver injects the events for a given organization into the organization component. */

--- a/frontend/src/app/organization/widgets/organization-not-found-card/organization-not-found-card.widget.css
+++ b/frontend/src/app/organization/widgets/organization-not-found-card/organization-not-found-card.widget.css
@@ -1,0 +1,14 @@
+
+
+.links {
+    display: flex;
+    flex-direction: row-reverse;
+    width: 100%;
+    justify-content: space-between;
+    padding-bottom: 14px;
+    padding-right: 14px;
+}
+
+mat-card-actions {
+    padding: 0;
+}

--- a/frontend/src/app/organization/widgets/organization-not-found-card/organization-not-found-card.widget.html
+++ b/frontend/src/app/organization/widgets/organization-not-found-card/organization-not-found-card.widget.html
@@ -1,0 +1,23 @@
+<mat-card class="card" appearance="outlined">
+    <!-- Card Header -->
+    <mat-card-header class="header">
+        <mat-card-title class="name">
+            Organization Not Found
+        </mat-card-title>
+    </mat-card-header>
+  
+    <!-- Description -->
+    <mat-card-content class="description">
+      <p>
+        No organization was found with this slug. Make sure that the URL was entered correctly, or click below to view all organizations.
+      </p>
+    </mat-card-content>
+  
+    <!-- Organization Links & Details -->
+    <mat-card-actions class="links">
+      <!-- Link to Organization Page -->
+      <a class="details-link" [routerLink]="['/organizations']">
+        <button mat-stroked-button>Back to Organizations</button>
+      </a>
+    </mat-card-actions>
+  </mat-card>

--- a/frontend/src/app/organization/widgets/organization-not-found-card/organization-not-found-card.widget.ts
+++ b/frontend/src/app/organization/widgets/organization-not-found-card/organization-not-found-card.widget.ts
@@ -1,0 +1,19 @@
+/**
+ * The Organization Not Found Card widget abstracts the implementation
+ * of the missing organization card.
+ *
+ * @author Ajay Gandecha, Jade Keegan, Brianna Ta, Audrey Toney
+ * @copyright 2023
+ * @license MIT
+ */
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'organization-not-found-card',
+  templateUrl: './organization-not-found-card.widget.html',
+  styleUrls: ['./organization-not-found-card.widget.css']
+})
+export class OrganizationNotFoundCard {
+  constructor() {}
+}


### PR DESCRIPTION
This PR aims to improve the UX when a user navigates to an invalid organization. 

## Major Changes
- Rework the organization resolver to return `undefined` upon an error retrieving an organization, allowing us to handle this scenario in the frontend without immediately causing a crash. This uses RxJS's `pipe`, `catchError`, and `of` functions.
- Add a new widget called `OrganizationNotFoundCard` that shows only when an organization is not found.

## Testing
- This feature was tested on the frontend using `honcho start`.

*This PR resolves #83*