### PR TITLE
Fix Querying Methods in Backend Service Logic

### DIFF
--- a/backend/services/event.py
+++ b/backend/services/event.py
@@ -113,20 +113,10 @@ class EventService:
         """
 
         # Query the organization with the matching slug
-        organization = (
-            self._session.query(OrganizationEntity)
-            .filter(OrganizationEntity.slug == slug)
-            .one_or_none()
-        )
-
-        # Ensure that the organization exists
-        if organization is None:
-            return []
-
-        # Query the event with matching organization slug
         events = (
             self._session.query(EventEntity)
-            .filter(EventEntity.organization_id == organization.id)
+            .join(OrganizationEntity)
+            .where(OrganizationEntity.slug == slug)
             .all()
         )
 


### PR DESCRIPTION
This small PR fixes an issue in the EventService where we use two queries to retrieve events for an organization by a slug. Instead, we have moved towards using the `.join()` syntax that is now standard, making the code more concise and efficient.