### PR TITLE
Make ngserve System Specific

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -2,9 +2,9 @@
 #
 # Start/spawn all processes with `honcho start` at the command-line.
 # Stop children processes with Control+C to send the interrupt signal.
-# 
+#
 # For more information, see: https://honcho.readthedocs.io/en/latest/index.html#what-are-procfiles
 
 proxy: caddy run
 backend: uvicorn --port=1561 --reload backend.main:app
-frontend: cd frontend && ng serve --poll 2000
+frontend: cd frontend && if [[ "$OSTYPE" =~ ^msys ]]; then ng serve --poll 2000; else ng serve; fi


### PR DESCRIPTION
This PR modifies the `honcho` Procfile to run `--poll=2000` conditionally if the user's computer uses Windows OS and runs just `ng serve` elsewhere.

@jadekeegan  / @briannata  / @atoneyd, feel free to test on Windows! It is working on my Mac.