### PR TITLE
User Admin tab should Navigate to Users Table

### DIFF
--- a/frontend/src/app/navigation/navigation.component.html
+++ b/frontend/src/app/navigation/navigation.component.html
@@ -34,7 +34,7 @@
           <a mat-list-item routerLink="/coworking/ambassador">XL Ambassador</a>
         </div>
         <div *ngIf="adminPermission$ | async">
-          <a mat-list-item routerLink="/admin">User Admin</a>
+          <a mat-list-item routerLink="/admin/users">User Admin</a>
         </div>
         <a
           mat-list-item


### PR DESCRIPTION
This PR makes it to where when a user with admin permissions clicks on User Admin, they will be directed to the Users table rather then the blank page!