### PR TITLE
Protect EventRegistrations attendees from accidental API disclosure

### DIFF
--- a/backend/api/events.py
+++ b/backend/api/events.py
@@ -234,6 +234,26 @@ def get_registration_status(
         return event_registration
 
 
+@api.get("/{event_id}/registrations", tags=["Events"])
+def get_event_registrations_status(
+    event_id: int,
+    subject: User = Depends(registered_user),
+    event_service: EventService = Depends(),
+) -> Sequence[EventRegistration]:
+    """
+    Get the registrations of an event.
+
+    Args:
+        event_id: the int identifier of an Event
+        subject: the logged in user making the request
+        event_service: the backing service
+
+    Returns:
+        Sequence[EventRegistration]
+    """
+    return event_service.get_registrations(subject, event_service.get_by_id(event_id))
+
+
 @api.delete("/{event_id}/registration", tags=["Events"])
 def unregister_for_event(
     event_id: int,

--- a/backend/api/events.py
+++ b/backend/api/events.py
@@ -213,7 +213,7 @@ def register_for_event(
 
 
 @api.get("/{event_id}/registration", tags=["Events"])
-def get_registration_status(
+def get_event_registration_of_user(
     event_id: int,
     subject: User = Depends(registered_user),
     event_service: EventService = Depends(),
@@ -235,7 +235,7 @@ def get_registration_status(
 
 
 @api.get("/{event_id}/registrations", tags=["Events"])
-def get_event_registrations_status(
+def get_event_registrations(
     event_id: int,
     subject: User = Depends(registered_user),
     event_service: EventService = Depends(),

--- a/backend/api/events.py
+++ b/backend/api/events.py
@@ -251,7 +251,9 @@ def get_event_registrations_status(
     Returns:
         Sequence[EventRegistration]
     """
-    return event_service.get_registrations(subject, event_service.get_by_id(event_id))
+    return event_service.get_registrations_of_event(
+        subject, event_service.get_by_id(event_id)
+    )
 
 
 @api.delete("/{event_id}/registration", tags=["Events"])

--- a/backend/entities/event_entity.py
+++ b/backend/entities/event_entity.py
@@ -82,26 +82,6 @@ class EventEntity(EntityBase):
             organization_id=self.organization_id,
         )
 
-    @classmethod
-    def from_details_model(cls, model: EventDetails):
-        """
-        Class method that converts an `EventDetails` model into a `EventEntity`
-
-        Parameters:
-            - model (EventDetails): Model to convert into an entity
-        Returns:
-            EventEntity: Entity created from model
-        """
-        return cls(
-            id=model.id,
-            name=model.name,
-            time=model.time,
-            location=model.location,
-            description=model.description,
-            public=model.public,
-            organization_id=model.organization_id,
-        )
-
     def to_details_model(self) -> EventDetails:
         """Create a EventDetails model from an EventEntity, with permissions and members included.
 
@@ -117,7 +97,4 @@ class EventEntity(EntityBase):
             public=self.public,
             organization_id=self.organization_id,
             organization=self.organization.to_model(),
-            registrations=[
-                registration.to_model() for registration in self.registrations
-            ],
         )

--- a/backend/entities/event_registration_entity.py
+++ b/backend/entities/event_registration_entity.py
@@ -27,18 +27,17 @@ class EventRegistrationEntity(EntityBase):
     # Name for the events table in the PostgreSQL database
     __tablename__ = "event_registration"
 
-    # Unique ID for the event registration
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-
     # Event for the current event registration
     # NOTE: This is ultimately a join table for a many-to-many relationship
-    event_id: Mapped[int] = mapped_column(ForeignKey("event.id"))
+    event_id: Mapped[int] = mapped_column(ForeignKey("event.id"), primary_key=True)
     event: Mapped["EventEntity"] = relationship(back_populates="registrations")
 
     # User for the current event registration
     # NOTE: This is ultimately a join table for a many-to-many relationship
-    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"))
+    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), primary_key=True)
     user: Mapped["UserEntity"] = relationship()
+
+    organizer: Mapped[bool] = mapped_column(Boolean, default=False)
 
     @classmethod
     def from_model(cls, model: EventRegistration) -> Self:
@@ -51,7 +50,6 @@ class EventRegistrationEntity(EntityBase):
             EventRegistrationEntity: Entity created from model
         """
         return cls(
-            id=model.id,
             event_id=model.event_id,
             user_id=model.user_id,
             event=model.event,
@@ -78,7 +76,6 @@ class EventRegistrationEntity(EntityBase):
             EventRegistration: `EventRegistration` object from the entity
         """
         return EventRegistration(
-            id=self.id,
             event_id=self.event_id,
             user_id=self.user_id,
             event=self.event.to_model(),

--- a/backend/entities/event_registration_entity.py
+++ b/backend/entities/event_registration_entity.py
@@ -37,7 +37,7 @@ class EventRegistrationEntity(EntityBase):
     user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), primary_key=True)
     user: Mapped["UserEntity"] = relationship()
 
-    organizer: Mapped[bool] = mapped_column(Boolean, default=False)
+    is_organizer: Mapped[bool] = mapped_column(Boolean, default=False)
 
     @classmethod
     def from_model(cls, model: EventRegistration) -> Self:
@@ -54,6 +54,7 @@ class EventRegistrationEntity(EntityBase):
             user_id=model.user_id,
             event=model.event,
             user=model.user,
+            is_organizer=model.is_organizer,
         )
 
     @classmethod
@@ -66,7 +67,11 @@ class EventRegistrationEntity(EntityBase):
         Returns:
             EventRegistrationEntity: Entity created from model
         """
-        return cls(event_id=model.event_id, user_id=model.user_id)
+        return cls(
+            event_id=model.event_id,
+            user_id=model.user_id,
+            is_organizer=model.is_organizer,
+        )
 
     def to_model(self) -> EventRegistration:
         """
@@ -78,6 +83,7 @@ class EventRegistrationEntity(EntityBase):
         return EventRegistration(
             event_id=self.event_id,
             user_id=self.user_id,
+            is_organizer=self.is_organizer,
             event=self.event.to_model(),
             user=self.user.to_model(),
         )

--- a/backend/models/event_details.py
+++ b/backend/models/event_details.py
@@ -1,6 +1,5 @@
 from backend.models.event import Event
 from backend.models.organization import Organization
-from backend.models.event_registration import EventRegistration
 
 
 class EventDetails(Event):

--- a/backend/models/event_details.py
+++ b/backend/models/event_details.py
@@ -5,12 +5,10 @@ from backend.models.event_registration import EventRegistration
 
 class EventDetails(Event):
     """
-    Pydantic model to represent an `Event`, including back-populated
-    relationship fields.
+    Pydantic model to represent an `Event`.
 
     This model is based on the `EventEntity` model, which defines the shape
     of the `Event` database in the PostgreSQL database.
     """
 
     organization: Organization
-    registrations: list[EventRegistration]

--- a/backend/models/event_registration.py
+++ b/backend/models/event_registration.py
@@ -19,6 +19,7 @@ class NewEventRegistration(BaseModel):
 
     event_id: int
     user_id: int
+    is_organizer: bool = False
 
 
 class EventRegistration(NewEventRegistration):
@@ -31,3 +32,4 @@ class EventRegistration(NewEventRegistration):
 
     event: Event | None
     user: User | None
+    is_organizer: bool = False

--- a/backend/models/event_registration.py
+++ b/backend/models/event_registration.py
@@ -17,7 +17,6 @@ class NewEventRegistration(BaseModel):
     This model is needed for the creation of new registrations in the event service
     """
 
-    id: int | None = None
     event_id: int
     user_id: int
 

--- a/backend/services/event.py
+++ b/backend/services/event.py
@@ -275,9 +275,26 @@ class EventService:
         registration = self.get_registration(user, user, event)
         return registration.is_organizer if registration else False
 
-    def get_registrations(
+    def get_registrations_of_event(
         self, subject: User, event: EventDetails
     ) -> list[EventRegistration]:
+        """
+        List the registrations of an event.
+
+        This API endpoint currently requires the subject to be registered as the
+        organizer of an event or have administrative permission of action
+        "organization.events.manage" for "organization/{organization id}".
+
+        Args:
+            subject: The authenticated user making the request.
+            event: The event whose registrations are being queried.
+
+        Returns:
+            list[EventRegistration]
+
+        Raises:
+            UserPermissionException if user is not an event organizer or admin.
+        """
         if not self.is_user_an_organizer(subject, event):
             self._permission.enforce(
                 subject,

--- a/backend/services/event.py
+++ b/backend/services/event.py
@@ -264,6 +264,8 @@ class EventService:
     def get_registrations(
         self, subject: User, event: EventDetails
     ) -> list[EventRegistration]:
+        # TODO: Check to see if subject is registered as organizer
+
         self._permission.enforce(
             subject,
             "organization.events.manage",

--- a/backend/services/event.py
+++ b/backend/services/event.py
@@ -261,16 +261,29 @@ class EventService:
         else:
             return None
 
+    def is_user_an_organizer(self, user: User, event: EventDetails) -> bool:
+        """
+        Test whether a user is an organizer of an event.
+
+        Args:
+            user: The user to check on event organizer status of.
+            event: The event in question.
+
+        Returns:
+            bool True if user is an organizer, False otherwise.
+        """
+        registration = self.get_registration(user, user, event)
+        return registration.is_organizer if registration else False
+
     def get_registrations(
         self, subject: User, event: EventDetails
     ) -> list[EventRegistration]:
-        # TODO: Check to see if subject is registered as organizer
-
-        self._permission.enforce(
-            subject,
-            "organization.events.manage",
-            f"organization/{event.organization.id}",
-        )
+        if not self.is_user_an_organizer(subject, event):
+            self._permission.enforce(
+                subject,
+                "organization.events.manage",
+                f"organization/{event.organization.id}",
+            )
 
         event_registration_entities = (
             self._session.query(EventRegistrationEntity)

--- a/backend/test/services/event/event_test.py
+++ b/backend/test/services/event/event_test.py
@@ -142,7 +142,6 @@ def test_register_for_event_as_user_twice(event_svc_integration: EventService):
     assert created_registration_1 is not None
     created_registration_2 = event_svc_integration.register(user, user, event_details)  # type: ignore
     assert created_registration_2 is not None
-    assert created_registration_1.id == created_registration_2.id
 
 
 def test_register_for_event_enforces_permission(event_svc_integration: EventService):
@@ -164,7 +163,6 @@ def test_get_registration(event_svc_integration: EventService):
         ambassador, ambassador, event_details
     )
     assert event_registration is not None
-    assert event_registration.id is registration.id
 
 
 def test_get_registration_that_does_not_exist(event_svc_integration: EventService):

--- a/backend/test/services/event/event_test.py
+++ b/backend/test/services/event/event_test.py
@@ -168,9 +168,24 @@ def test_get_registration(event_svc_integration: EventService):
 def test_get_registration_that_does_not_exist(event_svc_integration: EventService):
     event_details = event_svc_integration.get_by_id(event_one.id)  # type: ignore
     event_registration = event_svc_integration.get_registration(
-        user, user, event_details
+        root, root, event_details
     )
     assert event_registration is None
+
+
+def test_is_user_an_organizer_organizer(event_svc_integration: EventService):
+    event_details = event_svc_integration.get_by_id(event_one.id)  # type: ignore
+    assert event_svc_integration.is_user_an_organizer(user, event_details)
+
+
+def test_is_user_an_organizer_attendee(event_svc_integration: EventService):
+    event_details = event_svc_integration.get_by_id(event_one.id)  # type: ignore
+    assert not event_svc_integration.is_user_an_organizer(ambassador, event_details)
+
+
+def test_is_user_an_organizer_non_attendee(event_svc_integration: EventService):
+    event_details = event_svc_integration.get_by_id(event_one.id)  # type: ignore
+    assert not event_svc_integration.is_user_an_organizer(root, event_details)
 
 
 def test_unregister_for_event_as_registerer(
@@ -257,7 +272,7 @@ def test_get_registrations_of_user_without_reservations(
     """Test that a user without any registrations is able to query for it."""
     time_range = TimeRange(start=event_one.time - ONE_DAY, end=event_one.time + ONE_DAY)
     registrations = event_svc_integration.get_registrations_of_user(
-        user, user, time_range
+        root, root, time_range
     )
     assert len(registrations) == 0
 

--- a/backend/test/services/event/event_test_data.py
+++ b/backend/test/services/event/event_test_data.py
@@ -60,8 +60,14 @@ updated_event = Event(
 )
 
 registration = NewEventRegistration(
-    event_id=event_one.id | 0, user_id=ambassador.id | 0
+    event_id=event_one.id | 0, user_id=ambassador.id | 0, is_organizer=False
 )
+
+organizer_registration = NewEventRegistration(
+    event_id=event_one.id | 0, user_id=user.id | 0, is_organizer=True
+)
+
+registrations = [registration, organizer_registration]
 
 # Data Functions
 
@@ -77,8 +83,11 @@ def insert_fake_data(session: Session):
         event_entity = EventEntity.from_model(event)
         session.add(event_entity)
         entities.append(event_entity)
-    registration_entity = EventRegistrationEntity.from_new_model(registration)
-    session.add(registration_entity)
+
+    for registration in registrations:
+        registration_entity = EventRegistrationEntity.from_new_model(registration)
+        session.add(registration_entity)
+
     # Reset table IDs to prevent ID conflicts
     reset_table_id_seq(session, EventEntity, EventEntity.id, len(events) + 1)
 

--- a/backend/test/services/event/event_test_data.py
+++ b/backend/test/services/event/event_test_data.py
@@ -60,7 +60,7 @@ updated_event = Event(
 )
 
 registration = NewEventRegistration(
-    id=1, event_id=event_one.id | 0, user_id=ambassador.id | 0
+    event_id=event_one.id | 0, user_id=ambassador.id | 0
 )
 
 # Data Functions


### PR DESCRIPTION
We need registrations to events to be limited to users with permission to view. This PR is not ready for merge, but is the start of progress on this front.