### PR TITLE
Implement Design for Operating Hours

### DIFF
--- a/frontend/src/app/coworking/coworking.module.ts
+++ b/frontend/src/app/coworking/coworking.module.ts
@@ -14,6 +14,7 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTableModule } from '@angular/material/table';
 import { ReservationComponent } from './reservation/reservation.component';
+import { OperatingHoursDialog } from './widgets/operating-hours-dialog/operating-hours-dialog.widget';
 
 @NgModule({
   declarations: [
@@ -22,7 +23,8 @@ import { ReservationComponent } from './reservation/reservation.component';
     AmbassadorPageComponent,
     CoworkingDropInCard,
     CoworkingReservationCard,
-    CoworkingHoursCard
+    CoworkingHoursCard,
+    OperatingHoursDialog
   ],
   imports: [
     CommonModule,

--- a/frontend/src/app/coworking/widgets/operating-hours-dialog/operating-hours-dialog.widget.css
+++ b/frontend/src/app/coworking/widgets/operating-hours-dialog/operating-hours-dialog.widget.css
@@ -1,0 +1,10 @@
+
+.dialog {
+    padding: 24px;
+}
+
+@media (prefers-color-scheme: dark) {
+    .dialog {
+        color: white;
+    }
+}

--- a/frontend/src/app/coworking/widgets/operating-hours-dialog/operating-hours-dialog.widget.html
+++ b/frontend/src/app/coworking/widgets/operating-hours-dialog/operating-hours-dialog.widget.html
@@ -1,0 +1,10 @@
+<div class="dialog">
+  <h3>Upcoming Hours</h3>
+  <ul>
+    <li *ngFor="let hours of operatingHours">
+      {{ hours.start | date: 'EEEE M/d' }}
+      from {{ hours.start | date: 'h:mma' | lowercase }} to
+      {{ hours.end | date: 'h:mma' | lowercase }}
+    </li>
+  </ul>
+</div>

--- a/frontend/src/app/coworking/widgets/operating-hours-dialog/operating-hours-dialog.widget.ts
+++ b/frontend/src/app/coworking/widgets/operating-hours-dialog/operating-hours-dialog.widget.ts
@@ -1,0 +1,19 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { OperatingHours } from 'src/app/coworking/coworking.models';
+
+@Component({
+  selector: 'operating-hours-dialog',
+  templateUrl: './operating-hours-dialog.widget.html',
+  styleUrls: ['./operating-hours-dialog.widget.css']
+})
+export class OperatingHoursDialog {
+  constructor(
+    public dialogRef: MatDialogRef<OperatingHoursDialog>,
+    @Inject(MAT_DIALOG_DATA) public operatingHours: OperatingHours[]
+  ) {}
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.css
+++ b/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.css
@@ -1,5 +1,5 @@
 .header {
-    padding: 0 16px;
+    padding: 16px;
 }
 
 .hours-title {
@@ -31,6 +31,20 @@
     background: #612d23;
 }
 
-.mat-expansion-panel {
+.mat-mdc-card {
     max-width: 640px;
+    margin: 0;
+}
+
+:host /deep/ .mat-mdc-card-header-text {
+    width: 100% !important;
+}
+.header-row {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+}
+
+#hours-button {
+    margin-left: auto;
 }

--- a/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.html
+++ b/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.html
@@ -1,28 +1,21 @@
-<mat-expansion-panel
-  [expanded]="openOperatingHours === undefined"
-  appearance="outlined">
-  <mat-expansion-panel-header class="header">
-    <mat-panel-title
+<mat-card appearance="outlined">
+  <mat-card-header class="header">
+    <mat-card-title
       class="hours-title open"
-      *ngIf="openOperatingHours; else closed"
-      ><span class="badge">Open</span>
-      until
-      {{ openOperatingHours!.end | date: 'h:mma' | lowercase }}</mat-panel-title
-    >
+      *ngIf="openOperatingHours; else closed">
+      <div class="header-row">
+        <span class="badge">Open</span>
+        until
+        {{ openOperatingHours!.end | date: 'h:mma' | lowercase }}
+        <button mat-stroked-button id="hours-button" (click)="openDialog()">
+          All Hours
+        </button>
+      </div>
+    </mat-card-title>
     <ng-template #closed>
-      <mat-panel-title class="hours-title closed"
-        ><span class="badge">Closed</span></mat-panel-title
+      <mat-card-title class="hours-title closed"
+        ><span class="badge">Closed</span></mat-card-title
       >
     </ng-template>
-  </mat-expansion-panel-header>
-  <div>
-    <h3>Upcoming Hours</h3>
-    <ul>
-      <li *ngFor="let hours of operatingHours">
-        {{ hours.start | date: 'EEEE M/d' }}
-        from {{ hours.start | date: 'h:mma' | lowercase }} to
-        {{ hours.end | date: 'h:mma' | lowercase }}
-      </li>
-    </ul>
-  </div>
-</mat-expansion-panel>
+  </mat-card-header>
+</mat-card>

--- a/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.ts
+++ b/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.ts
@@ -1,5 +1,7 @@
 import { Component, Input } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
 import { OperatingHours } from 'src/app/coworking/coworking.models';
+import { OperatingHoursDialog } from '../operating-hours-dialog/operating-hours-dialog.widget';
 
 @Component({
   selector: 'coworking-operating-hours-panel',
@@ -9,4 +11,12 @@ import { OperatingHours } from 'src/app/coworking/coworking.models';
 export class CoworkingHoursCard {
   @Input() operatingHours!: OperatingHours[];
   @Input() openOperatingHours?: OperatingHours;
+
+  constructor(public dialog: MatDialog) {}
+
+  openDialog(): void {
+    const dialogRef = this.dialog.open(OperatingHoursDialog, {
+      data: this.operatingHours
+    });
+  }
 }


### PR DESCRIPTION
This PR implements a new design for the operating hours expansion panel on the coworking page. The new design utilized the Material `outlined` style and fits better into the style of the site. The new design also uses a Material Dialog component to display operating hours.

### Future Improvements
* We may be able to add some text specifying to the user when the XL will reopen.
* Better logic for when the XL has no future operating hours.