### PR TITLE
Add oc OpenShift Client to DevContainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -89,6 +89,18 @@ RUN curl https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.
 # Set Locale for Functional Autocompletion in zsh
 RUN sudo locale-gen en_US.UTF-8
 
+# Add `oc` OpenShift Client to DevContainer
+RUN arch="$(arch)"; \
+    case "$arch" in \
+        x86_64) export TARGET='' ;; \
+        aarch64) export TARGET='arm64-' ;; \
+    esac; \
+    wget -O /tmp/oc.tgz "https://github.com/okd-project/okd/releases/download/4.14.0-0.okd-2023-12-01-225814/openshift-client-linux-${TARGET}4.14.0-0.okd-2023-12-01-225814.tar.gz" && \
+    cd /tmp && \
+    tar -xvzf oc.tgz && \
+    sudo mv oc /usr/bin/oc && \
+    rm kubectl oc.tgz README.md
+
 # Install Database Dependencies
 COPY backend/requirements.txt /workspace/backend/requirements.txt
 WORKDIR /workspace/backend


### PR DESCRIPTION
DevContainer Dockerfile now downloads and installs the oc client for OpenShift. This enables a workflow of working with staging/production within the DevContainer terminal and removes a small hurdle for students needing to download and correctly install oc. Even more optimistically this enables us to begin scripting many devops/deployment concerns in the codebase. Some thought will need to be put into guard rails to avoid accidentally scripting against the production site before scripting anything, though!

As this changes the dev Dockerfile, a rebuild of the DevContainer is needed once the commit is pulled into a dev repository.