### PR TITLE
Added api routes for events + services, Added skeleton service code

### DIFF
--- a/backend/api/office_hours/oh_event.py
+++ b/backend/api/office_hours/oh_event.py
@@ -4,6 +4,8 @@ This API is used to access OH Event data."""
 
 from datetime import datetime, timedelta
 from fastapi import APIRouter, Depends
+
+from ...models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
 from ...models.coworking.time_range import TimeRange
 from ...models.office_hours.oh_event import OfficeHoursEvent, OfficeHoursEventDraft
 from ...models.office_hours.oh_event_details import OfficeHoursEventDetails
@@ -40,7 +42,9 @@ def new_oh_event(
     return oh_event_service.create(subject, oh_event)
 
 
-@api.put("/{oh_event_id}", response_model=OfficeHoursEventDetails, tags=["Office Hours"])
+@api.put(
+    "/{oh_event_id}", response_model=OfficeHoursEventDetails, tags=["Office Hours"]
+)
 def update_oh_event(
     oh_event: OfficeHoursEvent,
     subject: User = Depends(registered_user),
@@ -67,9 +71,14 @@ def delete_oh_event(
     oh_event: OfficeHoursEventDetails = oh_event_service.get_event_by_id(oh_event_id)
     return oh_event_service.delete(subject, oh_event)
 
-@api.get("/{oh_event_id}", response_model=OfficeHoursEventDetails, tags=["Office Hours"])
-def get_oh_section_by_id(
-    oh_event_id: int, subject: User = Depends(registered_user), oh_event_service: OfficeHoursEventService = Depends()
+
+@api.get(
+    "/{oh_event_id}", response_model=OfficeHoursEventDetails, tags=["Office Hours"]
+)
+def get_oh_event_by_id(
+    oh_event_id: int,
+    subject: User = Depends(registered_user),
+    oh_event_service: OfficeHoursEventService = Depends(),
 ) -> OfficeHoursEventDetails:
     """
     Gets an OH event by OH event ID
@@ -80,7 +89,9 @@ def get_oh_section_by_id(
     return oh_event_service.get_event_by_id(subject, oh_event_id)
 
 
-@api.get("/upcoming", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
+@api.get(
+    "/upcoming", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"]
+)
 def get_upcoming_oh_events_by_user(
     start: datetime = datetime.now(),
     subject: User = Depends(registered_user),
@@ -95,3 +106,23 @@ def get_upcoming_oh_events_by_user(
     """
     time_range = TimeRange(start=start, end=end)
     return oh_event_service.get_upcoming_events_by_user(subject, time_range)
+
+
+@api.get(
+    "/{oh_event_id}/tickets",
+    response_model=list[OfficeHoursTicketDetails],
+    tags=["Office Hours"],
+)
+def get_oh_tickets_by_event(
+    oh_event_id: int,
+    subject: User = Depends(registered_user),
+    oh_event_service: OfficeHoursEventService = Depends(),
+) -> list[OfficeHoursTicketDetails]:
+    """
+    Gets list of OH tickets by OH event
+
+    Returns:
+        list[OfficeHoursTicketDetails]: OH tickets within the given event
+    """
+    oh_event: OfficeHoursEventDetails = oh_event_service.get_event_by_id(oh_event_id)
+    return oh_event_service.get_event_tickets(subject, oh_event)

--- a/backend/api/office_hours/oh_event.py
+++ b/backend/api/office_hours/oh_event.py
@@ -5,7 +5,7 @@ This API is used to access OH Event data."""
 from datetime import datetime, timedelta
 from fastapi import APIRouter, Depends
 from backend.models.coworking.time_range import TimeRange
-from backend.models.office_hours.oh_event import OfficeHoursEventDraft
+from backend.models.office_hours.oh_event import OfficeHoursEvent, OfficeHoursEventDraft
 from backend.models.office_hours.oh_event_details import OfficeHoursEventDetails
 from backend.services.office_hours.oh_event import OfficeHoursEventService
 
@@ -40,9 +40,10 @@ def new_oh_event(
     return oh_event_service.create(subject, oh_event)
 
 
-@api.put("", response_model=OfficeHoursEventDetails, tags=["Office Hours"])
+@api.put("/{oh_event_id}", response_model=OfficeHoursEventDetails, tags=["Office Hours"])
 def update_oh_event(
-    oh_event: OfficeHoursEventDraft,
+    oh_event_id: int,
+    oh_event: OfficeHoursEvent,
     subject: User = Depends(registered_user),
     oh_event_service: OfficeHoursEventService = Depends(),
 ) -> OfficeHoursEventDetails:
@@ -52,7 +53,7 @@ def update_oh_event(
     Returns:
         OfficeHoursEventDetails: OH Event updated
     """
-    return oh_event_service.update(subject, oh_event)
+    return oh_event_service.update(subject, oh_event_id, oh_event)
 
 
 @api.delete("/{oh_event_id}", response_model=None, tags=["Office Hours"])
@@ -64,7 +65,8 @@ def delete_oh_event(
     """
     Deletes an OfficeHoursEvent from the database
     """
-    return oh_event_service.delete(subject, oh_event_id)
+    oh_event: OfficeHoursEventDetails = oh_event_service.get_event_by_id(oh_event_id)
+    return oh_event_service.delete(subject, oh_event)
 
 @api.get("/{oh_event_id}", response_model=OfficeHoursEventDetails, tags=["Office Hours"])
 def get_oh_section_by_id(
@@ -79,7 +81,7 @@ def get_oh_section_by_id(
     return oh_event_service.get_event_by_id(subject, oh_event_id)
 
 
-@api.get("/{section_id}", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
+@api.get("/section/{section_id}", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
 def get_oh_events_by_section(
     oh_section_id: int,
     subject: User = Depends(registered_user),
@@ -94,7 +96,7 @@ def get_oh_events_by_section(
     return oh_event_service.get_events_by_section(subject, oh_section_id)
 
 
-@api.get("/{section_id}/upcoming", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
+@api.get("/section/{section_id}/upcoming", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
 def get_upcoming_oh_events_by_section(
     oh_section_id: int,
     subject: User = Depends(registered_user),

--- a/backend/api/office_hours/oh_event.py
+++ b/backend/api/office_hours/oh_event.py
@@ -1,0 +1,118 @@
+"""OH Event API
+
+This API is used to access OH Event data."""
+
+from datetime import datetime, timedelta
+from fastapi import APIRouter, Depends
+from backend.models.coworking.time_range import TimeRange
+from backend.models.office_hours.oh_event import OfficeHoursEventDraft
+from backend.models.office_hours.oh_event_details import OfficeHoursEventDetails
+
+from ..authentication import registered_user
+from ...models import User
+
+
+__authors__ = ["Sadie Amato", "Bailey DeSouza"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+
+api = APIRouter(prefix="/api/office-hours")
+openapi_tags = {
+    "name": "Office Hours",
+    "description": "Office hours event, event, and ticket functionality",
+}
+
+
+@api.post("/event", response_model=OfficeHoursEventDetails, tags=["Office Hours"])
+def new_oh_event(
+    oh_event: OfficeHoursEventDraft,
+    subject: User = Depends(registered_user),
+    oh_event_service: OfficeHoursEventService = Depends(),
+) -> OfficeHoursEventDetails:
+    """
+    Adds a new OH event to the database
+
+    Returns:
+        OfficeHoursEventDetails: OH Event created
+    """
+    return oh_event_service.create(subject, oh_event)
+
+
+@api.put("", response_model=OfficeHoursEventDetails, tags=["Academics"])
+def update_oh_event(
+    oh_event: OfficeHoursEventDraft,
+    subject: User = Depends(registered_user),
+    oh_event_service: OfficeHoursEventService = Depends(),
+) -> OfficeHoursEventDetails:
+    """
+    Updates an OfficeHoursEvent to the database
+
+    Returns:
+        OfficeHoursEventDetails: OH Event updated
+    """
+    return oh_event_service.update(subject, oh_event)
+
+
+@api.delete("/{oh_event_id}", response_model=None, tags=["Office Hours"])
+def delete_oh_event(
+    oh_event_id: int,
+    subject: User = Depends(registered_user),
+    oh_event_service: OfficeHoursEventService = Depends(),
+):
+    """
+    Deletes an OfficeHoursEvent from the database
+    """
+    return oh_event_service.delete(subject, oh_event_id)
+
+
+@api.get("", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
+def get_oh_events_by_section(
+    oh_section_id: int,
+    subject: User = Depends(registered_user),
+    oh_event_service: OfficeHoursEventService = Depends(),
+) -> list[OfficeHoursEventDetails]:
+    """
+    Gets list of OH events by section ID
+
+    Returns:
+        list[OfficeHoursSectionDetails]: OH events associated with a given section
+    """
+    return oh_event_service.get_events_by_section(subject, oh_section_id)
+
+
+@api.get("", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
+def get_upcoming_oh_events_by_section(
+    oh_section_id: int,
+    subject: User = Depends(registered_user),
+    start: datetime = datetime.now(),
+    end: datetime = datetime.now() + timedelta(weeks=1),
+    oh_event_service: OfficeHoursEventService = Depends(),
+) -> list[OfficeHoursEventDetails]:
+    """
+    Gets list of upcoming OH events within a time range by section ID
+
+    Returns:
+        list[OfficeHoursSectionDetails]: OH events associated with a given section in a time range
+    """
+    time_range = TimeRange(start=start, end=end)
+    return oh_event_service.get_upcoming_events_by_section(
+        subject, oh_section_id, time_range
+    )
+
+
+@api.get("", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
+def get_upcoming_oh_events_by_user(
+    start: datetime = datetime.now(),
+    subject: User = Depends(registered_user),
+    end: datetime = datetime.now() + timedelta(weeks=1),
+    oh_event_service: OfficeHoursEventService = Depends(),
+) -> list[OfficeHoursEventDetails]:
+    """
+    Gets list of upcoming OH events within a time range by user
+
+    Returns:
+        list[OfficeHoursSectionDetails]: OH events associated with a given user in a time range
+    """
+    time_range = TimeRange(start=start, end=end)
+    return oh_event_service.get_upcoming_events_by_user(subject, time_range)

--- a/backend/api/office_hours/oh_event.py
+++ b/backend/api/office_hours/oh_event.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from backend.models.coworking.time_range import TimeRange
 from backend.models.office_hours.oh_event import OfficeHoursEventDraft
 from backend.models.office_hours.oh_event_details import OfficeHoursEventDetails
+from backend.services.office_hours.oh_event import OfficeHoursEventService
 
 from ..authentication import registered_user
 from ...models import User
@@ -39,7 +40,7 @@ def new_oh_event(
     return oh_event_service.create(subject, oh_event)
 
 
-@api.put("", response_model=OfficeHoursEventDetails, tags=["Academics"])
+@api.put("", response_model=OfficeHoursEventDetails, tags=["Office Hours"])
 def update_oh_event(
     oh_event: OfficeHoursEventDraft,
     subject: User = Depends(registered_user),
@@ -64,6 +65,18 @@ def delete_oh_event(
     Deletes an OfficeHoursEvent from the database
     """
     return oh_event_service.delete(subject, oh_event_id)
+
+@api.get("/{oh_event_id}", response_model=OfficeHoursEventDetails, tags=["Office Hours"])
+def get_oh_section_by_id(
+    oh_event_id: int, subject: User = Depends(registered_user), oh_event_service: OfficeHoursEventService = Depends()
+) -> OfficeHoursEventDetails:
+    """
+    Gets an OH event by OH event ID
+
+    Returns:
+        OfficeHoursEventDetails: The OH event with the given OH event id
+    """
+    return oh_event_service.get_event_by_id(subject, oh_event_id)
 
 
 @api.get("/{section_id}", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])

--- a/backend/api/office_hours/oh_event.py
+++ b/backend/api/office_hours/oh_event.py
@@ -17,14 +17,14 @@ __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
 
-api = APIRouter(prefix="/api/office-hours")
+api = APIRouter(prefix="/api/office-hours/event")
 openapi_tags = {
     "name": "Office Hours",
-    "description": "Office hours event, event, and ticket functionality",
+    "description": "Office hours event functionality",
 }
 
 
-@api.post("/event", response_model=OfficeHoursEventDetails, tags=["Office Hours"])
+@api.post("", response_model=OfficeHoursEventDetails, tags=["Office Hours"])
 def new_oh_event(
     oh_event: OfficeHoursEventDraft,
     subject: User = Depends(registered_user),
@@ -66,7 +66,7 @@ def delete_oh_event(
     return oh_event_service.delete(subject, oh_event_id)
 
 
-@api.get("", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
+@api.get("/{section_id}", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
 def get_oh_events_by_section(
     oh_section_id: int,
     subject: User = Depends(registered_user),
@@ -81,7 +81,7 @@ def get_oh_events_by_section(
     return oh_event_service.get_events_by_section(subject, oh_section_id)
 
 
-@api.get("", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
+@api.get("/{section_id}/upcoming", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
 def get_upcoming_oh_events_by_section(
     oh_section_id: int,
     subject: User = Depends(registered_user),
@@ -101,7 +101,7 @@ def get_upcoming_oh_events_by_section(
     )
 
 
-@api.get("", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
+@api.get("/upcoming", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
 def get_upcoming_oh_events_by_user(
     start: datetime = datetime.now(),
     subject: User = Depends(registered_user),

--- a/backend/api/office_hours/oh_event.py
+++ b/backend/api/office_hours/oh_event.py
@@ -42,7 +42,6 @@ def new_oh_event(
 
 @api.put("/{oh_event_id}", response_model=OfficeHoursEventDetails, tags=["Office Hours"])
 def update_oh_event(
-    oh_event_id: int,
     oh_event: OfficeHoursEvent,
     subject: User = Depends(registered_user),
     oh_event_service: OfficeHoursEventService = Depends(),
@@ -53,7 +52,7 @@ def update_oh_event(
     Returns:
         OfficeHoursEventDetails: OH Event updated
     """
-    return oh_event_service.update(subject, oh_event_id, oh_event)
+    return oh_event_service.update(subject, oh_event)
 
 
 @api.delete("/{oh_event_id}", response_model=None, tags=["Office Hours"])
@@ -79,26 +78,6 @@ def get_oh_section_by_id(
         OfficeHoursEventDetails: The OH event with the given OH event id
     """
     return oh_event_service.get_event_by_id(subject, oh_event_id)
-
-
-@api.get("/section/{section_id}/upcoming", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
-def get_upcoming_oh_events_by_section(
-    oh_section_id: int,
-    subject: User = Depends(registered_user),
-    start: datetime = datetime.now(),
-    end: datetime = datetime.now() + timedelta(weeks=1),
-    oh_event_service: OfficeHoursEventService = Depends(),
-) -> list[OfficeHoursEventDetails]:
-    """
-    Gets list of upcoming OH events within a time range by section ID
-
-    Returns:
-        list[OfficeHoursSectionDetails]: OH events associated with a given section in a time range
-    """
-    time_range = TimeRange(start=start, end=end)
-    return oh_event_service.get_upcoming_events_by_section(
-        subject, oh_section_id, time_range
-    )
 
 
 @api.get("/upcoming", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])

--- a/backend/api/office_hours/oh_event.py
+++ b/backend/api/office_hours/oh_event.py
@@ -4,16 +4,16 @@ This API is used to access OH Event data."""
 
 from datetime import datetime, timedelta
 from fastapi import APIRouter, Depends
-from backend.models.coworking.time_range import TimeRange
-from backend.models.office_hours.oh_event import OfficeHoursEvent, OfficeHoursEventDraft
-from backend.models.office_hours.oh_event_details import OfficeHoursEventDetails
-from backend.services.office_hours.oh_event import OfficeHoursEventService
+from ...models.coworking.time_range import TimeRange
+from ...models.office_hours.oh_event import OfficeHoursEvent, OfficeHoursEventDraft
+from ...models.office_hours.oh_event_details import OfficeHoursEventDetails
+from ...services.office_hours.oh_event import OfficeHoursEventService
 
 from ..authentication import registered_user
 from ...models import User
 
 
-__authors__ = ["Sadie Amato", "Bailey DeSouza"]
+__authors__ = ["Sadie Amato", "Madelyn Andrews", "Bailey DeSouza", "Meghan Sun"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
@@ -79,21 +79,6 @@ def get_oh_section_by_id(
         OfficeHoursEventDetails: The OH event with the given OH event id
     """
     return oh_event_service.get_event_by_id(subject, oh_event_id)
-
-
-@api.get("/section/{section_id}", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])
-def get_oh_events_by_section(
-    oh_section_id: int,
-    subject: User = Depends(registered_user),
-    oh_event_service: OfficeHoursEventService = Depends(),
-) -> list[OfficeHoursEventDetails]:
-    """
-    Gets list of OH events by section ID
-
-    Returns:
-        list[OfficeHoursSectionDetails]: OH events associated with a given section
-    """
-    return oh_event_service.get_events_by_section(subject, oh_section_id)
 
 
 @api.get("/section/{section_id}/upcoming", response_model=list[OfficeHoursEventDetails], tags=["Office Hours"])

--- a/backend/api/office_hours/oh_section.py
+++ b/backend/api/office_hours/oh_section.py
@@ -2,6 +2,7 @@
 
 This API is used to access OH section data."""
 
+import datetime
 from fastapi import APIRouter, Depends
 
 from ...models.office_hours.oh_event_details import OfficeHoursEventDetails
@@ -66,6 +67,21 @@ def get_section_events(
     return oh_section_service.get_events_by_section(subject, oh_section)
 
 
+@api.get("/{oh_section_id}/events/upcoming", response_model=list[OfficeHoursEventDetails], tag=["Office Hours"])
+def get_section_upcoming_events(
+    oh_section_id: int, subject: User = Depends(registered_user), oh_section_service: OfficeHoursSectionService = Depends(),
+    start: datetime = datetime.now(), end: datetime = datetime.now() + datetime.timedelta(weeks=1)
+) -> list[OfficeHoursEventDetails]:
+    """
+    Gets a list of upcoming OH events within a time range.
+
+    Returns:
+        list[OfficeHoursEventDetails]: OH events associated with a given user in a time range
+    """
+    oh_section: OfficeHoursSectionDetails = oh_section_service.get_section_by_id(oh_section_id)
+    return oh_section_service.get_events_by_section(subject, oh_section)
+
+
 @api.get("/term/{term_id}", response_model=list[OfficeHoursSectionDetails], tags=["Office Hours"])
 def get_oh_sections_by_term_id(
     term_id: str, subject: User = Depends(registered_user), oh_section_service: OfficeHoursSectionService = Depends()
@@ -96,7 +112,6 @@ def get_oh_sections_by_user_and_term(
 
 @api.put("/{oh_section_id}", response_model=OfficeHoursSectionDetails, tags=["Office Hours"])
 def update_oh_section(
-    oh_section_id: int,
     oh_section: OfficeHoursSection,
     subject: User = Depends(registered_user),
     oh_section_service: OfficeHoursSectionService = Depends(),
@@ -107,7 +122,7 @@ def update_oh_section(
     Returns:
         OfficeHoursSectionDetails: OH Section updated
     """
-    return oh_section_service.update(subject, oh_section_id, oh_section)
+    return oh_section_service.update(subject, oh_section)
 
 
 @api.delete("/{oh_section_id}", response_model=None, tags=["Office Hours"])

--- a/backend/api/office_hours/oh_section.py
+++ b/backend/api/office_hours/oh_section.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends
 
 from backend.models.office_hours.oh_section import OfficeHoursSectionDraft
 from backend.models.office_hours.oh_section_details import OfficeHoursSectionDetails
+from backend.services.office_hours.oh_section import OfficeHoursSectionService
 from ..authentication import registered_user
 from ...models import User
 
@@ -37,7 +38,20 @@ def new_oh_section(
     return oh_section_service.create(subject, oh_section)
 
 
-@api.get("/{term_id}", response_model=list[OfficeHoursSectionDetails], tags=["Office Hours"])
+@api.get("/{oh_section_id}", response_model=OfficeHoursSectionDetails, tags=["Office Hours"])
+def get_oh_section_by_id(
+    oh_section_id: int, subject: User = Depends(registered_user), oh_section_service: OfficeHoursSectionService = Depends()
+) -> OfficeHoursSectionDetails:
+    """
+    Gets an OH section by OH section ID
+
+    Returns:
+        OfficeHoursSectionDetails: The OH section with the given OH section id
+    """
+    return oh_section_service.get_section_by_id(subject, oh_section_id)
+
+
+@api.get("/term/{term_id}", response_model=list[OfficeHoursSectionDetails], tags=["Office Hours"])
 def get_oh_sections_by_term_id(
     term_id: str, subject: User = Depends(registered_user), oh_section_service: OfficeHoursSectionService = Depends()
 ) -> list[OfficeHoursSectionDetails]:
@@ -50,7 +64,7 @@ def get_oh_sections_by_term_id(
     return oh_section_service.get_sections_by_term(subject, term_id)
 
 
-@api.get("", response_model=list[OfficeHoursSectionDetails], tags=["Office Hours"])
+@api.get("/user/term/{term_id}", response_model=list[OfficeHoursSectionDetails], tags=["Office Hours"])
 def get_oh_sections_by_user_and_term(
     term_id: str,
     subject: User = Depends(registered_user),
@@ -65,7 +79,7 @@ def get_oh_sections_by_user_and_term(
     return oh_section_service.get_user_sections_by_term(subject, term_id)
 
 
-@api.put("", response_model=OfficeHoursSectionDetails, tags=["Academics"])
+@api.put("", response_model=OfficeHoursSectionDetails, tags=["Office Hours"])
 def update_oh_section(
     oh_section: OfficeHoursSectionDraft,
     subject: User = Depends(registered_user),

--- a/backend/api/office_hours/oh_section.py
+++ b/backend/api/office_hours/oh_section.py
@@ -18,7 +18,7 @@ __license__ = "MIT"
 api = APIRouter(prefix="/api/office-hours/section")
 openapi_tags = {
     "name": "Office Hours",
-    "description": "Office hours section, event, and ticket functionality",
+    "description": "Office hours section functionality",
 }
 
 

--- a/backend/api/office_hours/oh_section.py
+++ b/backend/api/office_hours/oh_section.py
@@ -4,7 +4,7 @@ This API is used to access OH section data."""
 
 from fastapi import APIRouter, Depends
 
-from backend.models.office_hours.oh_section import OfficeHoursSectionDraft
+from backend.models.office_hours.oh_section import OfficeHoursSection, OfficeHoursSectionDraft
 from backend.models.office_hours.oh_section_details import OfficeHoursSectionDetails
 from backend.services.office_hours.oh_section import OfficeHoursSectionService
 from ..authentication import registered_user
@@ -79,9 +79,10 @@ def get_oh_sections_by_user_and_term(
     return oh_section_service.get_user_sections_by_term(subject, term_id)
 
 
-@api.put("", response_model=OfficeHoursSectionDetails, tags=["Office Hours"])
+@api.put("/{oh_section_id}", response_model=OfficeHoursSectionDetails, tags=["Office Hours"])
 def update_oh_section(
-    oh_section: OfficeHoursSectionDraft,
+    oh_section_id: int,
+    oh_section: OfficeHoursSection,
     subject: User = Depends(registered_user),
     oh_section_service: OfficeHoursSectionService = Depends(),
 ) -> OfficeHoursSectionDetails:
@@ -91,7 +92,7 @@ def update_oh_section(
     Returns:
         OfficeHoursSectionDetails: OH Section updated
     """
-    return oh_section_service.update(subject, oh_section)
+    return oh_section_service.update(subject, oh_section_id, oh_section)
 
 
 @api.delete("/{oh_section_id}", response_model=None, tags=["Office Hours"])
@@ -103,4 +104,5 @@ def delete_oh_section(
     """
     Deletes an OfficeHoursSection from the database
     """
-    return oh_section_service.delete(subject, oh_section_id)
+    oh_section: OfficeHoursSectionDetails = oh_section_service.get_section_by_id(oh_section_id)
+    return oh_section_service.delete(subject, oh_section)

--- a/backend/api/office_hours/oh_section.py
+++ b/backend/api/office_hours/oh_section.py
@@ -2,11 +2,15 @@
 
 This API is used to access OH section data."""
 
-import datetime
+from datetime import datetime
 from fastapi import APIRouter, Depends
-
+from ...models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
+from ...services.office_hours.oh_ticket import OfficeHoursTicketService
 from ...models.office_hours.oh_event_details import OfficeHoursEventDetails
-from ...models.office_hours.oh_section import OfficeHoursSection, OfficeHoursSectionDraft
+from ...models.office_hours.oh_section import (
+    OfficeHoursSection,
+    OfficeHoursSectionDraft,
+)
 from ...models.office_hours.oh_section_details import OfficeHoursSectionDetails
 from ...services.office_hours.oh_section import OfficeHoursSectionService
 from ..authentication import registered_user
@@ -40,9 +44,13 @@ def new_oh_section(
     return oh_section_service.create(subject, oh_section)
 
 
-@api.get("/{oh_section_id}", response_model=OfficeHoursSectionDetails, tags=["Office Hours"])
+@api.get(
+    "/{oh_section_id}", response_model=OfficeHoursSectionDetails, tags=["Office Hours"]
+)
 def get_oh_section_by_id(
-    oh_section_id: int, subject: User = Depends(registered_user), oh_section_service: OfficeHoursSectionService = Depends()
+    oh_section_id: int,
+    subject: User = Depends(registered_user),
+    oh_section_service: OfficeHoursSectionService = Depends(),
 ) -> OfficeHoursSectionDetails:
     """
     Gets an OH section by OH section ID
@@ -53,9 +61,15 @@ def get_oh_section_by_id(
     return oh_section_service.get_section_by_id(subject, oh_section_id)
 
 
-@api.get("/{oh_section_id}/events", response_model=list[OfficeHoursEventDetails], tag=["Office Hours"])
-def get_section_events(
-    oh_section_id: int, subject: User = Depends(registered_user), oh_section_service: OfficeHoursSectionService = Depends()
+@api.get(
+    "/{oh_section_id}/events",
+    response_model=list[OfficeHoursEventDetails],
+    tag=["Office Hours"],
+)
+def get_oh_section_events(
+    oh_section_id: int,
+    subject: User = Depends(registered_user),
+    oh_section_service: OfficeHoursSectionService = Depends(),
 ) -> list[OfficeHoursEventDetails]:
     """
     Gets all events for a given section based on OH section id.
@@ -63,14 +77,23 @@ def get_section_events(
     Returns:
         list[OfficeHoursEventDetails]: List of events for the given section
     """
-    oh_section: OfficeHoursSectionDetails = oh_section_service.get_section_by_id(oh_section_id)
+    oh_section: OfficeHoursSectionDetails = oh_section_service.get_section_by_id(
+        oh_section_id
+    )
     return oh_section_service.get_events_by_section(subject, oh_section)
 
 
-@api.get("/{oh_section_id}/events/upcoming", response_model=list[OfficeHoursEventDetails], tag=["Office Hours"])
-def get_section_upcoming_events(
-    oh_section_id: int, subject: User = Depends(registered_user), oh_section_service: OfficeHoursSectionService = Depends(),
-    start: datetime = datetime.now(), end: datetime = datetime.now() + datetime.timedelta(weeks=1)
+@api.get(
+    "/{oh_section_id}/events/upcoming",
+    response_model=list[OfficeHoursEventDetails],
+    tag=["Office Hours"],
+)
+def get_oh_section_upcoming_events(
+    oh_section_id: int,
+    subject: User = Depends(registered_user),
+    oh_section_service: OfficeHoursSectionService = Depends(),
+    start: datetime = datetime.now(),
+    end: datetime = datetime.now() + datetime.timedelta(weeks=1),
 ) -> list[OfficeHoursEventDetails]:
     """
     Gets a list of upcoming OH events within a time range.
@@ -78,13 +101,21 @@ def get_section_upcoming_events(
     Returns:
         list[OfficeHoursEventDetails]: OH events associated with a given user in a time range
     """
-    oh_section: OfficeHoursSectionDetails = oh_section_service.get_section_by_id(oh_section_id)
+    oh_section: OfficeHoursSectionDetails = oh_section_service.get_section_by_id(
+        oh_section_id
+    )
     return oh_section_service.get_events_by_section(subject, oh_section)
 
 
-@api.get("/term/{term_id}", response_model=list[OfficeHoursSectionDetails], tags=["Office Hours"])
+@api.get(
+    "/term/{term_id}",
+    response_model=list[OfficeHoursSectionDetails],
+    tags=["Office Hours"],
+)
 def get_oh_sections_by_term_id(
-    term_id: str, subject: User = Depends(registered_user), oh_section_service: OfficeHoursSectionService = Depends()
+    term_id: str,
+    subject: User = Depends(registered_user),
+    oh_section_service: OfficeHoursSectionService = Depends(),
 ) -> list[OfficeHoursSectionDetails]:
     """
     Gets list of OH sections by term ID
@@ -95,7 +126,11 @@ def get_oh_sections_by_term_id(
     return oh_section_service.get_sections_by_term(subject, term_id)
 
 
-@api.get("/user/term/{term_id}", response_model=list[OfficeHoursSectionDetails], tags=["Office Hours"])
+@api.get(
+    "/user/term/{term_id}",
+    response_model=list[OfficeHoursSectionDetails],
+    tags=["Office Hours"],
+)
 def get_oh_sections_by_user_and_term(
     term_id: str,
     subject: User = Depends(registered_user),
@@ -110,7 +145,53 @@ def get_oh_sections_by_user_and_term(
     return oh_section_service.get_user_sections_by_term(subject, term_id)
 
 
-@api.put("/{oh_section_id}", response_model=OfficeHoursSectionDetails, tags=["Office Hours"])
+@api.get(
+    "/{oh_section_id}/tickets",
+    response_model=list[OfficeHoursTicketDetails],
+    tags=["Office Hours"],
+)
+def get_oh_section_tickets(
+    oh_section_id: int,
+    subject: User = Depends(registered_user),
+    oh_section_service: OfficeHoursSectionService = Depends(),
+) -> list[OfficeHoursTicketDetails]:
+    """
+    Gets list of OH tickets from an OH section
+
+    Returns:
+        list[OfficeHoursTicketDetails]: OH tickets within the given section
+    """
+    oh_section: OfficeHoursSectionDetails = oh_section_service.get_section_by_id(
+        oh_section_id
+    )
+    return oh_section_service.get_section_tickets(subject, oh_section)
+
+
+@api.get(
+    "/{oh_section_id}/user/tickets",
+    response_model=list[OfficeHoursTicketDetails],
+    tags=["Office Hours"],
+)
+def get_oh_tickets_by_section_and_user(
+    oh_section_id: int,
+    subject: User = Depends(registered_user),
+    oh_section_service: OfficeHoursSectionService = Depends(),
+) -> list[OfficeHoursTicketDetails]:
+    """
+    Gets list of OH tickets by OH section and user
+
+    Returns:
+        list[OfficeHoursTicketDetails]: OH tickets within the given section and for the specific user
+    """
+    oh_section: OfficeHoursSectionDetails = oh_section_service.get_section_by_id(
+        oh_section_id
+    )
+    return oh_section_service.get_tickets_by_section_and_user(subject, oh_section)
+
+
+@api.put(
+    "/{oh_section_id}", response_model=OfficeHoursSectionDetails, tags=["Office Hours"]
+)
 def update_oh_section(
     oh_section: OfficeHoursSection,
     subject: User = Depends(registered_user),
@@ -134,5 +215,7 @@ def delete_oh_section(
     """
     Deletes an OfficeHoursSection from the database
     """
-    oh_section: OfficeHoursSectionDetails = oh_section_service.get_section_by_id(oh_section_id)
+    oh_section: OfficeHoursSectionDetails = oh_section_service.get_section_by_id(
+        oh_section_id
+    )
     return oh_section_service.delete(subject, oh_section)

--- a/backend/api/office_hours/oh_section.py
+++ b/backend/api/office_hours/oh_section.py
@@ -1,0 +1,98 @@
+"""OH Section API
+
+This API is used to access OH section data."""
+
+from fastapi import APIRouter, Depends
+
+from backend.models.office_hours.oh_section import OfficeHoursSectionDraft
+from backend.models.office_hours.oh_section_details import OfficeHoursSectionDetails
+from ..authentication import registered_user
+from ...models import User
+
+
+__authors__ = ["Sadie Amato", "Bailey DeSouza"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+
+api = APIRouter(prefix="/api/office-hours")
+openapi_tags = {
+    "name": "Office Hours",
+    "description": "Office hours section, event, and ticket functionality",
+}
+
+
+@api.post("/section", response_model=OfficeHoursSectionDetails, tags=["Office Hours"])
+def new_oh_section(
+    oh_section: OfficeHoursSectionDraft,
+    subject: User = Depends(registered_user),
+    oh_section_service: OfficeHoursSectionService = Depends(),
+) -> OfficeHoursSectionDetails:
+    """
+    Adds a new OH section to the database
+
+    Returns:
+        OfficeHoursSectionDetails: OH Section created
+    """
+    return oh_section_service.create(subject, oh_section)
+
+
+@api.get("", response_model=list[OfficeHoursSectionDetails], tags=["Office Hours"])
+def get_oh_sections_by_term_id(
+    term_id: str,
+    subject: User = Depends(registered_user),
+    oh_section_service: OfficeHoursSectionService = Depends(),
+) -> list[OfficeHoursSectionDetails]:
+    """
+    Gets list of OH sections by term ID
+
+    Returns:
+        list[OfficeHoursSectionDetails]: OH sections within the given term
+    """
+    return oh_section_service.get_sections_by_term(subject, term_id)
+
+
+@api.get(
+    "api/office-hours/term/",
+    response_model=list[OfficeHoursSectionDetails],
+    tags=["Office Hours"],
+)
+def get_oh_sections_by_user_and_term(
+    term_id: str,
+    subject: User = Depends(registered_user),
+    oh_section_service: OfficeHoursSectionService = Depends(),
+) -> list[OfficeHoursSectionDetails]:
+    """
+    Gets list of OH sections the currrent user is in during a given term
+
+    Returns:
+        list[OfficeHoursSectionDetails]: User's OH sections within the given term
+    """
+    return oh_section_service.get_user_sections_by_term(term_id, subject)
+
+
+@api.put("", response_model=OfficeHoursSectionDetails, tags=["Academics"])
+def update_oh_section(
+    oh_section: OfficeHoursSectionDraft,
+    subject: User = Depends(registered_user),
+    oh_section_service: OfficeHoursSectionService = Depends(),
+) -> OfficeHoursSectionDetails:
+    """
+    Updates an OfficeHoursSection to the database
+
+    Returns:
+        OfficeHoursSectionDetails: OH Section updated
+    """
+    return oh_section_service.update(subject, oh_section)
+
+
+@api.delete("/{oh_section_id}", response_model=None, tags=["Office Hours"])
+def delete_oh_section(
+    oh_section_id: int,
+    subject: User = Depends(registered_user),
+    oh_section_service: OfficeHoursSectionService = Depends(),
+):
+    """
+    Deletes an OfficeHoursSection from the database
+    """
+    return oh_section_service.delete(subject, oh_section_id)

--- a/backend/api/office_hours/oh_section.py
+++ b/backend/api/office_hours/oh_section.py
@@ -4,14 +4,15 @@ This API is used to access OH section data."""
 
 from fastapi import APIRouter, Depends
 
-from backend.models.office_hours.oh_section import OfficeHoursSection, OfficeHoursSectionDraft
-from backend.models.office_hours.oh_section_details import OfficeHoursSectionDetails
-from backend.services.office_hours.oh_section import OfficeHoursSectionService
+from ...models.office_hours.oh_event_details import OfficeHoursEventDetails
+from ...models.office_hours.oh_section import OfficeHoursSection, OfficeHoursSectionDraft
+from ...models.office_hours.oh_section_details import OfficeHoursSectionDetails
+from ...services.office_hours.oh_section import OfficeHoursSectionService
 from ..authentication import registered_user
 from ...models import User
 
 
-__authors__ = ["Sadie Amato", "Bailey DeSouza"]
+__authors__ = ["Sadie Amato", "Madelyn Andrews", "Bailey DeSouza", "Meghan Sun"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
@@ -49,6 +50,20 @@ def get_oh_section_by_id(
         OfficeHoursSectionDetails: The OH section with the given OH section id
     """
     return oh_section_service.get_section_by_id(subject, oh_section_id)
+
+
+@api.get("/{oh_section_id}/events", response_model=list[OfficeHoursEventDetails], tag=["Office Hours"])
+def get_section_events(
+    oh_section_id: int, subject: User = Depends(registered_user), oh_section_service: OfficeHoursSectionService = Depends()
+) -> list[OfficeHoursEventDetails]:
+    """
+    Gets all events for a given section based on OH section id.
+
+    Returns:
+        list[OfficeHoursEventDetails]: List of events for the given section
+    """
+    oh_section: OfficeHoursSectionDetails = oh_section_service.get_section_by_id(oh_section_id)
+    return oh_section_service.get_events_by_section(subject, oh_section)
 
 
 @api.get("/term/{term_id}", response_model=list[OfficeHoursSectionDetails], tags=["Office Hours"])

--- a/backend/api/office_hours/oh_ticket.py
+++ b/backend/api/office_hours/oh_ticket.py
@@ -60,60 +60,9 @@ def get_oh_ticket_by_id(
     return oh_ticket_service.get_ticket_by_id(subject, oh_ticket_id)
 
 
-@api.get(
-    "/{oh_section_id}",
-    response_model=list[OfficeHoursTicketDetails],
-    tags=["Office Hours"],
+@api.put(
+    "/{oh_ticket_id}", response_model=OfficeHoursTicketDetails, tags=["Office Hours"]
 )
-def get_oh_tickets_by_section(
-    oh_section_id: int,
-    subject: User = Depends(registered_user),
-    oh_ticket_service: OfficeHoursTicketService = Depends(),
-) -> list[OfficeHoursTicketDetails]:
-    """
-    Gets list of OH tickets by OH section
-
-    Returns:
-        list[OfficeHoursTicketDetails]: OH tickets within the given section
-    """
-    return oh_ticket_service.get_tickets_by_section(subject, oh_section_id)
-
-
-@api.get("", response_model=list[OfficeHoursTicketDetails], tags=["Office Hours"])
-def get_oh_tickets_by_section_and_user(
-    oh_section_id: int,
-    subject: User = Depends(registered_user),
-    oh_ticket_service: OfficeHoursTicketService = Depends(),
-) -> list[OfficeHoursTicketDetails]:
-    """
-    Gets list of OH tickets by OH section and user
-
-    Returns:
-        list[OfficeHoursTicketDetails]: OH tickets within the given section and for the specific user
-    """
-    return oh_ticket_service.get_tickets_by_section_and_user(subject, oh_section_id)
-
-
-@api.get(
-    "/{oh_event_id}",
-    response_model=list[OfficeHoursTicketDetails],
-    tags=["Office Hours"],
-)
-def get_oh_tickets_by_event(
-    oh_event_id: int,
-    subject: User = Depends(registered_user),
-    oh_ticket_service: OfficeHoursTicketService = Depends(),
-) -> list[OfficeHoursTicketDetails]:
-    """
-    Gets list of OH tickets by OH event
-
-    Returns:
-        list[OfficeHoursTicketDetails]: OH tickets within the given event
-    """
-    return oh_ticket_service.get_tickets_by_event(subject, oh_event_id)
-
-
-@api.put("/{ticket_id}", response_model=OfficeHoursTicketDetails, tags=["Office Hours"])
 def update_oh_ticket(
     oh_ticket: OfficeHoursTicket,
     subject: User = Depends(registered_user),
@@ -128,7 +77,11 @@ def update_oh_ticket(
     return oh_ticket_service.update(subject, oh_ticket)
 
 
-@api.put("/state/{id}", response_model=OfficeHoursTicketDetails, tags=["Office Hours"])
+@api.put(
+    "/state/{oh_ticket_id}",
+    response_model=OfficeHoursTicketDetails,
+    tags=["Office Hours"],
+)
 def update_oh_ticket_state(
     oh_ticket: OfficeHoursTicket,
     subject: User = Depends(registered_user),

--- a/backend/services/office_hours/oh_event.py
+++ b/backend/services/office_hours/oh_event.py
@@ -1,0 +1,111 @@
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from backend.database import db_session
+from backend.entities.academics.event_entity import EventEntity
+from backend.entities.office_hours.oh_event_entity import OfficeHoursEventEntity
+from backend.models.coworking.time_range import TimeRange
+from backend.models.office_hours.oh_event import OfficeHoursEvent, OfficeHoursEventDraft
+from backend.models.office_hours.oh_event_details import OfficeHoursEventDetails
+from backend.models.user import User
+from backend.services.exceptions import ResourceNotFoundException
+
+from backend.services.permission import PermissionService
+
+
+__authors__ = ["Sadie Amato", "Bailey DeSouza"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+
+class OfficeHoursEventService:
+    """Service that performs all of the actions on the `OfficeHoursEvent` table"""
+
+    def __init__(
+        self,
+        session: Session = Depends(db_session),
+        permission_svc: PermissionService = Depends(),
+    ):
+        """Initializes the database session."""
+        self._session = session
+        self._permission_svc = permission_svc
+
+    
+    def create(self, subject: User, oh_event: OfficeHoursEventDraft) -> OfficeHoursEventDetails:
+        """Creates a new office hours event.
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_event: OfficeHoursEventDraft to add to table
+
+        Returns:
+            OfficeHoursEventDetails: Object added to table
+        """
+        #TODO
+        return None
+    
+
+    def update(self, subject: User, oh_event: OfficeHoursEvent) -> OfficeHoursEventDetails:
+        """Updates an office hours event.
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_event: OfficeHoursEvent to update in the table
+
+        Returns:
+            OfficeHoursEventDetails: Updated object in table
+        """ 
+        #TODO
+        return None
+    
+    
+    def delete(self, subject: User, oh_event_id: int) -> None:
+        """Deletes an office hours event.
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_event_id: ID of office hours event to delete
+        """
+        #TODO
+
+    
+    def get_events_by_section(self, subject: User, oh_section_id: int) -> list[OfficeHoursEventDetails]:
+        """Gets all office hours events for a section.
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_section_id: OfficeHoursSection id to get all events for
+
+        Returns:
+            list[OfficeHoursEventDetails]: OH events associated with a given section
+        """ 
+        #TODO
+        return None
+    
+    def get_upcoming_events_by_section(self, oh_section_id: int, time_range: TimeRange) -> list[OfficeHoursEventDetails]:
+        """Gets all upcoming office hours events for a section.
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_section_id: OfficeHoursSection id to get all upcoming events for
+            time_range: Time range to retrieve events for
+
+        Returns:
+            list[OfficeHoursEventDetails]: upcoming OH events associated with a given section
+        """ 
+        #TODO
+        return None 
+    
+
+    def get_upcoming_events_by_user(self, subject: User, time_range: TimeRange) -> list[OfficeHoursEventDetails]:
+        """Gets all upcoming office hours events for a user.
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            time_range: Time range to retrieve events for
+
+        Returns:
+            list[OfficeHoursEventDetails]: upcoming OH events associated with a user
+        """ 
+        #TODO
+        return None 

--- a/backend/services/office_hours/oh_event.py
+++ b/backend/services/office_hours/oh_event.py
@@ -45,7 +45,7 @@ class OfficeHoursEventService:
         return None
     
 
-    def update(self, subject: User, oh_event_id: int, oh_event: OfficeHoursEvent) -> OfficeHoursEventDetails:
+    def update(self, subject: User, oh_event: OfficeHoursEvent) -> OfficeHoursEventDetails:
         """Updates an office hours event.
 
         Args:
@@ -82,21 +82,6 @@ class OfficeHoursEventService:
         """
         #TODO
         return None
-
-    
-    def get_upcoming_events_by_section(self, oh_section_id: int, time_range: TimeRange) -> list[OfficeHoursEventDetails]:
-        """Gets all upcoming office hours events for a section.
-
-        Args:
-            subject: a valid User model representing the currently logged in User
-            oh_section_id: OfficeHoursSection id to get all upcoming events for
-            time_range: Time range to retrieve events for
-
-        Returns:
-            list[OfficeHoursEventDetails]: upcoming OH events associated with a given section
-        """ 
-        #TODO
-        return None 
     
 
     def get_upcoming_events_by_user(self, subject: User, time_range: TimeRange) -> list[OfficeHoursEventDetails]:

--- a/backend/services/office_hours/oh_event.py
+++ b/backend/services/office_hours/oh_event.py
@@ -45,11 +45,12 @@ class OfficeHoursEventService:
         return None
     
 
-    def update(self, subject: User, oh_event: OfficeHoursEvent) -> OfficeHoursEventDetails:
+    def update(self, subject: User, oh_event_id: int, oh_event: OfficeHoursEvent) -> OfficeHoursEventDetails:
         """Updates an office hours event.
 
         Args:
             subject: a valid User model representing the currently logged in User
+            oh_event_id: id of the OfficeHoursEvent to update in the table
             oh_event: OfficeHoursEvent to update in the table
 
         Returns:
@@ -59,12 +60,12 @@ class OfficeHoursEventService:
         return None
     
     
-    def delete(self, subject: User, oh_event_id: int) -> None:
+    def delete(self, subject: User, oh_event: OfficeHoursEventDetails) -> None:
         """Deletes an office hours event.
 
         Args:
             subject: a valid User model representing the currently logged in User
-            oh_event_id: ID of office hours event to delete
+            oh_event: OfficeHoursEventDetails to delete
         """
         #TODO
 

--- a/backend/services/office_hours/oh_event.py
+++ b/backend/services/office_hours/oh_event.py
@@ -69,6 +69,20 @@ class OfficeHoursEventService:
         #TODO
 
     
+    def get_event_by_id(self, subject: User, oh_event_id: int) -> OfficeHoursEventDetails:
+        """Gets an office hour event based on OH event id.
+        
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_event_id: OfficeHoursEvent id to get the corresponding event for
+        
+        Returns:
+            OfficeHoursEventDetails: OH event associated with the OH event id
+        """
+        #TODO
+        return None
+
+    
     def get_events_by_section(self, subject: User, oh_section_id: int) -> list[OfficeHoursEventDetails]:
         """Gets all office hours events for a section.
 

--- a/backend/services/office_hours/oh_event.py
+++ b/backend/services/office_hours/oh_event.py
@@ -1,19 +1,19 @@
 from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from backend.database import db_session
-from backend.entities.academics.event_entity import EventEntity
-from backend.entities.office_hours.oh_event_entity import OfficeHoursEventEntity
-from backend.models.coworking.time_range import TimeRange
-from backend.models.office_hours.oh_event import OfficeHoursEvent, OfficeHoursEventDraft
-from backend.models.office_hours.oh_event_details import OfficeHoursEventDetails
-from backend.models.user import User
-from backend.services.exceptions import ResourceNotFoundException
+from ...database import db_session
+from ...entities.academics.event_entity import EventEntity
+from ...entities.office_hours.oh_event_entity import OfficeHoursEventEntity
+from ...models.coworking.time_range import TimeRange
+from ...models.office_hours.oh_event import OfficeHoursEvent, OfficeHoursEventDraft
+from ...models.office_hours.oh_event_details import OfficeHoursEventDetails
+from ...models.user import User
+from ..services.exceptions import ResourceNotFoundException
 
-from backend.services.permission import PermissionService
+from ..services.permission import PermissionService
 
 
-__authors__ = ["Sadie Amato", "Bailey DeSouza"]
+__authors__ = ["Sadie Amato", "Madelyn Andrews", "Bailey DeSouza", "Meghan Sun"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
@@ -83,19 +83,6 @@ class OfficeHoursEventService:
         #TODO
         return None
 
-    
-    def get_events_by_section(self, subject: User, oh_section_id: int) -> list[OfficeHoursEventDetails]:
-        """Gets all office hours events for a section.
-
-        Args:
-            subject: a valid User model representing the currently logged in User
-            oh_section_id: OfficeHoursSection id to get all events for
-
-        Returns:
-            list[OfficeHoursEventDetails]: OH events associated with a given section
-        """ 
-        #TODO
-        return None
     
     def get_upcoming_events_by_section(self, oh_section_id: int, time_range: TimeRange) -> list[OfficeHoursEventDetails]:
         """Gets all upcoming office hours events for a section.

--- a/backend/services/office_hours/oh_event.py
+++ b/backend/services/office_hours/oh_event.py
@@ -1,16 +1,17 @@
 from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.orm import Session
+
+from ...models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
 from ...database import db_session
-from ...entities.academics.event_entity import EventEntity
 from ...entities.office_hours.oh_event_entity import OfficeHoursEventEntity
 from ...models.coworking.time_range import TimeRange
 from ...models.office_hours.oh_event import OfficeHoursEvent, OfficeHoursEventDraft
 from ...models.office_hours.oh_event_details import OfficeHoursEventDetails
 from ...models.user import User
-from ..services.exceptions import ResourceNotFoundException
 
-from ..services.permission import PermissionService
+from ...services.exceptions import ResourceNotFoundException
+from ...services.permission import PermissionService
 
 
 __authors__ = ["Sadie Amato", "Madelyn Andrews", "Bailey DeSouza", "Meghan Sun"]
@@ -30,8 +31,9 @@ class OfficeHoursEventService:
         self._session = session
         self._permission_svc = permission_svc
 
-    
-    def create(self, subject: User, oh_event: OfficeHoursEventDraft) -> OfficeHoursEventDetails:
+    def create(
+        self, subject: User, oh_event: OfficeHoursEventDraft
+    ) -> OfficeHoursEventDetails:
         """Creates a new office hours event.
 
         Args:
@@ -41,25 +43,24 @@ class OfficeHoursEventService:
         Returns:
             OfficeHoursEventDetails: Object added to table
         """
-        #TODO
+        # TODO
         return None
-    
 
-    def update(self, subject: User, oh_event: OfficeHoursEvent) -> OfficeHoursEventDetails:
+    def update(
+        self, subject: User, oh_event: OfficeHoursEvent
+    ) -> OfficeHoursEventDetails:
         """Updates an office hours event.
 
         Args:
             subject: a valid User model representing the currently logged in User
-            oh_event_id: id of the OfficeHoursEvent to update in the table
             oh_event: OfficeHoursEvent to update in the table
 
         Returns:
             OfficeHoursEventDetails: Updated object in table
-        """ 
-        #TODO
+        """
+        # TODO
         return None
-    
-    
+
     def delete(self, subject: User, oh_event: OfficeHoursEventDetails) -> None:
         """Deletes an office hours event.
 
@@ -67,24 +68,26 @@ class OfficeHoursEventService:
             subject: a valid User model representing the currently logged in User
             oh_event: OfficeHoursEventDetails to delete
         """
-        #TODO
+        # TODO
 
-    
-    def get_event_by_id(self, subject: User, oh_event_id: int) -> OfficeHoursEventDetails:
+    def get_event_by_id(
+        self, subject: User, oh_event_id: int
+    ) -> OfficeHoursEventDetails:
         """Gets an office hour event based on OH event id.
-        
+
         Args:
             subject: a valid User model representing the currently logged in User
             oh_event_id: OfficeHoursEvent id to get the corresponding event for
-        
+
         Returns:
             OfficeHoursEventDetails: OH event associated with the OH event id
         """
-        #TODO
+        # TODO
         return None
-    
 
-    def get_upcoming_events_by_user(self, subject: User, time_range: TimeRange) -> list[OfficeHoursEventDetails]:
+    def get_upcoming_events_by_user(
+        self, subject: User, time_range: TimeRange
+    ) -> list[OfficeHoursEventDetails]:
         """Gets all upcoming office hours events for a user.
 
         Args:
@@ -93,6 +96,19 @@ class OfficeHoursEventService:
 
         Returns:
             list[OfficeHoursEventDetails]: upcoming OH events associated with a user
-        """ 
-        #TODO
-        return None 
+        """
+        # TODO
+        return None
+
+    def get_event_tickets(
+        self, subject: User, oh_event: OfficeHoursEventDetails
+    ) -> list[OfficeHoursTicketDetails]:
+        """Retrieves all office hours tickets in an event from the table.
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_event: the OfficeHoursEventDetails to query by.
+        Returns:
+            list[OfficeHoursTicketDetails]: List of all `OfficeHoursTicketDetails` in an OHEvent
+        """
+        # TODO
+        return None

--- a/backend/services/office_hours/oh_section.py
+++ b/backend/services/office_hours/oh_section.py
@@ -58,6 +58,18 @@ class OfficeHoursSectionService:
         # Return added object
         return oh_section_entity.to_details_model()
     
+    def get_section_by_id(self, subject: User, oh_section_id: int) -> OfficeHoursSectionDetails:
+        """Returns the office hours section from the table by an OH section id
+        
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_section_id: ID of the office hours section to query by.
+        Returns:
+            OfficeHoursSectionDetails: the office hours section with the given id
+        """
+        # TODO
+        return None
+    
     def get_sections_by_term(self, subject: User, term_id: int) -> list[OfficeHoursSectionDetails]:
         """Retrieves all office hours sections from the table by a term.
 

--- a/backend/services/office_hours/oh_section.py
+++ b/backend/services/office_hours/oh_section.py
@@ -1,6 +1,7 @@
 from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.orm import Session
+from backend.models.coworking.time_range import TimeRange
 
 from backend.models.office_hours.oh_event_details import OfficeHoursEventDetails
 from ...database import db_session
@@ -72,7 +73,7 @@ class OfficeHoursSectionService:
         # TODO
         return None
     
-    def get_events_by_section(self, subject: User, oh_section: OfficeHoursSectionDetails) -> list[OfficeHoursEventDetails]:
+    def get_events_by_section(self, subject: User, oh_section: OfficeHoursSectionDetails, time_range: TimeRange | None = None) -> list[OfficeHoursEventDetails]:
         """Returns all events for a given office hours section
 
         Args:
@@ -82,6 +83,8 @@ class OfficeHoursSectionService:
             list[OfficeHoursEventDetails]: list of all office hours events for the given section
         """
         # TODO
+        # make sure to check if time range is None
+        # if time range is not None, you are retrieving upcoming events
         return None
     
     def get_sections_by_term(self, subject: User, term_id: int) -> list[OfficeHoursSectionDetails]:
@@ -120,7 +123,7 @@ class OfficeHoursSectionService:
         return []  
     
 
-    def update(self, subject: User, oh_section_id: int, oh_section: OfficeHoursSection) -> OfficeHoursSectionDetails:
+    def update(self, subject: User, oh_section: OfficeHoursSection) -> OfficeHoursSectionDetails:
         """Updates an OfficeHoursSection.
 
         Args:

--- a/backend/services/office_hours/oh_section.py
+++ b/backend/services/office_hours/oh_section.py
@@ -1,18 +1,22 @@
 from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from backend.models.coworking.time_range import TimeRange
+from ...models.coworking.time_range import TimeRange
 
-from backend.models.office_hours.oh_event_details import OfficeHoursEventDetails
+from ...models.office_hours.oh_event_details import OfficeHoursEventDetails
+from ...models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
 from ...database import db_session
 from ...entities.academics.section_entity import SectionEntity
 from ...entities.office_hours.oh_section_entity import OfficeHoursSectionEntity
-from ...models.office_hours.oh_section import OfficeHoursSection, OfficeHoursSectionDraft
+from ...models.office_hours.oh_section import (
+    OfficeHoursSection,
+    OfficeHoursSectionDraft,
+)
 from ...models.office_hours.oh_section_details import OfficeHoursSectionDetails
 from ...models.user import User
-from ..services.exceptions import ResourceNotFoundException
+from ...services.exceptions import ResourceNotFoundException
 
-from ..services.permission import PermissionService
+from ...services.permission import PermissionService
 
 
 __authors__ = ["Sadie Amato", "Madelyn Andrews", "Bailey DeSouza", "Meghan Sun"]
@@ -32,8 +36,9 @@ class OfficeHoursSectionService:
         self._session = session
         self._permission_svc = permission_svc
 
-
-    def create(self, subject: User, oh_section: OfficeHoursSection) -> OfficeHoursSectionDetails:
+    def create(
+        self, subject: User, oh_section: OfficeHoursSection
+    ) -> OfficeHoursSectionDetails:
         """Creates a new office hours section.
 
         Args:
@@ -44,12 +49,11 @@ class OfficeHoursSectionService:
             OfficeHoursSectionDetails: Object added to table
         """
         # TODO: this is a WIP!
-		# ----- Permission check for section creation ----
+        # ----- Permission check for section creation ----
         # Check if user has admin permissions
         # self._permission_svc.enforce(subject, "academics.section.create", f"section/")
-				
-				# TODO: investigate what permission checks we will need to do here
 
+        # TODO: investigate what permission checks we will need to do here
 
         # Create new object
         oh_section_entity = OfficeHoursSectionEntity.from_model(oh_section)
@@ -60,10 +64,12 @@ class OfficeHoursSectionService:
 
         # Return added object
         return oh_section_entity.to_details_model()
-    
-    def get_section_by_id(self, subject: User, oh_section_id: int) -> OfficeHoursSectionDetails:
+
+    def get_section_by_id(
+        self, subject: User, oh_section_id: int
+    ) -> OfficeHoursSectionDetails:
         """Returns the office hours section from the table by an OH section id
-        
+
         Args:
             subject: a valid User model representing the currently logged in User
             oh_section_id: ID of the office hours section to query by.
@@ -72,8 +78,13 @@ class OfficeHoursSectionService:
         """
         # TODO
         return None
-    
-    def get_events_by_section(self, subject: User, oh_section: OfficeHoursSectionDetails, time_range: TimeRange | None = None) -> list[OfficeHoursEventDetails]:
+
+    def get_events_by_section(
+        self,
+        subject: User,
+        oh_section: OfficeHoursSectionDetails,
+        time_range: TimeRange | None = None,
+    ) -> list[OfficeHoursEventDetails]:
         """Returns all events for a given office hours section
 
         Args:
@@ -86,8 +97,10 @@ class OfficeHoursSectionService:
         # make sure to check if time range is None
         # if time range is not None, you are retrieving upcoming events
         return None
-    
-    def get_sections_by_term(self, subject: User, term_id: int) -> list[OfficeHoursSectionDetails]:
+
+    def get_sections_by_term(
+        self, subject: User, term_id: int
+    ) -> list[OfficeHoursSectionDetails]:
         """Retrieves all office hours sections from the table by a term.
 
         Args:
@@ -100,7 +113,7 @@ class OfficeHoursSectionService:
         # Select all entries in the `OfficeHoursSection` table where their section(s)'s term id == term_id
         query = (
             select(OfficeHoursSectionEntity)
-						.join(SectionEntity)
+            .join(SectionEntity)
             .where(SectionEntity.term_id == term_id)
             .order_by(OfficeHoursSectionEntity.title)
         )
@@ -108,40 +121,63 @@ class OfficeHoursSectionService:
 
         # Return the model
         return [entity.to_details_model() for entity in entities]
-    
 
-    def get_user_sections_by_term(self, subject: User, term_id: int) -> list[OfficeHoursSectionDetails]:
+    def get_user_sections_by_term(
+        self, subject: User, term_id: int
+    ) -> list[OfficeHoursSectionDetails]:
         """Retrieves all office hours sections from the table by a term and specific user.
-
         Args:
             subject: a valid User model representing the currently logged in User
             term_id: ID of the term to query by.
         Returns:
             list[OfficeHoursSectionDetails]: List of all `OfficeHoursSectionDetails`
-        """  
+        """
         # TODO
-        return []  
-    
+        return []
 
-    def update(self, subject: User, oh_section: OfficeHoursSection) -> OfficeHoursSectionDetails:
-        """Updates an OfficeHoursSection.
-
+    def get_section_tickets(
+        self, subject: User, oh_section: OfficeHoursSectionDetails
+    ) -> list[OfficeHoursTicketDetails]:
+        """Retrieves all office hours tickets from the table by a section.
         Args:
             subject: a valid User model representing the currently logged in User
-            oh_section_id: id of the OfficeHoursSection to update
+            oh_section: the OfficeHoursSectionDetails to query by.
+        Returns:
+            list[OfficeHoursTicketDetails]: List of all `OfficeHoursTicketDetails` in an OHsection
+        """
+        # TODO
+        return None
+
+    def get_user_section_tickets(
+        self, subject: User, oh_section_id: int
+    ) -> list[OfficeHoursTicketDetails]:
+        """Retrieves all of the subject's office hours tickets in a section from the table.
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_section: the OfficeHoursSectionDetails to query by.
+        Returns:
+            list[OfficeHoursTicketDetails]: List of all of a user's `OfficeHoursTicketDetails` in an OHsection
+        """
+        # TODO
+        return None
+
+    def update(
+        self, subject: User, oh_section: OfficeHoursSection
+    ) -> OfficeHoursSectionDetails:
+        """Updates an OfficeHoursSection.
+        Args:
+            subject: a valid User model representing the currently logged in User
             oh_section: the updated OfficeHoursSection
         Returns:
             OfficeHoursSectionDetails: updated OfficeHoursSectionDetails
-        """   
+        """
         # TODO
-        return None  
-    
+        return None
 
     def delete(self, subject: User, oh_section: int) -> None:
         """Deletes an office hours section.
-
         Args:
             subject: a valid User model representing the currently logged in User
             oh_section: OfficeHoursSectionDetails to delete
         """
-        #TODO
+        # TODO

--- a/backend/services/office_hours/oh_section.py
+++ b/backend/services/office_hours/oh_section.py
@@ -1,18 +1,20 @@
 from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from backend.database import db_session
-from backend.entities.academics.section_entity import SectionEntity
-from backend.entities.office_hours.oh_section_entity import OfficeHoursSectionEntity
-from backend.models.office_hours.oh_section import OfficeHoursSection, OfficeHoursSectionDraft
-from backend.models.office_hours.oh_section_details import OfficeHoursSectionDetails
-from backend.models.user import User
-from backend.services.exceptions import ResourceNotFoundException
 
-from backend.services.permission import PermissionService
+from backend.models.office_hours.oh_event_details import OfficeHoursEventDetails
+from ...database import db_session
+from ...entities.academics.section_entity import SectionEntity
+from ...entities.office_hours.oh_section_entity import OfficeHoursSectionEntity
+from ...models.office_hours.oh_section import OfficeHoursSection, OfficeHoursSectionDraft
+from ...models.office_hours.oh_section_details import OfficeHoursSectionDetails
+from ...models.user import User
+from ..services.exceptions import ResourceNotFoundException
+
+from ..services.permission import PermissionService
 
 
-__authors__ = ["Sadie Amato", "Bailey DeSouza"]
+__authors__ = ["Sadie Amato", "Madelyn Andrews", "Bailey DeSouza", "Meghan Sun"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
@@ -66,6 +68,18 @@ class OfficeHoursSectionService:
             oh_section_id: ID of the office hours section to query by.
         Returns:
             OfficeHoursSectionDetails: the office hours section with the given id
+        """
+        # TODO
+        return None
+    
+    def get_events_by_section(self, subject: User, oh_section: OfficeHoursSectionDetails) -> list[OfficeHoursEventDetails]:
+        """Returns all events for a given office hours section
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_section: OfficeHoursSectionDetails to get all the events of
+        Returns:
+            list[OfficeHoursEventDetails]: list of all office hours events for the given section
         """
         # TODO
         return None

--- a/backend/services/office_hours/oh_section.py
+++ b/backend/services/office_hours/oh_section.py
@@ -1,0 +1,129 @@
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from backend.database import db_session
+from backend.entities.academics.section_entity import SectionEntity
+from backend.entities.office_hours.oh_section_entity import OfficeHoursSectionEntity
+from backend.models.office_hours.oh_section import OfficeHoursSection, OfficeHoursSectionDraft
+from backend.models.office_hours.oh_section_details import OfficeHoursSectionDetails
+from backend.models.user import User
+from backend.services.exceptions import ResourceNotFoundException
+
+from backend.services.permission import PermissionService
+
+
+__authors__ = ["Sadie Amato", "Bailey DeSouza"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+
+class OfficeHoursSectionService:
+    """Service that performs all of the actions on the `OfficeHoursSection` table"""
+
+    def __init__(
+        self,
+        session: Session = Depends(db_session),
+        permission_svc: PermissionService = Depends(),
+    ):
+        """Initializes the database session."""
+        self._session = session
+        self._permission_svc = permission_svc
+
+
+    def create(self, subject: User, oh_section: OfficeHoursSection) -> OfficeHoursSectionDetails:
+        """Creates a new office hours section.
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_section: OfficeHoursSection to add to table
+
+        Returns:
+            OfficeHoursSectionDetails: Object added to table
+        """
+        # TODO: this is a WIP!
+		# ----- Permission check for section creation ----
+        # Check if user has admin permissions
+        # self._permission_svc.enforce(subject, "academics.section.create", f"section/")
+				
+				# TODO: investigate what permission checks we will need to do here
+
+
+        # Create new object
+        oh_section_entity = OfficeHoursSectionEntity.from_model(oh_section)
+
+        # Add new object to table and commit changes
+        self._session.add(oh_section_entity)
+        self._session.commit()
+
+        # Return added object
+        return oh_section_entity.to_details_model()
+    
+    def get_sections_by_term(self, subject: User, term_id: int) -> list[OfficeHoursSectionDetails]:
+        """Retrieves all office hours sections from the table by a term.
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            term_id: ID of the term to query by.
+        Returns:
+            list[OfficeHoursSectionDetails]: List of all `OfficeHoursSectionDetails`
+        """
+        # TODO: this is a WIP!
+        # Select all entries in the `OfficeHoursSection` table where their section(s)'s term id == term_id
+        query = (
+            select(OfficeHoursSectionEntity)
+						.join(SectionEntity)
+            .where(SectionEntity.term_id == term_id)
+            .order_by(OfficeHoursSectionEntity.title)
+        )
+        entities = self._session.scalars(query).all()
+
+        # Return the model
+        return [entity.to_details_model() for entity in entities]
+    
+
+    def get_user_sections_by_term(self, subject: User, term_id: int) -> list[OfficeHoursSectionDetails]:
+        """Retrieves all office hours sections from the table by a term and specific user.
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            term_id: ID of the term to query by.
+        Returns:
+            list[OfficeHoursSectionDetails]: List of all `OfficeHoursSectionDetails`
+        """  
+        # TODO
+        return []  
+    
+
+    def update(self, subject: User, oh_section: OfficeHoursSection) -> OfficeHoursSectionDetails:
+        """Updates an OfficeHoursSection.
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_section: the updated OfficeHoursSection
+        Returns:
+            OfficeHoursSectionDetails: updated OfficeHoursSectionDetails
+        """   
+        # TODO
+        return None  
+    
+
+    def delete(self, subject: User, section_id: int) -> None:
+        """Deletes an office hours section.
+
+        Args:
+            subject: a valid User model representing the currently logged in User
+            section_id: ID of office hours section to delete
+        """
+        # TODO: this is a WIP!
+        # TODO: add permission check
+
+        # Find the entity to delete
+        oh_section_entity = self._session.get(OfficeHoursSectionEntity, section_id)
+
+        # Raise an error if no entity was found
+        if oh_section_entity is None:
+            raise ResourceNotFoundException(f"Office hours section with id: {section_id} does not exist.")
+
+        # Delete and commit changes
+        self._session.delete(oh_section_entity)
+        self._session.commit()

--- a/backend/services/office_hours/oh_section.py
+++ b/backend/services/office_hours/oh_section.py
@@ -106,11 +106,12 @@ class OfficeHoursSectionService:
         return []  
     
 
-    def update(self, subject: User, oh_section: OfficeHoursSection) -> OfficeHoursSectionDetails:
+    def update(self, subject: User, oh_section_id: int, oh_section: OfficeHoursSection) -> OfficeHoursSectionDetails:
         """Updates an OfficeHoursSection.
 
         Args:
             subject: a valid User model representing the currently logged in User
+            oh_section_id: id of the OfficeHoursSection to update
             oh_section: the updated OfficeHoursSection
         Returns:
             OfficeHoursSectionDetails: updated OfficeHoursSectionDetails
@@ -119,23 +120,11 @@ class OfficeHoursSectionService:
         return None  
     
 
-    def delete(self, subject: User, section_id: int) -> None:
+    def delete(self, subject: User, oh_section: int) -> None:
         """Deletes an office hours section.
 
         Args:
             subject: a valid User model representing the currently logged in User
-            section_id: ID of office hours section to delete
+            oh_section: OfficeHoursSectionDetails to delete
         """
-        # TODO: this is a WIP!
-        # TODO: add permission check
-
-        # Find the entity to delete
-        oh_section_entity = self._session.get(OfficeHoursSectionEntity, section_id)
-
-        # Raise an error if no entity was found
-        if oh_section_entity is None:
-            raise ResourceNotFoundException(f"Office hours section with id: {section_id} does not exist.")
-
-        # Delete and commit changes
-        self._session.delete(oh_section_entity)
-        self._session.commit()
+        #TODO

--- a/backend/services/office_hours/oh_ticket.py
+++ b/backend/services/office_hours/oh_ticket.py
@@ -56,45 +56,6 @@ class OfficeHoursTicketService:
         # TODO
         return None
 
-    def get_tickets_by_section(
-        self, subject: User, oh_section_id: int
-    ) -> list[OfficeHoursTicketDetails]:
-        """Retrieves all office hours tickets from the table by a section.
-        Args:
-            subject: a valid User model representing the currently logged in User
-            oh_section_id: ID of the section to query by.
-        Returns:
-            list[OfficeHoursTicketDetails]: List of all `OfficeHoursTicketDetails` in an OHsection
-        """
-        # TODO
-        return None
-
-    def get_tickets_by_section_and_user(
-        self, subject: User, oh_section_id: int
-    ) -> list[OfficeHoursTicketDetails]:
-        """Retrieves all of the subject's office hours tickets in a section from the table.
-        Args:
-            subject: a valid User model representing the currently logged in User
-            oh_section_id: ID of the section to query by.
-        Returns:
-            list[OfficeHoursTicketDetails]: List of all of a user's `OfficeHoursTicketDetails` in an OHsection
-        """
-        # TODO
-        return None
-
-    def get_tickets_by_event(
-        self, subject: User, oh_event_id: int
-    ) -> list[OfficeHoursTicketDetails]:
-        """Retrieves all office hours tickets in an event from the table.
-        Args:
-            subject: a valid User model representing the currently logged in User
-            oh_event_id: ID of the event to query by.
-        Returns:
-            list[OfficeHoursTicketDetails]: List of all `OfficeHoursTicketDetails` in an OHEvent
-        """
-        # TODO
-        return None
-
     def update(
         self, subject: User, oh_ticket: OfficeHoursTicket
     ) -> OfficeHoursTicketDetails:


### PR DESCRIPTION
Add OH section API endpoints with new models:

- Created api routes for OfficeHoursSections (get, create, update, delete)

Add OH event API endpoints with new models:

- Created api routes for OfficeHoursEvents
    - get by section id, get upcoming events by section id, get upcoming events by user, create, update, delete
    - added fix User subject to api/office_hours/oh_section.py

Add Service files skeleton — func defs + starter thoughts

- all function bodies are WIP/TODO
- changed `update` section & event API routes to take in non-draft model, so that the service can use an id from the db
- OHSectionService: create, delete, get sections by term, get user sections by term, update
- OHEventService: create, update, delete, get events by section, get upcoming events by section, get upcoming events for a user
