### PR TITLE
Dark Mode Button and Tab Styling

### DIFF
--- a/frontend/src/app/admin/admin.component.html
+++ b/frontend/src/app/admin/admin.component.html
@@ -1,4 +1,4 @@
-<nav mat-tab-nav-bar [tabPanel]="tabPanel">
+<nav mat-tab-nav-bar [tabPanel]="tabPanel" color="accent">
   <a
     mat-tab-link
     *ngFor="let link of links"

--- a/frontend/src/app/coworking/ambassador-home/ambassador-home.component.css
+++ b/frontend/src/app/coworking/ambassador-home/ambassador-home.component.css
@@ -1,3 +1,7 @@
 .mat-mdc-card {
     max-width: 100%;
 }
+
+button {
+    margin-right: 1vw;
+}

--- a/frontend/src/app/coworking/ambassador-home/ambassador-home.component.html
+++ b/frontend/src/app/coworking/ambassador-home/ambassador-home.component.html
@@ -42,13 +42,11 @@
           <td mat-cell *matCellDef="let reservation">
             <button
               mat-stroked-button
-              color="primary"
               (click)="this.ambassadorService.checkIn(reservation)">
               Check-in
             </button>
             <button
               mat-stroked-button
-              color="warn"
               (click)="this.ambassadorService.cancel(reservation)">
               Cancel
             </button>

--- a/frontend/src/app/coworking/widgets/coworking-reservation-card/coworking-reservation-card.html
+++ b/frontend/src/app/coworking/widgets/coworking-reservation-card/coworking-reservation-card.html
@@ -73,11 +73,7 @@
           Cancel
         </button>
         &nbsp;
-        <button
-          mat-stroked-button
-          type="submit"
-          color="primary"
-          (click)="confirm()">
+        <button mat-stroked-button type="submit" (click)="confirm()">
           {{ draftConfirmationDeadline$ | async }}
         </button>
       </ng-container>
@@ -89,11 +85,7 @@
       </ng-container>
 
       <ng-container *ngSwitchCase="'CHECKED_IN'">
-        <button
-          mat-stroked-button
-          type="submit"
-          (click)="checkout()"
-          color="primary">
+        <button mat-stroked-button type="submit" (click)="checkout()">
           Check Out
         </button>
       </ng-container>
@@ -102,8 +94,7 @@
         <button
           mat-stroked-button
           type="submit"
-          (click)="router.navigateByUrl('/coworking')"
-          color="primary">
+          (click)="router.navigateByUrl('/coworking')">
           Return to Coworking Home
         </button>
       </ng-container>
@@ -112,8 +103,7 @@
         <button
           mat-stroked-button
           type="submit"
-          (click)="router.navigateByUrl('/coworking')"
-          color="primary">
+          (click)="router.navigateByUrl('/coworking')">
           Return to Coworking Home
         </button>
       </ng-container>


### PR DESCRIPTION
This pull request changes the color of the buttons and tabs on dark mode to white outlines to be consistent with the rest of the application.

## Major Changes
- Changed admin tabs from pink to white outlines
- Changed coworking dark mode buttons from pink to white outline buttons
- Changed ambassador dark mode buttons from pink and red to white outline buttons
- Added a right-margin to the ambassador reservation card so that the buttons don't touch

*This PR resolves #159*

Notes:
I kept the `Revoke` and `Grant` permission buttons on Admin page the same colors.
![image](https://github.com/unc-csxl/csxl.unc.edu/assets/37271052/b4cf5ac9-fb11-48f3-a43f-77ab178351c4)
