### PR TITLE
Ng serve polling fix

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - csxl.unc.edu-node_modules:/workspace/frontend/node_modules
     command: /bin/sh -c "while sleep 1000; do :; done"
     environment:
-      - OS # Defined on Windows but not on other platforms
+      - WINDIR # Defined on Windows but not on other platforms
   db:
     image: postgres:15.2
     restart: unless-stopped

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,12 +5,12 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
-      environment:
-        - OS # Defined on Windows but not on other platforms
     volumes:
       - ..:/workspace
       - csxl.unc.edu-node_modules:/workspace/frontend/node_modules
     command: /bin/sh -c "while sleep 1000; do :; done"
+    environment:
+      - OS # Defined on Windows but not on other platforms
   db:
     image: postgres:15.2
     restart: unless-stopped

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - csxl.unc.edu-node_modules:/workspace/frontend/node_modules
     command: /bin/sh -c "while sleep 1000; do :; done"
     environment:
-      - WINDIR # Defined on Windows but not on other platforms
+      - windir # Defined on Windows but not on other platforms
   db:
     image: postgres:15.2
     restart: unless-stopped

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
+      environment:
+        - OS # Defined on Windows but not on other platforms
     volumes:
       - ..:/workspace
       - csxl.unc.edu-node_modules:/workspace/frontend/node_modules

--- a/Procfile
+++ b/Procfile
@@ -2,9 +2,9 @@
 #
 # Start/spawn all processes with `honcho start` at the command-line.
 # Stop children processes with Control+C to send the interrupt signal.
-# 
+#
 # For more information, see: https://honcho.readthedocs.io/en/latest/index.html#what-are-procfiles
 
 proxy: caddy run
 backend: uvicorn --port=1561 --reload backend.main:app
-frontend: cd frontend && ng serve --poll 2000
+frontend: cd frontend && npm run start:dynamic

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "ng lint",
-    "start:dynamic": "ng serve ${OS:+--poll 2000}"
+    "start:dynamic": "ng serve ${WINDIR:+--poll 2000}"
   },
   "private": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
     "lint": "ng lint",
-    "start:dynamic": "ng serve ${WINDIR:+--poll 2000}"
+    "start:dynamic": "ng serve ${windir:+--poll 2000}"
   },
   "private": true,
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
-    "lint": "ng lint"
+    "lint": "ng lint",
+    "start:dynamic": "ng serve ${OS:+--poll 2000}"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
These changes implement a mechanism to differentiate between windows and non-windows systems from within the devcontainer. This is done through the use of the default `windir` (case sensitive) environment variable on windows, which is then forwarded to the devcontainer through the docker-compose file if it exists.

A new npm script is included called `start:dynamic` which will append the `--poll 2000` flag to `ng serve` iff the `windir` variable exists in the container, which will only occur on windows machines.

Closes #78 