### PR TITLE
Temporarily Hide Instructor Column on Section View

### DIFF
--- a/frontend/src/app/academics/section-offerings/section-offerings.component.ts
+++ b/frontend/src/app/academics/section-offerings/section-offerings.component.ts
@@ -73,7 +73,7 @@ export class SectionOfferingsComponent implements OnInit {
   public displayedColumns: string[] = [
     'code',
     'title',
-    'instructor',
+    //'instructor',
     'meetingpattern',
     'room'
   ];


### PR DESCRIPTION
This small PR temporarily hides the 'Instructor' column on the Section Offerings view while the admin feature for staff is developed.