### PR TITLE
Use get_by Convention in Organizations and Events

### DIFF
--- a/backend/api/events.py
+++ b/backend/api/events.py
@@ -33,7 +33,7 @@ def get_events(event_service: EventService = Depends()) -> list[EventDetails]:
 
 
 @api.get("/organization/{slug}", response_model=list[EventDetails], tags=["Events"])
-def get_events_from_organization(
+def get_events_by_organization(
     slug: str, event_service: EventService = Depends()
 ) -> list[EventDetails]:
     """
@@ -46,7 +46,7 @@ def get_events_from_organization(
     Returns:
         list[EventDetails]: All `EventDetails`s in the `Event` database table from a specific organization
     """
-    return event_service.get_events_from_organization(slug)
+    return event_service.get_events_by_organization(slug)
 
 
 @api.post("", response_model=EventDetails, tags=["Events"])
@@ -75,7 +75,7 @@ def new_event(
     response_model=EventDetails,
     tags=["Events"],
 )
-def get_event_from_id(id: int, event_service: EventService = Depends()) -> EventDetails:
+def get_event_by_id(id: int, event_service: EventService = Depends()) -> EventDetails:
     """
     Get event with matching id
 
@@ -86,7 +86,7 @@ def get_event_from_id(id: int, event_service: EventService = Depends()) -> Event
     Returns:
         EventDetails: a valid EventDetails model corresponding to the given event id
     """
-    return event_service.get_from_id(id)
+    return event_service.get_by_id(id)
 
 
 @api.put(

--- a/backend/api/organizations.py
+++ b/backend/api/organizations.py
@@ -69,7 +69,7 @@ def new_organization(
     response_model=OrganizationDetails,
     tags=["Organizations"],
 )
-def get_organization_from_slug(
+def get_organization_by_slug(
     slug: str, organization_service: OrganizationService = Depends()
 ) -> OrganizationDetails:
     """
@@ -83,10 +83,10 @@ def get_organization_from_slug(
         Organization: Organization with matching slug
 
     Raises:
-        HTTPException 404 if get_from_slug() raises an Exception
+        HTTPException 404 if get_by_slug() raises an Exception
     """
 
-    return organization_service.get_from_slug(slug)
+    return organization_service.get_by_slug(slug)
 
 
 @api.put(

--- a/backend/services/event.py
+++ b/backend/services/event.py
@@ -79,7 +79,7 @@ class EventService:
         # Return added object
         return event_entity.to_details_model()
 
-    def get_from_id(self, id: int) -> EventDetails:
+    def get_by_id(self, id: int) -> EventDetails:
         """
         Get the event from an id
         If none retrieved, a debug description is displayed.
@@ -101,7 +101,7 @@ class EventService:
         # Convert entry to a model and return
         return entity.to_details_model()
 
-    def get_events_from_organization(self, slug: str) -> list[EventDetails]:
+    def get_events_by_organization(self, slug: str) -> list[EventDetails]:
         """
         Get all the events hosted by an organization with slug
 

--- a/backend/services/organization.py
+++ b/backend/services/organization.py
@@ -79,7 +79,7 @@ class OrganizationService:
         # Return added object
         return organization_entity.to_model()
 
-    def get_from_slug(self, slug: str) -> OrganizationDetails:
+    def get_by_slug(self, slug: str) -> OrganizationDetails:
         """
         Get the organization from a slug
         If none retrieved, a debug description is displayed.

--- a/backend/test/services/event/event_test.py
+++ b/backend/test/services/event/event_test.py
@@ -34,9 +34,9 @@ def test_get_all(event_svc_integration: EventService):
     assert isinstance(fetched_events[0], EventDetails)
 
 
-def test_get_from_id(event_svc_integration: EventService):
+def test_get_by_id(event_svc_integration: EventService):
     """Test that events can be retrieved based on their ID."""
-    fetched_event = event_svc_integration.get_from_id(1)
+    fetched_event = event_svc_integration.get_by_id(1)
     assert fetched_event is not None
     assert isinstance(fetched_event, Event)
     assert fetched_event.id == event_one.id
@@ -71,9 +71,9 @@ def test_create_event_as_user(event_svc_integration: EventService):
         pytest.fail()  # Fail test if no error was thrown above
 
 
-def test_get_events_from_organization(event_svc_integration: EventService):
+def test_get_events_by_organization(event_svc_integration: EventService):
     """Test that list of events can be retrieved based on specified organization."""
-    fetched_events = event_svc_integration.get_events_from_organization("cssg")
+    fetched_events = event_svc_integration.get_events_by_organization("cssg")
     assert fetched_events is not None
     assert len(fetched_events) == 2
 
@@ -85,7 +85,7 @@ def test_update_event_as_root(
     Note: Test data's website field is updated
     """
     event_svc_integration.update(root, updated_event)
-    assert event_svc_integration.get_from_id(1).location == "Fetzer Gym"
+    assert event_svc_integration.get_by_id(1).location == "Fetzer Gym"
 
 
 def test_update_event_as_user(event_svc_integration: EventService):
@@ -113,7 +113,7 @@ def test_delete_event_as_root(event_svc_integration: EventService):
     """Test that the root user is able to delete events."""
     event_svc_integration.delete(root, 1)
     with pytest.raises(ResourceNotFoundException):
-        event_svc_integration.get_from_id(1)
+        event_svc_integration.get_by_id(1)
 
 
 def test_delete_event_as_user(event_svc_integration: EventService):

--- a/backend/test/services/organization/organization_test.py
+++ b/backend/test/services/organization/organization_test.py
@@ -45,12 +45,12 @@ def test_get_all(organization_svc_integration: OrganizationService):
     assert isinstance(fetched_organizations[0], Organization)
 
 
-# Test `OrganizationService.get_from_id()`
+# Test `OrganizationService.get_by_id()`
 
 
-def test_get_from_slug(organization_svc_integration: OrganizationService):
+def test_get_by_slug(organization_svc_integration: OrganizationService):
     """Test that organizations can be retrieved based on their ID."""
-    fetched_organization = organization_svc_integration.get_from_slug(cads.slug)
+    fetched_organization = organization_svc_integration.get_by_slug(cads.slug)
     assert fetched_organization is not None
     assert isinstance(fetched_organization, Organization)
     assert fetched_organization.slug == cads.slug
@@ -97,7 +97,7 @@ def test_update_organization_as_root(
     """
     organization_svc_integration.update(root, new_cads)
     assert (
-        organization_svc_integration.get_from_slug("cads").website
+        organization_svc_integration.get_by_slug("cads").website
         == "https://cads.cs.unc.edu/"
     )
 
@@ -127,7 +127,7 @@ def test_delete_organization_as_root(organization_svc_integration: OrganizationS
     """Test that the root user is able to delete organizations."""
     organization_svc_integration.delete(root, cads.slug)
     with pytest.raises(ResourceNotFoundException):
-        organization_svc_integration.get_from_slug(cads.slug)
+        organization_svc_integration.get_by_slug(cads.slug)
 
 
 def test_delete_organization_as_user(organization_svc_integration: OrganizationService):


### PR DESCRIPTION
As noted in the https://github.com/unc-csxl/csxl.unc.edu/pull/196 PR, @KrisJordan recommended that we standardize around the convention of calling getter backend service methods that use parameters get_by_{arg} rather than get_from_{arg}.

This PR makes this change in the backend for organizations and events.