### PR TITLE
Fix fields in OH entities to match models

### DIFF
--- a/backend/entities/office_hours/oh_event_entity.py
+++ b/backend/entities/office_hours/oh_event_entity.py
@@ -8,7 +8,6 @@ from backend.models.office_hours.oh_type import OfficeHoursType
 
 
 from ..entity_base import EntityBase
-from typing import Self
 from sqlalchemy import Enum as SQLAlchemyEnum
 
 __authors__ = ["Madelyn Andrews", "Sadie Amato", "Bailey DeSouza", "Meghan Sun"]
@@ -28,12 +27,12 @@ class OfficeHoursEventEntity(EntityBase):
     type: Mapped[OfficeHoursType] = mapped_column(
         SQLAlchemyEnum(OfficeHoursType), nullable=False
     )
-    # Name of event
-    title: Mapped[str] = mapped_column(String, nullable=False)
     # Description of event
-    description: Mapped[str] = mapped_column(String, nullable=True)
+    description: Mapped[str] = mapped_column(String, default="", nullable=False)
     # Description of the location; allows for instructors to write note about attending office hours
-    location_description: Mapped[str] = mapped_column(String, nullable=True)
+    location_description: Mapped[str] = mapped_column(
+        String, default="", nullable=False
+    )
     # Date of the event
     event_date: Mapped[date] = mapped_column(Date, nullable=False)  # type: ignore
     # Time the event starts
@@ -50,8 +49,8 @@ class OfficeHoursEventEntity(EntityBase):
     )
 
     # NOTE: Unidirectional relationship to Room
-    location_id: Mapped[int] = mapped_column(ForeignKey("room.id"), nullable=False)
-    location: Mapped["RoomEntity"] = relationship("RoomEntity")
+    room_id: Mapped[int] = mapped_column(ForeignKey("room.id"), nullable=False)
+    room: Mapped["RoomEntity"] = relationship("RoomEntity")
 
     # NOTE: One-to-many relationship of OfficeHoursEvent to tickets
     tickets: Mapped[list["OfficeHoursTicketEntity"]] = relationship(

--- a/backend/entities/office_hours/oh_ticket_entity.py
+++ b/backend/entities/office_hours/oh_ticket_entity.py
@@ -40,11 +40,13 @@ class OfficeHoursTicketEntity(EntityBase):
         DateTime, default=datetime.now, nullable=False
     )
     # Time ticket was closed by a TA; nullable if ticket gets canceled
-    closed_at: Mapped[datetime] = mapped_column(DateTime, nullable=True)
+    closed_at: Mapped[datetime] = mapped_column(
+        DateTime, default=datetime.now, onupdate=datetime.now, nullable=False
+    )
     # Flag for if UTA has concerns about student
-    have_concerns: Mapped[bool] = mapped_column(Boolean, nullable=True)
+    have_concerns: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     # Notes from TA
-    caller_notes: Mapped[str] = mapped_column(String, nullable=True)
+    caller_notes: Mapped[str] = mapped_column(String, default="", nullable=False)
 
     # One-to-one relationship to event that the ticket was created in
     event_id: Mapped[int] = mapped_column(
@@ -58,7 +60,7 @@ class OfficeHoursTicketEntity(EntityBase):
     )
 
     # One-to-one relationship of OfficeHoursTicket to UTA that has called it; optional field
-    caller_id: Mapped[int] = mapped_column(
+    caller_id: Mapped[int | None] = mapped_column(
         ForeignKey("academics__user_section.id"), nullable=True
     )
     caller: Mapped["SectionMemberEntity"] = relationship(


### PR DESCRIPTION
This PR makes changes to our entities that reflect the modifications requested of our Pydantic models.

- Several string fields are now non-nullable, with a default of empty string, if they are optional fields
- `location_id` is changed to `room_id`
- Defaults given for fields with DateTime types