### PR TITLE
Fix Menu Icon Alignment

### DIFF
--- a/frontend/src/app/navigation/navigation.component.css
+++ b/frontend/src/app/navigation/navigation.component.css
@@ -46,6 +46,7 @@
     width: 100%;
     display: flex;
     flex-direction: row;
+    align-items: center;
 }
 
 #gear-icon {


### PR DESCRIPTION
This small PR fixes the burger menu icon alignment by aligning it vertically.