### PR TITLE
[Room Reservations] Query DB instead to get list of reservable rooms

### DIFF
--- a/backend/services/coworking/policy.py
+++ b/backend/services/coworking/policy.py
@@ -51,6 +51,10 @@ class PolicyService:
 
     def reservation_draft_timeout(self) -> timedelta:
         return timedelta(minutes=5)
+    
 
     def reservation_checkin_timeout(self) -> timedelta:
         return timedelta(minutes=10)
+    
+    def non_reservable_rooms(self) -> list[str]:
+        return ['SN151']

--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -327,7 +327,7 @@ class ReservationService:
     
     def _get_reservable_rooms(self) -> Sequence[RoomDetails]:
         """
-        Retrieves a list of all reservable rooms, excluding the XL.
+        Retrieves a list of all reservable rooms.
         This method queries the RoomEntity table to find all rooms that are marked as reservable 
         (i.e., their 'reservable' attribute is True) and are not the room with ID 'SN156'. 
         The rooms are then ordered by their ID in ascending order. 
@@ -341,8 +341,7 @@ class ReservationService:
         rooms = (
             self._session.query(RoomEntity)
             .filter(
-                RoomEntity.id != 'SN156',
-                RoomEntity.reservable == True
+                RoomEntity.id.not_in(self._policy_svc.non_reservable_rooms())
             )
             .order_by(RoomEntity.id)
             .all()

--- a/backend/test/services/coworking/reservation/get_map_current_reservations_test.py
+++ b/backend/test/services/coworking/reservation/get_map_current_reservations_test.py
@@ -1,4 +1,4 @@
-"""ReservationService#get_map_reservations_for_date tests."""
+"""Tests for ReservationService#get_map_reservations_for_date and helper functions."""
 
 from unittest.mock import create_autospec
 
@@ -62,6 +62,13 @@ def test_idx_calculation(reservation_svc: ReservationService):
     time_3 = datetime.now().replace(hour=13, minute=40)
     assert reservation_svc._idx_calculation(time_3) == 7
 
+
+def test_get_reservable_rooms(reservation_svc: ReservationService):
+    rooms = reservation_svc._get_reservable_rooms()
+    assert rooms[0].id == 'SN135' and rooms[0].reservable is True
+    assert rooms[1].id == 'SN137' and rooms[1].reservable is True
+    assert rooms[2].id == 'SN139' and rooms[2].reservable is True
+    assert rooms[3].id == 'SN141' and rooms[3].reservable is True
 
 def test_get_map_reserved_times_by_date(
     reservation_svc: ReservationService, time: dict[str, datetime]


### PR DESCRIPTION
## An aside:

This is not a PR to `main` but rather a PR to `room-reservations`. The way Jade and I had decided to move forward with merging strategies for our feature was to send PR into the room reservation branch. Once we have made the necessary changes required to launch the beta version for our feature, we will merge `room-reservations` into main, which will be a giant merge. Was just wondering if you were okay with this strategy @KrisJordan?

## Back to the PR:

Previously, we were just iterating over a hardcoded list to get all the rooms available. This change ensures that we instead query the rooms database to get all the reservable rooms. There is also a test for this method.

However, one thing I did notice is that this query only returned 4 reservable rooms. I am sure that there are more than 4 reservable rooms, so I was wondering how I should go about adding them into the database if anyone was aware? @KrisJordan @ajaygandecha @jadekeegan.