### PR TITLE
Add Generate Bearer Token feature

### DIFF
--- a/frontend/src/app/profile/profile-editor/profile-editor.component.css
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.css
@@ -1,24 +1,28 @@
 .mat-mdc-card {
-    margin: 1em;
-    max-width: 640px;
+  margin: 1em;
+  max-width: 640px;
 }
 
 .mat-mdc-form-field {
-    width: stretch;
-    /* margin-left: 1em; */
+  width: stretch;
+  /* margin-left: 1em; */
 }
 
 .mat-mdc-card-actions .mdc-button {
-    margin-left: 8px;
-    margin-bottom: 8px;
+  margin-left: 8px;
+  margin-bottom: 8px;
 }
 
 .mat-mdc-card-title a,
 .mat-mdc-card-title a:hover,
 .mat-mdc-card-title a:visited {
-    color: #fff;
+  color: #fff;
 }
 
 mat-card-content {
-    margin-top: 8px;
+  margin-top: 8px;
+}
+
+.token {
+  word-wrap: break-word;
 }

--- a/frontend/src/app/profile/profile-editor/profile-editor.component.html
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.html
@@ -93,24 +93,21 @@
   </ng-template>
 </mat-card>
 
-<html>
-  <mat-card appearance="outlined">
-    <mat-card-actions class="token">
-      <button mat-stroked-button type="submit" (click)="displayToken()">
-        Display Bearer Token
-      </button>
-      <button
-        class="cancel-button"
-        mat-stroked-button
-        type="submit"
-        (click)="copyToken()">
-        Copy
-      </button>
-    </mat-card-actions>
-    <div *ngIf="token">
-      <mat-card-content class="token" *ngIf="token">
-        {{ token }}</mat-card-content
-      >
-    </div>
-  </mat-card>
-</html>
+<mat-card *ngIf="profile.id" appearance="outlined">
+  <mat-card-actions class="token">
+    <button mat-stroked-button type="submit" (click)="displayToken()">
+      Display Bearer Token
+    </button>
+    <button
+      class="cancel-button"
+      mat-stroked-button
+      type="submit"
+      (click)="copyToken()">
+      Copy
+    </button>
+  </mat-card-actions>
+  <div *ngIf="showToken">
+    <mat-card-content class="token" *ngIf="token">
+      <code>{{ token }}</code></mat-card-content>
+  </div>
+</mat-card>

--- a/frontend/src/app/profile/profile-editor/profile-editor.component.html
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.html
@@ -92,3 +92,25 @@
     </mat-card-actions>
   </ng-template>
 </mat-card>
+
+<html>
+  <mat-card appearance="outlined">
+    <mat-card-actions class="token">
+      <button mat-stroked-button type="submit" (click)="displayToken()">
+        Display Bearer Token
+      </button>
+      <button
+        class="cancel-button"
+        mat-stroked-button
+        type="submit"
+        (click)="copyToken()">
+        Copy
+      </button>
+    </mat-card-actions>
+    <div *ngIf="token">
+      <mat-card-content class="token" *ngIf="token">
+        {{ token }}</mat-card-content
+      >
+    </div>
+  </mat-card>
+</html>

--- a/frontend/src/app/profile/profile-editor/profile-editor.component.ts
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.ts
@@ -21,7 +21,8 @@ export class ProfileEditorComponent implements OnInit {
   };
 
   public profile: Profile;
-  public token = new String();
+  public token: string;
+  public showToken: boolean = false;
 
   public profileForm = this.formBuilder.group({
     first_name: '',
@@ -50,6 +51,8 @@ export class ProfileEditorComponent implements OnInit {
 
     const data = route.snapshot.data as { profile: Profile };
     this.profile = data.profile;
+
+    this.token = `${localStorage.getItem('bearerToken')}`;
   }
 
   ngOnInit(): void {
@@ -64,11 +67,11 @@ export class ProfileEditorComponent implements OnInit {
   }
 
   displayToken(): void {
-    this.token = String(localStorage.getItem('bearerToken'));
+    this.showToken = !this.showToken;
   }
 
   copyToken(): void {
-    navigator.clipboard.writeText(String(localStorage.getItem('bearerToken')));
+    navigator.clipboard.writeText(this.token);
     this.snackBar.open('Token Copied', '', { duration: 2000 });
   }
 

--- a/frontend/src/app/profile/profile-editor/profile-editor.component.ts
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.ts
@@ -21,6 +21,7 @@ export class ProfileEditorComponent implements OnInit {
   };
 
   public profile: Profile;
+  public token = new String();
 
   public profileForm = this.formBuilder.group({
     first_name: '',
@@ -60,6 +61,15 @@ export class ProfileEditorComponent implements OnInit {
       email: profile.email,
       pronouns: profile.pronouns
     });
+  }
+
+  displayToken(): void {
+    this.token = String(localStorage.getItem('bearerToken'));
+  }
+
+  copyToken(): void {
+    navigator.clipboard.writeText(String(localStorage.getItem('bearerToken')));
+    this.snackBar.open('Token Copied', '', { duration: 2000 });
   }
 
   onSubmit(): void {


### PR DESCRIPTION
This PR gives students the ability to display/copy the bearer token of a user after signing in. It removes the tedious process of having to continuously access the browsers developer tools when wanting to test the backend. I decided to add the feature to the Profiles page, because when signing in that is the page users are led to. 

Potential Improvements:
1.  Getting rid of this weird margin between the buttons and the token itself.
![image](https://github.com/unc-csxl/csxl.unc.edu/assets/89494600/5ec2c8d9-db0f-4299-804e-8f276f0df000)
