### PR TITLE
Pass Initial Selected Event Through Pipe

### DIFF
--- a/frontend/src/app/event/event-page/event-page.component.ts
+++ b/frontend/src/app/event/event-page/event-page.component.ts
@@ -70,7 +70,7 @@ export class EventPageComponent implements OnInit {
 
     // Initialize the initially selected event
     if (data.events.length > 0) {
-      this.selectedEvent = data.events[0];
+      this.selectedEvent = eventFilterPipe.transform(data.events, "")[0];
     }
   }
 


### PR DESCRIPTION
This PR fixes a bug where the initially selected event would occasionally show a past event rather than the most upcoming event.