### PR TITLE
Create Entities for Courses Feature

### DIFF
--- a/backend/entities/__init__.py
+++ b/backend/entities/__init__.py
@@ -14,6 +14,7 @@ global to a module are available for import from other modules."""
 
 
 from .entity_base import EntityBase
+from .courses import *
 from .user_entity import UserEntity
 from .role_entity import RoleEntity
 from .permission_entity import PermissionEntity

--- a/backend/entities/courses/__init__.py
+++ b/backend/entities/courses/__init__.py
@@ -1,3 +1,5 @@
 from .course_entity import CourseEntity
 from .term_entity import TermEntity
 from .section_entity import SectionEntnity
+from .user_section_entity import UserSectionEntity
+from .instructor_section_entity import InstructorSectionEntity

--- a/backend/entities/courses/__init__.py
+++ b/backend/entities/courses/__init__.py
@@ -1,0 +1,3 @@
+from .course_entity import CourseEntity
+from .term_entity import TermEntity
+from .section_entity import SectionEntnity

--- a/backend/entities/courses/__init__.py
+++ b/backend/entities/courses/__init__.py
@@ -1,5 +1,5 @@
+from .section_entity import SectionEntity
 from .course_entity import CourseEntity
 from .term_entity import TermEntity
-from .section_entity import SectionEntnity
 from .user_section_entity import UserSectionEntity
 from .instructor_section_entity import InstructorSectionEntity

--- a/backend/entities/courses/course_entity.py
+++ b/backend/entities/courses/course_entity.py
@@ -26,3 +26,8 @@ class CourseEntity(EntityBase):
     code: Mapped[str] = mapped_column(String, default="")
     # Title or name for the course
     title: Mapped[str] = mapped_column(String, default="")
+
+    # NOTE: This field establishes a one-to-many relationship between the course and section tables.
+    events: Mapped[list["SectionEntity"]] = relationship(
+        back_populates="course", cascade="all,delete"
+    )

--- a/backend/entities/courses/course_entity.py
+++ b/backend/entities/courses/course_entity.py
@@ -13,7 +13,7 @@ class CourseEntity(EntityBase):
     """Serves as the database model schema defining the shape of the `Course` table"""
 
     # Name for the course table in the PostgreSQL database
-    __tablename__ = "course"
+    __tablename__ = "courses__course"
 
     # Course properties (columns in the database table)
 
@@ -27,6 +27,6 @@ class CourseEntity(EntityBase):
     title: Mapped[str] = mapped_column(String, default="")
 
     # NOTE: This field establishes a one-to-many relationship between the course and section tables.
-    events: Mapped[list["SectionEntity"]] = relationship(
+    sections: Mapped[list["SectionEntity"]] = relationship(
         back_populates="course", cascade="all,delete"
     )

--- a/backend/entities/courses/course_entity.py
+++ b/backend/entities/courses/course_entity.py
@@ -1,9 +1,8 @@
 """Definition of SQLAlchemy table-backed object mapping entity for Course."""
 
-from sqlalchemy import Integer, String, Boolean
+from sqlalchemy import Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..entity_base import EntityBase
-from typing import Self
 
 __authors__ = ["Ajay Gandecha"]
 __copyright__ = "Copyright 2023"

--- a/backend/entities/courses/course_entity.py
+++ b/backend/entities/courses/course_entity.py
@@ -1,0 +1,28 @@
+"""Definition of SQLAlchemy table-backed object mapping entity for Course."""
+
+from sqlalchemy import Integer, String, Boolean
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from ..entity_base import EntityBase
+from typing import Self
+
+__authors__ = ["Ajay Gandecha", "Jade Keegan", "Brianna Ta", "Audrey Toney"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+
+class CourseEntity(EntityBase):
+    """Serves as the database model schema defining the shape of the `Course` table"""
+
+    # Name for the course table in the PostgreSQL database
+    __tablename__ = "course"
+
+    # Course properties (columns in the database table)
+
+    # Unique ID for the course
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # Suject for the course (for example, the subject of COMP 110 would be COMP)
+    subject: Mapped[str] = mapped_column(String, default="")
+    # Code for the course (for example, the code of COMP 110 would be 110)
+    code: Mapped[str] = mapped_column(String, default="")
+    # Title or name for the course
+    title: Mapped[str] = mapped_column(String, default="")

--- a/backend/entities/courses/course_entity.py
+++ b/backend/entities/courses/course_entity.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..entity_base import EntityBase
 from typing import Self
 
-__authors__ = ["Ajay Gandecha", "Jade Keegan", "Brianna Ta", "Audrey Toney"]
+__authors__ = ["Ajay Gandecha"]
 __copyright__ = "Copyright 2023"
 __license__ = "MIT"
 

--- a/backend/entities/courses/instructor_section_entity.py
+++ b/backend/entities/courses/instructor_section_entity.py
@@ -1,7 +1,7 @@
 """Definition of SQLAlchemy table-backed object mapping entity for the user - section association table."""
 
 from sqlalchemy import ForeignKey, Boolean, Integer
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..entity_base import EntityBase
 
 __authors__ = ["Ajay Gandecha"]
@@ -20,7 +20,7 @@ class InstructorSectionEntity(EntityBase):
     """
 
     # Name for the user section table in the PostgreSQL database
-    __tablename__ = "instructor_section"
+    __tablename__ = "courses__instructor_section"
 
     # Instructor Section properties (columns in the database table)
 
@@ -30,7 +30,9 @@ class InstructorSectionEntity(EntityBase):
 
     # Section for the current relation
     # NOTE: This is ultimately a join table for a many-to-many relationship
-    section_id: Mapped[int] = mapped_column(ForeignKey("section.id"), primary_key=True)
+    section_id: Mapped[int] = mapped_column(
+        ForeignKey("courses__section.id"), primary_key=True
+    )
 
     # Whether or not the user is the primary instructor
     is_primary_instructor: Mapped[bool] = mapped_column(Boolean)

--- a/backend/entities/courses/instructor_section_entity.py
+++ b/backend/entities/courses/instructor_section_entity.py
@@ -1,0 +1,42 @@
+"""Definition of SQLAlchemy table-backed object mapping entity for the user - section association table."""
+
+from sqlalchemy import ForeignKey, Boolean, Integer
+from sqlalchemy.orm import Mapped, mapped_column
+from ..entity_base import EntityBase
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+
+class InstructorSectionEntity(EntityBase):
+    """Serves as the database model schema defining the shape of the `InstructorSection` table
+
+    This table is the association / join table to establish the many-to-many relationship
+    between the `user` and `section` tables for instructors.
+
+    To establish this relationship, this entity contains two primary key fields for each related
+    table.
+    """
+
+    # Name for the user section table in the PostgreSQL database
+    __tablename__ = "instructor_section"
+
+    # Instructor Section properties (columns in the database table)
+
+    # Instructor for the current relation
+    # NOTE: This is ultimately a join table for a many-to-many relationship
+    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), primary_key=True)
+
+    # Section for the current relation
+    # NOTE: This is ultimately a join table for a many-to-many relationship
+    section_id: Mapped[int] = mapped_column(ForeignKey("section.id"), primary_key=True)
+
+    # Whether or not the user is the primary instructor
+    is_primary_instructor: Mapped[bool] = mapped_column(Boolean)
+
+    # Type of instructor
+    # 1 = Undergraduate Teaching Assistant
+    # 2 = Graduate Teaching Assistant
+    # 3 = Main Instructor
+    instructor_type: Mapped[int] = mapped_column(Integer)

--- a/backend/entities/courses/section_entity.py
+++ b/backend/entities/courses/section_entity.py
@@ -10,11 +10,11 @@ __copyright__ = "Copyright 2023"
 __license__ = "MIT"
 
 
-class SectionEntnity(EntityBase):
+class SectionEntity(EntityBase):
     """Serves as the database model schema defining the shape of the `Section` table"""
 
     # Name for the course section table in the PostgreSQL database
-    __tablename__ = "section"
+    __tablename__ = "courses__section"
 
     # Section properties (columns in the database table)
 
@@ -29,20 +29,20 @@ class SectionEntnity(EntityBase):
 
     # Course the section is for
     # NOTE: This defines a one-to-many relationship between the course and sections tables.
-    course_id: Mapped[int] = mapped_column(ForeignKey("course.id"))
+    course_id: Mapped[int] = mapped_column(ForeignKey("courses__course.id"))
     course: Mapped["CourseEntity"] = relationship(back_populates="sections")
 
     # Term the section is in
     # NOTE: This defines a one-to-many relationship between the term and sections tables.
-    term_id: Mapped[int] = mapped_column(ForeignKey("term.id"))
+    term_id: Mapped[int] = mapped_column(ForeignKey("courses__term.id"))
     term: Mapped["TermEntity"] = relationship(back_populates="course_sections")
 
     # NOTE: This field establishes a many-to-many relationship between the user and section tables for students.
     students: Mapped[list["UserEntity"]] = relationship(
-        secondary="user_section", back_populates="course_sections"
+        secondary="courses__user_section", back_populates="course_sections"
     )
 
     # NOTE: This field establishes a many-to-many relationship between the user and section tables for instructors.
     instructors: Mapped[list["UserEntity"]] = relationship(
-        secondary="instructor_section", back_populates="course_sections"
+        secondary="courses__instructor_section", back_populates="instructor_for"
     )

--- a/backend/entities/courses/section_entity.py
+++ b/backend/entities/courses/section_entity.py
@@ -1,0 +1,39 @@
+"""Definition of SQLAlchemy table-backed object mapping entity for Course Sections."""
+
+from sqlalchemy import Integer, String, DateTime, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from ..entity_base import EntityBase
+from typing import Self
+from datetime import datetime
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+
+class SectionEntnity(EntityBase):
+    """Serves as the database model schema defining the shape of the `Section` table"""
+
+    # Name for the course section table in the PostgreSQL database
+    __tablename__ = "section"
+
+    # Section properties (columns in the database table)
+
+    # Unique ID for the section
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # Code of the section (for example, COMP 100-003's code would be "003")
+    code: Mapped[str] = mapped_column(String, default="")
+    # Starting date for the term
+    start_date: Mapped[datetime] = mapped_column(DateTime)
+    # Ending date for the term
+    end_date: Mapped[datetime] = mapped_column(DateTime)
+
+    # Course the section is for
+    # NOTE: This defines a one-to-many relationship between the course and sections tables.
+    course_id: Mapped[int] = mapped_column(ForeignKey("course.id"))
+    course: Mapped["CourseEntity"] = relationship(back_populates="sections")
+
+    # Term the section is in
+    # NOTE: This defines a one-to-many relationship between the term and sections tables.
+    term_id: Mapped[int] = mapped_column(ForeignKey("term.id"))
+    term: Mapped["TermEntity"] = relationship(back_populates="course_sections")

--- a/backend/entities/courses/section_entity.py
+++ b/backend/entities/courses/section_entity.py
@@ -3,7 +3,6 @@
 from sqlalchemy import Integer, String, DateTime, ForeignKey
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..entity_base import EntityBase
-from typing import Self
 from datetime import datetime
 
 __authors__ = ["Ajay Gandecha"]
@@ -37,3 +36,13 @@ class SectionEntnity(EntityBase):
     # NOTE: This defines a one-to-many relationship between the term and sections tables.
     term_id: Mapped[int] = mapped_column(ForeignKey("term.id"))
     term: Mapped["TermEntity"] = relationship(back_populates="course_sections")
+
+    # NOTE: This field establishes a many-to-many relationship between the user and section tables for students.
+    students: Mapped[list["UserEntity"]] = relationship(
+        secondary="user_section", back_populates="course_sections"
+    )
+
+    # NOTE: This field establishes a many-to-many relationship between the user and section tables for instructors.
+    instructors: Mapped[list["UserEntity"]] = relationship(
+        secondary="instructor_section", back_populates="course_sections"
+    )

--- a/backend/entities/courses/term_entity.py
+++ b/backend/entities/courses/term_entity.py
@@ -1,0 +1,29 @@
+"""Definition of SQLAlchemy table-backed object mapping entity for Terms."""
+
+from sqlalchemy import Integer, String, DateTime
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from ..entity_base import EntityBase
+from typing import Self
+from datetime import datetime
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+
+class TermEntity(EntityBase):
+    """Serves as the database model schema defining the shape of the `Term` table"""
+
+    # Name for the term table in the PostgreSQL database
+    __tablename__ = "term"
+
+    # Term properties (columns in the database table)
+
+    # Unique ID for the term
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # Name of the term (for example, "Fall 2023")
+    name: Mapped[str] = mapped_column(String, default="")
+    # Starting date for the term
+    start_date: Mapped[datetime] = mapped_column(DateTime)
+    # Ending date for the term
+    end_date: Mapped[datetime] = mapped_column(DateTime)

--- a/backend/entities/courses/term_entity.py
+++ b/backend/entities/courses/term_entity.py
@@ -3,7 +3,6 @@
 from sqlalchemy import Integer, String, DateTime
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..entity_base import EntityBase
-from typing import Self
 from datetime import datetime
 
 __authors__ = ["Ajay Gandecha"]

--- a/backend/entities/courses/term_entity.py
+++ b/backend/entities/courses/term_entity.py
@@ -14,7 +14,7 @@ class TermEntity(EntityBase):
     """Serves as the database model schema defining the shape of the `Term` table"""
 
     # Name for the term table in the PostgreSQL database
-    __tablename__ = "term"
+    __tablename__ = "courses__term"
 
     # Term properties (columns in the database table)
 

--- a/backend/entities/courses/term_entity.py
+++ b/backend/entities/courses/term_entity.py
@@ -27,3 +27,8 @@ class TermEntity(EntityBase):
     start_date: Mapped[datetime] = mapped_column(DateTime)
     # Ending date for the term
     end_date: Mapped[datetime] = mapped_column(DateTime)
+
+    # NOTE: This field establishes a one-to-many relationship between the term and section tables.
+    course_sections: Mapped[list["SectionEntity"]] = relationship(
+        back_populates="term", cascade="all,delete"
+    )

--- a/backend/entities/courses/user_section_entity.py
+++ b/backend/entities/courses/user_section_entity.py
@@ -1,7 +1,7 @@
 """Definition of SQLAlchemy table-backed object mapping entity for the user - section association table."""
 
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..entity_base import EntityBase
 
 __authors__ = ["Ajay Gandecha"]
@@ -20,7 +20,7 @@ class UserSectionEntity(EntityBase):
     """
 
     # Name for the user section table in the PostgreSQL database
-    __tablename__ = "user_section"
+    __tablename__ = "courses__user_section"
 
     # User Section properties (columns in the database table)
 
@@ -30,4 +30,6 @@ class UserSectionEntity(EntityBase):
 
     # Section for the current relation
     # NOTE: This is ultimately a join table for a many-to-many relationship
-    section_id: Mapped[int] = mapped_column(ForeignKey("section.id"), primary_key=True)
+    section_id: Mapped[int] = mapped_column(
+        ForeignKey("courses__section.id"), primary_key=True
+    )

--- a/backend/entities/courses/user_section_entity.py
+++ b/backend/entities/courses/user_section_entity.py
@@ -1,0 +1,33 @@
+"""Definition of SQLAlchemy table-backed object mapping entity for the user - section association table."""
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column
+from ..entity_base import EntityBase
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+
+class UserSectionEntity(EntityBase):
+    """Serves as the database model schema defining the shape of the `UserSection` table
+
+    This table is the association / join table to establish the many-to-many relationship
+    between the `user` and `section` tables.
+
+    To establish this relationship, this entity contains two primary key fields for each related
+    table.
+    """
+
+    # Name for the user section table in the PostgreSQL database
+    __tablename__ = "user_section"
+
+    # User Section properties (columns in the database table)
+
+    # User for the current relation
+    # NOTE: This is ultimately a join table for a many-to-many relationship
+    user_id: Mapped[int] = mapped_column(ForeignKey("user.id"), primary_key=True)
+
+    # Section for the current relation
+    # NOTE: This is ultimately a join table for a many-to-many relationship
+    section_id: Mapped[int] = mapped_column(ForeignKey("section.id"), primary_key=True)

--- a/backend/entities/user_entity.py
+++ b/backend/entities/user_entity.py
@@ -55,12 +55,16 @@ class UserEntity(EntityBase):
 
     # NOTE: This field establishes a many-to-many relationship between the user and course section tables.
     course_sections: Mapped[list["SectionEntity"]] = relationship(
-        secondary="user_section", back_populates="students"
+        secondary="courses__user_section",
+        back_populates="students",
+        cascade="all, delete",
     )
 
     # NOTE: This field establishes a many-to-many relationship between the user and course section tables.
     instructor_for: Mapped[list["SectionEntity"]] = relationship(
-        secondary="user_section", back_populates="instructors"
+        secondary="courses__instructor_section",
+        back_populates="instructors",
+        cascade="all, delete",
     )
 
     @classmethod

--- a/backend/entities/user_entity.py
+++ b/backend/entities/user_entity.py
@@ -53,6 +53,16 @@ class UserEntity(EntityBase):
     # NOTE: This field establishes a one-to-many relationship between the permission and users table.
     permissions: Mapped["PermissionEntity"] = relationship(back_populates="user")
 
+    # NOTE: This field establishes a many-to-many relationship between the user and course section tables.
+    course_sections: Mapped[list["SectionEntity"]] = relationship(
+        secondary="user_section", back_populates="students"
+    )
+
+    # NOTE: This field establishes a many-to-many relationship between the user and course section tables.
+    instructor_for: Mapped[list["SectionEntity"]] = relationship(
+        secondary="user_section", back_populates="instructors"
+    )
+
     @classmethod
     def from_model(cls, model: User) -> Self:
         """


### PR DESCRIPTION
This major makes progress on adding all of the necessary entities for the courses feature to function. This includes including courses, terms (semesters), course sections, and the necessary association tables to connect users to sections, both as students and as instructors.

## Implementation

The entities follow this basic diagram:

![Image from iOS](https://github.com/unc-csxl/csxl.unc.edu/assets/17516747/d823cfbf-6afb-4cea-8634-2048acb4415c)

The addition of relationships between the `section` and `room` table can wait until it becomes necessary to add it.

Note that to keep with consistency of the *coworking* feature, all table names in the database have been added with a `courses__` prefix.