### PR TITLE
Compress HTTP responses for faster load times

### DIFF
--- a/backend/api/static_files.py
+++ b/backend/api/static_files.py
@@ -15,22 +15,23 @@ from fastapi.staticfiles import StaticFiles
 
 
 class StaticFileMiddleware(StaticFiles):
-    def __init__(self, directory: os.PathLike, index="index.html") -> None:
+    def __init__(self, directory: os.PathLike, index: str = "index.html") -> None:
         self.index = index
         super().__init__(directory=directory, packages=None, html=True, check_dir=True)
 
-    def lookup_path(self, path: str) -> tuple[str, os.stat_result]:
+    def lookup_path(self, path: str) -> tuple[str, os.stat_result | None]:
         """Returns the index file when no match is found.
 
         Args:
             path (str): Resource path.
 
         Returns:
-            tuple[str, os.stat_result]: Returns a full path and stat result.
+            tuple[str, os.stat_result | None]: Returns a full path and stat result or None if file not found.
         """
         full_path, stat_result = super().lookup_path(path)
 
         if stat_result is None:
-            return super().lookup_path(self.index)
+            full_path, stat_result = super().lookup_path(self.index)
+            return (full_path, stat_result)
         else:
             return (full_path, stat_result)

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from fastapi.middleware.gzip import GZipMiddleware
 from .api import (
     events,
     health,
@@ -42,6 +43,9 @@ app = FastAPI(
         admin_roles.openapi_tags,
     ],
 )
+
+# Use GZip middleware for compressing HTML responses over the network
+app.add_middleware(GZipMiddleware)
 
 # Plugging in each of the router APIs
 feature_apis = [


### PR DESCRIPTION
Use the FastAPI GZip middleware to compress responses; especially the static file responses of the application in production, in order to reduce load times and network transfer over cell networks.

This commit also fixes some typing issues in the StaticFiles middleware.

Verified by testing locally and confirming GZip responses coming from the API.