### PR TITLE
Use absolute path to .env file in backend/env.py

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -9,7 +9,7 @@ __copyright__ = "Copyright 2023"
 __license__ = "MIT"
 
 
-def _engine_str(database=getenv("POSTGRES_DATABASE")) -> str:
+def _engine_str(database: str = getenv("POSTGRES_DATABASE")) -> str:
     """Helper function for reading settings from environment variables to produce connection string."""
     dialect = "postgresql+psycopg2"
     user = getenv("POSTGRES_USER")

--- a/backend/env.py
+++ b/backend/env.py
@@ -8,7 +8,7 @@ __copyright__ = "Copyright 2023"
 __license__ = "MIT"
 
 # Load envirnment variables from .env file upon module start.
-dotenv.load_dotenv(verbose=True)
+dotenv.load_dotenv(f"{os.path.dirname(__file__)}/.env", verbose=True)
 
 
 def getenv(variable: str) -> str:


### PR DESCRIPTION
This commit fixes an issue when working in the REPL with backend code.
The fundamental issue is path related and resolved by using an absolute
path in the `dotenv` loader for our development environment.

A type annotation was also added to backend/database.py to align with
project style.