### PR TITLE
Minor changes for the academics feature

### DIFF
--- a/backend/entities/academics/section_entity.py
+++ b/backend/entities/academics/section_entity.py
@@ -54,6 +54,13 @@ class SectionEntity(EntityBase):
         back_populates="section"
     )
 
+    # Relationship subset of members queries for non-students
+    staff: Mapped[list["SectionMemberEntity"]] = relationship(
+        back_populates="section",
+        viewonly=True,
+        primaryjoin="and_(SectionEntity.id==SectionMemberEntity.section_id, SectionMemberEntity.member_role!='STUDENT')",
+    )
+
     @classmethod
     def from_model(cls, model: Section) -> Self:
         """
@@ -89,11 +96,7 @@ class SectionEntity(EntityBase):
             for room in self.rooms
             if room.assignment_type == RoomAssignmentType.OFFICE_HOURS
         ]
-        staff = [
-            members.to_flat_model()
-            for members in self.members
-            if members.member_role != RosterRole.STUDENT
-        ]
+        staff = [members.to_flat_model() for members in self.staff]
 
         return Section(
             id=self.id,

--- a/backend/entities/academics/section_entity.py
+++ b/backend/entities/academics/section_entity.py
@@ -96,7 +96,6 @@ class SectionEntity(EntityBase):
             for room in self.rooms
             if room.assignment_type == RoomAssignmentType.OFFICE_HOURS
         ]
-        staff = [members.to_flat_model() for members in self.staff]
 
         return Section(
             id=self.id,
@@ -106,7 +105,7 @@ class SectionEntity(EntityBase):
             meeting_pattern=self.meeting_pattern,
             lecture_room=(lecture_rooms[0] if len(lecture_rooms) > 0 else None),
             office_hour_rooms=office_hour_rooms,
-            staff=staff,
+            staff=[members.to_flat_model() for members in self.staff],
         )
 
     def to_details_model(self) -> SectionDetails:

--- a/backend/entities/academics/section_entity.py
+++ b/backend/entities/academics/section_entity.py
@@ -49,6 +49,18 @@ class SectionEntity(EntityBase):
     # NOTE: This defines a one-to-many relationship between the room and sections tables.
     rooms: Mapped[list["SectionRoomEntity"]] = relationship(back_populates="section")
 
+    lecture_rooms: Mapped[list["SectionRoomEntity"]] = relationship(
+        back_populates="section",
+        viewonly=True,
+        primaryjoin="and_(SectionEntity.id==SectionRoomEntity.section_id, SectionRoomEntity.assignment_type=='LECTURE_ROOM')",
+    )
+
+    office_hour_rooms: Mapped[list["SectionRoomEntity"]] = relationship(
+        back_populates="section",
+        viewonly=True,
+        primaryjoin="and_(SectionEntity.id==SectionRoomEntity.section_id, SectionRoomEntity.assignment_type=='OFFICE_HOURS')",
+    )
+
     # Members of the course
     members: Mapped[list["SectionMemberEntity"]] = relationship(
         back_populates="section"
@@ -86,16 +98,6 @@ class SectionEntity(EntityBase):
         Returns:
             Section: `Section` object from the entity
         """
-        lecture_rooms = [
-            room.room.to_model()
-            for room in self.rooms
-            if room.assignment_type == RoomAssignmentType.LECTURE_ROOM
-        ]
-        office_hour_rooms = [
-            room.room.to_model()
-            for room in self.rooms
-            if room.assignment_type == RoomAssignmentType.OFFICE_HOURS
-        ]
 
         return Section(
             id=self.id,
@@ -103,8 +105,12 @@ class SectionEntity(EntityBase):
             number=self.number,
             term_id=self.term_id,
             meeting_pattern=self.meeting_pattern,
-            lecture_room=(lecture_rooms[0] if len(lecture_rooms) > 0 else None),
-            office_hour_rooms=office_hour_rooms,
+            lecture_room=(
+                self.lecture_rooms[0].room.to_model()
+                if len(self.lecture_rooms) > 0
+                else None
+            ),
+            office_hour_rooms=[room.to_model() for room in self.office_hour_rooms],
             staff=[members.to_flat_model() for members in self.staff],
         )
 

--- a/backend/models/coworking/__init__.py
+++ b/backend/models/coworking/__init__.py
@@ -19,8 +19,6 @@ from .availability import SeatAvailability, RoomAvailability
 from .status import Status
 
 __all__ = [
-    "Room",
-    "RoomDetails",
     "Seat",
     "SeatDetails",
     "TimeRange",

--- a/backend/models/roster_role.py
+++ b/backend/models/roster_role.py
@@ -8,7 +8,7 @@ __license__ = "MIT"
 
 
 class RosterRole(Enum):
-    STUDENT = "Student"
-    UTA = "Undergraduate Teaching Assistant"
-    GTA = "Graduate Teaching Assistant"
-    INSTRUCTOR = "Instructor"
+    STUDENT = "STUDENT"
+    UTA = "UTA"
+    GTA = "GTA"
+    INSTRUCTOR = "INSTRUCTOR"

--- a/backend/models/roster_role.py
+++ b/backend/models/roster_role.py
@@ -8,7 +8,7 @@ __license__ = "MIT"
 
 
 class RosterRole(Enum):
-    STUDENT = "STUDENT"
-    UTA = "UTA"
-    GTA = "GTA"
-    INSTRUCTOR = "INSTRUCTOR"
+    STUDENT = 0
+    UTA = 1
+    GTA = 2
+    INSTRUCTOR = 3

--- a/backend/services/academics/term.py
+++ b/backend/services/academics/term.py
@@ -56,7 +56,7 @@ class TermService:
             TermDetails: Term based on the id.
         """
         # Select all entries in the `Term` table and sort by end date
-        query = select(TermEntity).filter(TermEntity.id == id)
+        query = select(TermEntity).filter(TermEntity.id == id).limit(1)
         entity = self._session.scalars(query).one_or_none()
 
         # Raise an error if no entity was found.


### PR DESCRIPTION
1. Added the view only `staff` relationship to `SectionEntity` which places a limit on the join.
2. Reverted my suggested enum changes because after looking in the actual database, SqlAlchemy appears to only store the enum name not the enum value.
3. Fixed some imports in coworkign models that prevented the repl script from loading
4. Slight modification to the current term query to limit the number of rows returned by the database to be 1 in SQL rather than in fetching after SQL executes