### PR TITLE
Community Agreement Bug Fix

### DIFF
--- a/frontend/src/app/shared/community-agreement/community-agreement.widget.css
+++ b/frontend/src/app/shared/community-agreement/community-agreement.widget.css
@@ -3,18 +3,18 @@
   max-height: 90vh; 
   overflow: auto; 
   scroll-behavior: auto; 
+  padding-bottom: env(safe-area-inset-bottom);
 }
+
 ::-webkit-scrollbar {
   width: 5px;
 }
 
-/* Handle */
 ::-webkit-scrollbar-thumb {
   background: #888;
   border-radius: 10px;
 }
 
-/* Handle on hover */
 ::-webkit-scrollbar-thumb:hover {
   background: #555;
 }

--- a/frontend/src/app/shared/community-agreement/community-agreement.widget.html
+++ b/frontend/src/app/shared/community-agreement/community-agreement.widget.html
@@ -275,6 +275,7 @@
         color: white;
         margin-left: 8px;
         margin-top: 12px;
+        margin-bottom: 30px;
       "
       (click)="onButtonClick()">
       {{ has_user_agreed ? 'Close' : 'Accept' }}


### PR DESCRIPTION
- Few users are currently experiencing UI bug where their browser's interface (particularly some Safari layouts) is blocking the accept button on the community agreement pop up
- Added spacing on bottom of button that should allow user to scroll a little bit more
- In case, also added:  padding-bottom: env(safe-area-inset-bottom);
    - This should ensure that the browsers interface or device's physical features should not block anything on the pop up
