### PR TITLE
[DRAFT] [DO NOT MERGE] Implement Audit Log Feature to the CSXL Application - Backend

### DIFF
--- a/backend/entities/log_entity.py
+++ b/backend/entities/log_entity.py
@@ -3,6 +3,8 @@
 from sqlalchemy import Integer, String, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from .entity_base import EntityBase
+from typing import Self
+from ..models.log import Log, LogDetails
 
 __authors__ = ["Ajay Gandecha"]
 __copyright__ = "Copyright 2023"
@@ -27,3 +29,29 @@ class LogEntity(EntityBase):
     # NOTE: This defines a one-to-many relationship between the user and log tables.
     user_id: Mapped[int] = mapped_column(ForeignKey("user.id"))
     user: Mapped["UserEntity"] = relationship(back_populates="logs")
+
+    @classmethod
+    def from_model(cls, model: Log) -> Self:
+        """
+        Class method that converts a `Log` model into a `LogEntity`
+
+        Parameters:
+            - model (Log): Model to convert into an entity
+        Returns:
+            LogEntity: Entity created from model
+        """
+        return cls(id=model.id, description=model.description, user_id=model.user_id)
+
+    def to_detail_model(self) -> LogDetails:
+        """
+        Converts a `LogEntity` object into a `Log` model object
+
+        Returns:
+            Log: `Log` object from the entity
+        """
+        return LogDetails(
+            id=self.id,
+            description=self.description,
+            user_id=self.user_id,
+            user=self.user,
+        )

--- a/backend/entities/log_entity.py
+++ b/backend/entities/log_entity.py
@@ -1,0 +1,29 @@
+"""Definition of SQLAlchemy table-backed object mapping entity for Audit Log listings."""
+
+from sqlalchemy import Integer, String, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from .entity_base import EntityBase
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+
+class LogEntity(EntityBase):
+    """Serves as the database model schema defining the shape of the `log` table"""
+
+    # Name for the log table in the PostgreSQL database
+    __tablename__ = "log"
+
+    # Log properties (columns in the database table)
+
+    # Unique ID for the log
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+
+    # Description of action taken
+    description: Mapped[str] = mapped_column(String)
+
+    # User for the log
+    # NOTE: This defines a one-to-many relationship between the user and log tables.
+    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"))
+    user: Mapped["UserEntity"] = relationship(back_populates="logs")

--- a/backend/entities/log_entity.py
+++ b/backend/entities/log_entity.py
@@ -53,5 +53,5 @@ class LogEntity(EntityBase):
             id=self.id,
             description=self.description,
             user_id=self.user_id,
-            user=self.user,
+            user=self.user.to_model(),
         )

--- a/backend/entities/user_entity.py
+++ b/backend/entities/user_entity.py
@@ -7,6 +7,7 @@ from typing import Self
 from .entity_base import EntityBase
 from .user_role_table import user_role_table
 from ..models import User
+from .log_entity import LogEntity
 
 __authors__ = ["Kris Jordan"]
 __copyright__ = "Copyright 2023"
@@ -52,6 +53,11 @@ class UserEntity(EntityBase):
     # The permissions for the given user.
     # NOTE: This field establishes a one-to-many relationship between the permission and users table.
     permissions: Mapped["PermissionEntity"] = relationship(back_populates="user")
+
+    # NOTE: This field establishes a one-to-many relationship between the users and logs table.
+    logs: Mapped[list["LogEntity"]] = relationship(
+        back_populates="user", cascade="all,delete"
+    )
 
     @classmethod
     def from_model(cls, model: User) -> Self:

--- a/backend/entities/user_entity.py
+++ b/backend/entities/user_entity.py
@@ -7,7 +7,7 @@ from typing import Self
 from .entity_base import EntityBase
 from .user_role_table import user_role_table
 from ..models import User
-from .log_entity import LogEntity
+from ..entities.log_entity import LogEntity
 
 __authors__ = ["Kris Jordan"]
 __copyright__ = "Copyright 2023"

--- a/backend/models/log.py
+++ b/backend/models/log.py
@@ -17,4 +17,15 @@ class Log(BaseModel):
     id: int | None = None
     description: str
     user_id: int
+
+
+class LogDetails(Log):
+    """
+    Pydantic model to represent a `log`, including back-populated
+    relationship fields.
+
+    This model is based on the `LogEntity` model, which defines the shape
+    of the `Log` database in the PostgreSQL database.
+    """
+
     user: User

--- a/backend/models/log.py
+++ b/backend/models/log.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+from .user import User
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+
+class Log(BaseModel):
+    """
+    Pydantic model to represent a `Log`.
+
+    This model is based on the `LogEntity` model, which defines the shape
+    of the `Log` database in the PostgreSQL database.
+    """
+
+    id: int | None = None
+    description: str
+    user_id: int
+    user: User

--- a/backend/script/reset_testing.py
+++ b/backend/script/reset_testing.py
@@ -22,6 +22,7 @@ from ..test.services.organization import organization_test_data
 from ..test.services.event import event_test_data
 from ..test.services.coworking import room_data, seat_data, operating_hours_data, time
 from ..test.services.coworking.reservation import reservation_data
+from ..test.services.log import log_test_data
 
 __authors__ = ["Kris Jordan", "Ajay Gandecha"]
 __copyright__ = "Copyright 2023"
@@ -50,6 +51,6 @@ with Session(engine) as session:
     room_data.insert_fake_data(session)
     seat_data.insert_fake_data(session)
     reservation_data.insert_fake_data(session, time)
-
+    log_test_data.insert_fake_data(session)
     # Commit changes to the database
     session.commit()

--- a/backend/services/log.py
+++ b/backend/services/log.py
@@ -1,0 +1,66 @@
+"""
+The Logs Service allows the API to manipulate the audit log in the database.
+"""
+
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..database import db_session
+from ..models.log import Log, LogDetails
+from ..entities.log_entity import LogEntity
+from ..models import User
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+
+class LogService:
+    """Service that performs all of the actions on the `Log` table"""
+
+    def __init__(self, session: Session = Depends(db_session)):
+        """Initializes the `LogService` session"""
+        self._session = session
+
+    def all(self) -> list[LogDetails]:
+        """
+        Retrieves all organizations from the table
+
+        Returns:
+            list[Log]: List of all `Log`s
+        """
+        # Select all entries in `Organization` table
+        query = select(LogEntity)
+        entities = self._session.scalars(query).all()
+
+        # Convert entries to a model and return
+        return [entity.to_detail_model() for entity in entities]
+
+    def create(self, subject: User, log_message: str) -> LogDetails | None:
+        """
+        Creates a organization based on the input object and adds it to the table.
+
+        Parameters:
+            subject: a valid User model representing the currently logged in User
+            log (Log): Log to add to table
+
+        Returns:
+            Log: Object added to table
+        """
+
+        # First, ensure that a valid user exists
+        # (unauthenticated users cannot add to log)
+        if not subject or not subject.id:
+            return None
+
+        # Create log
+        log = Log(description=log_message, user_id=subject.id)
+        log_entity = LogEntity.from_model(log)
+
+        # Add to session
+        self._session.add(log_entity)
+        self._session.commit()
+
+        # Return added log
+        return log_entity.to_detail_model()

--- a/backend/services/log.py
+++ b/backend/services/log.py
@@ -27,7 +27,7 @@ class LogService:
 
     def all(self) -> list[LogDetails]:
         """
-        Retrieves all organizations from the table
+        Retrieves all logs from the table
 
         Returns:
             list[Log]: List of all `Log`s
@@ -41,7 +41,7 @@ class LogService:
 
     def create(self, subject: User | None, log_message: str) -> LogDetails | None:
         """
-        Creates a organization based on the input object and adds it to the table.
+        Creates a log based on the input object and adds it to the table.
 
         Parameters:
             subject: a valid User model representing the currently logged in User

--- a/backend/test/services/core_data.py
+++ b/backend/test/services/core_data.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import Session
 from .organization import organization_test_data
 from .event import event_test_data
 from . import permission_data, role_data, user_data
+from .log import log_test_data
 
 __authors__ = ["Kris Jordan"]
 __copyright__ = "Copyright 2023"
@@ -22,6 +23,7 @@ def setup_insert_data_fixture(session: Session):
     permission_data.insert_fake_data(session)
     organization_test_data.insert_fake_data(session)
     event_test_data.insert_fake_data(session)
+    log_test_data.insert_fake_data(session)
 
     session.commit()
     yield

--- a/backend/test/services/fixtures.py
+++ b/backend/test/services/fixtures.py
@@ -10,6 +10,7 @@ from ...services import (
     OrganizationService,
     EventService,
 )
+from ...services.log import LogService
 
 __authors__ = ["Kris Jordan", "Ajay Gandecha"]
 __copyright__ = "Copyright 2023"
@@ -54,3 +55,9 @@ def organization_svc_integration(session: Session):
 def event_svc_integration(session: Session):
     """This fixture is used to test the EventService class with a real PermissionService."""
     return EventService(session, PermissionService(session))
+
+
+@pytest.fixture()
+def log_svc_integration(session: Session):
+    """This fixture is used to test the LogClass class."""
+    return LogService(session)

--- a/backend/test/services/log/log_test.py
+++ b/backend/test/services/log/log_test.py
@@ -1,0 +1,55 @@
+"""Tests for the LogService class."""
+
+# PyTest
+import pytest
+from unittest.mock import create_autospec
+
+from backend.services.exceptions import ResourceNotFoundException
+
+# Tested Dependencies
+from ....models.log import LogDetails
+from ....services.log import LogService
+
+# Injected Service Fixtures
+from ..fixtures import log_svc_integration
+
+# Explicitly import Data Fixture to load entities in database
+from ..core_data import setup_insert_data_fixture
+
+# Data Models for Fake Data Inserted in Setup
+from .log_test_data import logs
+
+from ..user_data import root, user
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+# Test Functions
+
+# Test `LogService.all()`
+
+
+def test_get_all(log_svc_integration: LogService):
+    """Test that all logs can be retrieved."""
+    fetched_logs = log_svc_integration.all()
+    assert fetched_logs is not None
+    assert len(fetched_logs) == len(logs)
+    assert isinstance(fetched_logs[0], LogDetails)
+
+
+# Test `LogService.create()`
+
+
+def test_create(log_svc_integration: LogService):
+    """Test that a log can be created."""
+    created_log = log_svc_integration.create(user, "Test log created!")
+    assert created_log is not None
+    assert created_log.id is not None
+
+
+def test_create_no_user(log_svc_integration: LogService):
+    """Test that a log cannot be created without a valid user."""
+    with pytest.raises(ResourceNotFoundException):
+        log_svc_integration.create(None, "Test log created!")
+        pytest.fail()  # Fail test if no error was thrown above

--- a/backend/test/services/log/log_test_data.py
+++ b/backend/test/services/log/log_test_data.py
@@ -1,0 +1,52 @@
+"""Contains mock data for to run tests on the test feature."""
+
+import pytest
+from sqlalchemy.orm import Session
+from ....models.log import Log
+from ....entities.log_entity import LogEntity
+
+from ..reset_table_id_seq import reset_table_id_seq
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+# Sample Data Objects
+
+log_one = Log(id=1, description="Added an organization.", user_id=1)
+
+log_two = Log(id=2, description="Deleted an event.", user_id=2)
+
+logs = [log_one, log_two]
+
+# Data Functions
+
+
+def insert_fake_data(session: Session):
+    """Inserts fake organization data into the test session."""
+
+    global organizations
+
+    # Create entities for test data
+    entities = []
+    for log in logs:
+        entity = LogEntity.from_model(log)
+        session.add(entity)
+        entities.append(entity)
+
+    # Reset table IDs to prevent ID conflicts
+    reset_table_id_seq(session, LogEntity, LogEntity.id, len(logs) + 1)
+
+    # Commit all changes
+    session.commit()
+
+
+@pytest.fixture(autouse=True)
+def fake_data_fixture(session: Session):
+    """Insert fake data the session automatically when test is run.
+    Note:
+        This function runs automatically due to the fixture property `autouse=True`.
+    """
+    insert_fake_data(session)
+    session.commit()
+    yield

--- a/backend/test/services/log/log_test_data.py
+++ b/backend/test/services/log/log_test_data.py
@@ -23,7 +23,7 @@ logs = [log_one, log_two]
 
 
 def insert_fake_data(session: Session):
-    """Inserts fake organization data into the test session."""
+    """Inserts fake log data into the test session."""
 
     global organizations
 


### PR DESCRIPTION
This PR introduces backend entities, models, services, and tests for implementing the audit log feature. The audit log would be an admin-level feature that tracks the usage of major mutating API calls (for example, editing organizations, deleting events, etc). This allows the administrators of the CSXL Application to have a history of these calls in case a user either maliciously uses their permissions or if unauthorized users gain access to admin or ambassador level permissions. Note, at the moment, logs are not intended for `GET` API calls, however we can easily implement this for features such as retrieving sensitive user information.

## Major Changes
- Implemented the `LogEntity` in the backend to represent the new `log` table in the database. This entity has a one-to-many relationship with the `User` table, where each log is related to a single user, but a user can have many logs.
    - The `log` table stores a primary key `id`, the `user_id` representing the user attached to the log, and a short `description` field to describe the changes that were made.
    - We can consider changing this to specific API routes if needed, but I thought that a description would be more readable.
    - We can also consider passing request bodies here, although I thought that this may not be the most efficient use of space. Thoughts @KrisJordan?
- Implemented a `Log` and `LogDetail` model to represent the data for FastAPI.
- Implemented the `LogService` to control reading and adding logs to the database.
- Added test data and unit tests for the logs.

## Testing
- Tested the service using `pytest` (100% passing)

## Still To-Do
- Add calls to the `LogService` to each mutating service method for other features. Wanted to confirm that this is the best approach @KrisJordan! Probably does not make sense to expose any other APIs for logs except `GET`.
- Create a `GET` API for the log service.