### PR TITLE
303 add ticket api and service skeleton

### DIFF
--- a/backend/api/office_hours/oh_ticket.py
+++ b/backend/api/office_hours/oh_ticket.py
@@ -9,6 +9,7 @@ from backend.models.office_hours.oh_ticket import (
     OfficeHoursTicketDraft,
 )
 from backend.models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
+from backend.services.office_hours.oh_ticket import OfficeHoursTicketService
 from ..authentication import registered_user
 from ...models import User
 
@@ -41,12 +42,31 @@ def new_oh_ticket(
 
 
 @api.get(
-    "/{section_id}",
+    "/{oh_ticket_id}",
+    response_model=OfficeHoursTicketDetails,
+    tags=["Office Hours"],
+)
+def get_oh_ticket_by_id(
+    oh_ticket_id: int,
+    subject: User = Depends(registered_user),
+    oh_ticket_service: OfficeHoursTicketService = Depends(),
+) -> OfficeHoursTicketDetails:
+    """
+    Gets an OH ticket by its id
+
+    Returns:
+        OfficeHoursTicketDetails: OH ticket with the given id
+    """
+    return oh_ticket_service.get_ticket_by_id(subject, oh_ticket_id)
+
+
+@api.get(
+    "/{oh_section_id}",
     response_model=list[OfficeHoursTicketDetails],
     tags=["Office Hours"],
 )
 def get_oh_tickets_by_section(
-    section_id: int,
+    oh_section_id: int,
     subject: User = Depends(registered_user),
     oh_ticket_service: OfficeHoursTicketService = Depends(),
 ) -> list[OfficeHoursTicketDetails]:
@@ -56,13 +76,12 @@ def get_oh_tickets_by_section(
     Returns:
         list[OfficeHoursTicketDetails]: OH tickets within the given section
     """
-    return oh_ticket_service.get_tickets_by_section(subject, section_id)
+    return oh_ticket_service.get_tickets_by_section(subject, oh_section_id)
 
 
-# TODO: check this api route
 @api.get("", response_model=list[OfficeHoursTicketDetails], tags=["Office Hours"])
 def get_oh_tickets_by_section_and_user(
-    section_id: int,
+    oh_section_id: int,
     subject: User = Depends(registered_user),
     oh_ticket_service: OfficeHoursTicketService = Depends(),
 ) -> list[OfficeHoursTicketDetails]:
@@ -72,14 +91,16 @@ def get_oh_tickets_by_section_and_user(
     Returns:
         list[OfficeHoursTicketDetails]: OH tickets within the given section and for the specific user
     """
-    return oh_ticket_service.get_tickets_by_section_and_user(subject, section_id)
+    return oh_ticket_service.get_tickets_by_section_and_user(subject, oh_section_id)
 
 
 @api.get(
-    "/{event_id}", response_model=list[OfficeHoursTicketDetails], tags=["Office Hours"]
+    "/{oh_event_id}",
+    response_model=list[OfficeHoursTicketDetails],
+    tags=["Office Hours"],
 )
 def get_oh_tickets_by_event(
-    event_id: int,
+    oh_event_id: int,
     subject: User = Depends(registered_user),
     oh_ticket_service: OfficeHoursTicketService = Depends(),
 ) -> list[OfficeHoursTicketDetails]:
@@ -89,10 +110,10 @@ def get_oh_tickets_by_event(
     Returns:
         list[OfficeHoursTicketDetails]: OH tickets within the given event
     """
-    return oh_ticket_service.get_tickets_by_event(subject, event_id)
+    return oh_ticket_service.get_tickets_by_event(subject, oh_event_id)
 
 
-@api.put("", response_model=OfficeHoursTicketDetails, tags=["Academics"])
+@api.put("", response_model=OfficeHoursTicketDetails, tags=["Office Hours"])
 def update_oh_ticket(
     oh_ticket: OfficeHoursTicket,
     subject: User = Depends(registered_user),
@@ -107,8 +128,7 @@ def update_oh_ticket(
     return oh_ticket_service.update(subject, oh_ticket)
 
 
-# TODO: Please check this api route
-@api.put("/state", response_model=OfficeHoursTicketDetails, tags=["Academics"])
+@api.put("/state", response_model=OfficeHoursTicketDetails, tags=["Office Hours"])
 def update_oh_ticket_state(
     oh_ticket: OfficeHoursTicket,
     subject: User = Depends(registered_user),

--- a/backend/api/office_hours/oh_ticket.py
+++ b/backend/api/office_hours/oh_ticket.py
@@ -4,12 +4,12 @@ This API is used to access OH ticket data for history purposes."""
 
 from fastapi import APIRouter, Depends
 
-from backend.models.office_hours.oh_ticket import (
+from ...models.office_hours.oh_ticket import (
     OfficeHoursTicket,
     OfficeHoursTicketDraft,
 )
-from backend.models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
-from backend.services.office_hours.oh_ticket import OfficeHoursTicketService
+from ...models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
+from ...services.office_hours.oh_ticket import OfficeHoursTicketService
 from ..authentication import registered_user
 from ...models import User
 

--- a/backend/api/office_hours/oh_ticket.py
+++ b/backend/api/office_hours/oh_ticket.py
@@ -113,7 +113,7 @@ def get_oh_tickets_by_event(
     return oh_ticket_service.get_tickets_by_event(subject, oh_event_id)
 
 
-@api.put("", response_model=OfficeHoursTicketDetails, tags=["Office Hours"])
+@api.put("/{ticket_id}", response_model=OfficeHoursTicketDetails, tags=["Office Hours"])
 def update_oh_ticket(
     oh_ticket: OfficeHoursTicket,
     subject: User = Depends(registered_user),
@@ -128,7 +128,7 @@ def update_oh_ticket(
     return oh_ticket_service.update(subject, oh_ticket)
 
 
-@api.put("/state", response_model=OfficeHoursTicketDetails, tags=["Office Hours"])
+@api.put("/state/{id}", response_model=OfficeHoursTicketDetails, tags=["Office Hours"])
 def update_oh_ticket_state(
     oh_ticket: OfficeHoursTicket,
     subject: User = Depends(registered_user),

--- a/backend/api/office_hours/oh_ticket.py
+++ b/backend/api/office_hours/oh_ticket.py
@@ -1,0 +1,114 @@
+"""OH Ticket API
+
+This API is used to access OH ticket data for history purposes."""
+
+from fastapi import APIRouter, Depends
+
+from backend.models.office_hours.oh_ticket import OfficeHoursTicketDraft
+from backend.models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
+from ..authentication import registered_user
+from ...models import User
+
+
+__authors__ = ["Sadie Amato", "Bailey DeSouza"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+
+api = APIRouter(prefix="/api/office-hours/ticket")
+openapi_tags = {
+    "name": "Office Hours",
+    "description": "Office hours ticket functionality",
+}
+
+
+@api.post("", response_model=OfficeHoursTicketDetails, tags=["Office Hours"])
+def new_oh_ticket(
+    oh_ticket: OfficeHoursTicketDraft,
+    subject: User = Depends(registered_user),
+    oh_ticket_service: OfficeHoursTicketService = Depends(),
+) -> OfficeHoursTicketDetails:
+    """
+    Adds a new OH ticket to the database
+
+    Returns:
+        OfficeHoursTicketDetails: OH Ticket created
+    """
+    return oh_ticket_service.create(subject, oh_ticket)
+
+
+@api.get("/{section_id}", response_model=list[OfficeHoursTicketDetails], tags=["Office Hours"])
+def get_oh_tickets_by_section(
+    section_id: int,
+    subject: User = Depends(registered_user),
+    oh_ticket_service: OfficeHoursTicketService = Depends(),
+) -> list[OfficeHoursTicketDetails]:
+    """
+    Gets list of OH tickets by OH section
+
+    Returns:
+        list[OfficeHoursTicketDetails]: OH tickets within the given section
+    """
+    return oh_ticket_service.get_tickets_by_section(subject, section_id)
+
+
+#TODO: check this api route
+@api.get("", response_model=list[OfficeHoursTicketDetails], tags=["Office Hours"])
+def get_oh_tickets_by_section_and_user(
+    section_id: int,
+    subject: User = Depends(registered_user),
+    oh_ticket_service: OfficeHoursTicketService = Depends(),
+) -> list[OfficeHoursTicketDetails]:
+    """
+    Gets list of OH tickets by OH section and user
+
+    Returns:
+        list[OfficeHoursTicketDetails]: OH tickets within the given section and for the specific user
+    """
+    return oh_ticket_service.get_tickets_by_section_and_user(subject, section_id)
+
+
+@api.get("/{event_id}", response_model=list[OfficeHoursTicketDetails], tags=["Office Hours"])
+def get_oh_tickets_by_event(
+    event_id: int,
+    subject: User = Depends(registered_user),
+    oh_ticket_service: OfficeHoursTicketService = Depends(),
+) -> list[OfficeHoursTicketDetails]:
+    """
+    Gets list of OH tickets by OH event
+
+    Returns:
+        list[OfficeHoursTicketDetails]: OH tickets within the given event
+    """
+    return oh_ticket_service.get_tickets_by_section_and_user(subject, event_id)
+
+
+@api.put("", response_model=OfficeHoursTicketDetails, tags=["Academics"])
+def update_oh_ticket(
+    oh_ticket: OfficeHoursTicketDraft,
+    subject: User = Depends(registered_user),
+    oh_ticket_service: OfficeHoursTicketService = Depends(),
+) -> OfficeHoursTicketDetails:
+    """
+    Updates an OfficeHoursTicket to the database
+
+    Returns:
+        OfficeHoursTicketDetails: OH Ticket updated
+    """
+    return oh_ticket_service.update(subject, oh_ticket)
+
+
+#TODO: Please check this api route
+@api.put("/state", response_model=OfficeHoursTicketDetails, tags=["Academics"])
+def update_oh_ticket_state(
+    oh_ticket: OfficeHoursTicketDraft,
+    subject: User = Depends(registered_user),
+    oh_ticket_service: OfficeHoursTicketService = Depends(),
+) -> OfficeHoursTicketDetails:
+    """
+    Updates an OfficeHoursTicket's state in the database
+
+    Returns:
+        OfficeHoursTicketDetails: OH Ticket updated
+    """
+    return oh_ticket_service.update_state(subject, oh_ticket)

--- a/backend/api/office_hours/oh_ticket.py
+++ b/backend/api/office_hours/oh_ticket.py
@@ -4,7 +4,10 @@ This API is used to access OH ticket data for history purposes."""
 
 from fastapi import APIRouter, Depends
 
-from backend.models.office_hours.oh_ticket import OfficeHoursTicketDraft
+from backend.models.office_hours.oh_ticket import (
+    OfficeHoursTicket,
+    OfficeHoursTicketDraft,
+)
 from backend.models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
 from ..authentication import registered_user
 from ...models import User
@@ -37,7 +40,11 @@ def new_oh_ticket(
     return oh_ticket_service.create(subject, oh_ticket)
 
 
-@api.get("/{section_id}", response_model=list[OfficeHoursTicketDetails], tags=["Office Hours"])
+@api.get(
+    "/{section_id}",
+    response_model=list[OfficeHoursTicketDetails],
+    tags=["Office Hours"],
+)
 def get_oh_tickets_by_section(
     section_id: int,
     subject: User = Depends(registered_user),
@@ -52,7 +59,7 @@ def get_oh_tickets_by_section(
     return oh_ticket_service.get_tickets_by_section(subject, section_id)
 
 
-#TODO: check this api route
+# TODO: check this api route
 @api.get("", response_model=list[OfficeHoursTicketDetails], tags=["Office Hours"])
 def get_oh_tickets_by_section_and_user(
     section_id: int,
@@ -68,7 +75,9 @@ def get_oh_tickets_by_section_and_user(
     return oh_ticket_service.get_tickets_by_section_and_user(subject, section_id)
 
 
-@api.get("/{event_id}", response_model=list[OfficeHoursTicketDetails], tags=["Office Hours"])
+@api.get(
+    "/{event_id}", response_model=list[OfficeHoursTicketDetails], tags=["Office Hours"]
+)
 def get_oh_tickets_by_event(
     event_id: int,
     subject: User = Depends(registered_user),
@@ -80,12 +89,12 @@ def get_oh_tickets_by_event(
     Returns:
         list[OfficeHoursTicketDetails]: OH tickets within the given event
     """
-    return oh_ticket_service.get_tickets_by_section_and_user(subject, event_id)
+    return oh_ticket_service.get_tickets_by_event(subject, event_id)
 
 
 @api.put("", response_model=OfficeHoursTicketDetails, tags=["Academics"])
 def update_oh_ticket(
-    oh_ticket: OfficeHoursTicketDraft,
+    oh_ticket: OfficeHoursTicket,
     subject: User = Depends(registered_user),
     oh_ticket_service: OfficeHoursTicketService = Depends(),
 ) -> OfficeHoursTicketDetails:
@@ -98,10 +107,10 @@ def update_oh_ticket(
     return oh_ticket_service.update(subject, oh_ticket)
 
 
-#TODO: Please check this api route
+# TODO: Please check this api route
 @api.put("/state", response_model=OfficeHoursTicketDetails, tags=["Academics"])
 def update_oh_ticket_state(
-    oh_ticket: OfficeHoursTicketDraft,
+    oh_ticket: OfficeHoursTicket,
     subject: User = Depends(registered_user),
     oh_ticket_service: OfficeHoursTicketService = Depends(),
 ) -> OfficeHoursTicketDetails:

--- a/backend/services/office_hours/oh_ticket.py
+++ b/backend/services/office_hours/oh_ticket.py
@@ -1,0 +1,109 @@
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from backend.database import db_session
+from backend.entities.office_hours.oh_ticket_entity import OfficeHoursTicketEntity
+from backend.models.office_hours.oh_ticket import (
+    OfficeHoursTicket,
+    OfficeHoursTicketDraft,
+)
+from backend.models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
+from backend.models.user import User
+
+from backend.services.permission import PermissionService
+
+
+__authors__ = ["Sadie Amato", "Bailey DeSouza"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+
+class OfficeHoursTicketService:
+    """Service that performs all of the actions on the `OfficeHoursTicket` table"""
+
+    def __init__(
+        self,
+        session: Session = Depends(db_session),
+        permission_svc: PermissionService = Depends(),
+    ):
+        """Initializes the database session."""
+        self._session = session
+        self._permission_svc = permission_svc
+
+    def create(
+        self, subject: User, oh_ticket: OfficeHoursTicketDraft
+    ) -> OfficeHoursTicketDetails:
+        """Creates a new office hours ticket.
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_ticket: OfficeHoursTicketDraft to add to table
+        Returns:
+            OfficeHoursTicketDetails: Object added to table
+        """
+        # TODO
+        return None
+
+    def get_tickets_by_section(
+        self, subject: User, section_id: int
+    ) -> list[OfficeHoursTicketDetails]:
+        """Retrieves all office hours tickets from the table by a section.
+        Args:
+            subject: a valid User model representing the currently logged in User
+            section_id: ID of the section to query by.
+        Returns:
+            list[OfficeHoursTicketDetails]: List of all `OfficeHoursTicketDetails` in an OHsection
+        """
+        # TODO
+        return None
+
+    def get_tickets_by_section_and_user(
+        self, subject: User, section_id: int
+    ) -> list[OfficeHoursTicketDetails]:
+        """Retrieves all of the subject's office hours tickets in a section from the table.
+        Args:
+            subject: a valid User model representing the currently logged in User
+            section_id: ID of the section to query by.
+        Returns:
+            list[OfficeHoursTicketDetails]: List of all of a user's `OfficeHoursTicketDetails` in an OHsection
+        """
+        # TODO
+        return None
+
+    def get_tickets_by_event(
+        self, subject: User, event_id: int
+    ) -> list[OfficeHoursTicketDetails]:
+        """Retrieves all office hours tickets in an event from the table.
+        Args:
+            subject: a valid User model representing the currently logged in User
+            event_id: ID of the event to query by.
+        Returns:
+            list[OfficeHoursTicketDetails]: List of all `OfficeHoursTicketDetails` in an OHEvent
+        """
+        # TODO
+        return None
+
+    def update(
+        self, subject: User, oh_ticket: OfficeHoursTicket
+    ) -> OfficeHoursTicketDetails:
+        """Updates an office hours ticket.
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_ticket: OfficeHoursTicket to update in the table
+        Returns:
+            OfficeHoursTicketDetails: Updated object in table
+        """
+        # TODO
+        return None
+
+    def update_state(
+        self, subject: User, oh_ticket: OfficeHoursTicket
+    ) -> OfficeHoursTicketDetails:
+        """Updates an office hours ticket's state.
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_ticket: OfficeHoursTicket to update in the table
+        Returns:
+            OfficeHoursTicketDetails: Updated object in table
+        """
+        # TODO
+        return None

--- a/backend/services/office_hours/oh_ticket.py
+++ b/backend/services/office_hours/oh_ticket.py
@@ -1,16 +1,16 @@
 from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from backend.database import db_session
-from backend.entities.office_hours.oh_ticket_entity import OfficeHoursTicketEntity
-from backend.models.office_hours.oh_ticket import (
+from ...database import db_session
+from ...entities.office_hours.oh_ticket_entity import OfficeHoursTicketEntity
+from ...models.office_hours.oh_ticket import (
     OfficeHoursTicket,
     OfficeHoursTicketDraft,
 )
-from backend.models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
-from backend.models.user import User
+from ...models.office_hours.oh_ticket_details import OfficeHoursTicketDetails
+from ...models.user import User
 
-from backend.services.permission import PermissionService
+from ...services.permission import PermissionService
 
 
 __authors__ = ["Sadie Amato", "Bailey DeSouza"]

--- a/backend/services/office_hours/oh_ticket.py
+++ b/backend/services/office_hours/oh_ticket.py
@@ -43,13 +43,26 @@ class OfficeHoursTicketService:
         # TODO
         return None
 
+    def get_ticket_by_id(
+        self, subject: User, oh_ticket_id: int
+    ) -> OfficeHoursTicketDetails:
+        """Retrieves an office hours ticket from the table by its id.
+        Args:
+            subject: a valid User model representing the currently logged in User
+            oh_ticket_id: ID of the ticket to query by.
+        Returns:
+            OfficeHoursTicketDetails: `OfficeHoursTicketDetails` with the given id
+        """
+        # TODO
+        return None
+
     def get_tickets_by_section(
-        self, subject: User, section_id: int
+        self, subject: User, oh_section_id: int
     ) -> list[OfficeHoursTicketDetails]:
         """Retrieves all office hours tickets from the table by a section.
         Args:
             subject: a valid User model representing the currently logged in User
-            section_id: ID of the section to query by.
+            oh_section_id: ID of the section to query by.
         Returns:
             list[OfficeHoursTicketDetails]: List of all `OfficeHoursTicketDetails` in an OHsection
         """
@@ -57,12 +70,12 @@ class OfficeHoursTicketService:
         return None
 
     def get_tickets_by_section_and_user(
-        self, subject: User, section_id: int
+        self, subject: User, oh_section_id: int
     ) -> list[OfficeHoursTicketDetails]:
         """Retrieves all of the subject's office hours tickets in a section from the table.
         Args:
             subject: a valid User model representing the currently logged in User
-            section_id: ID of the section to query by.
+            oh_section_id: ID of the section to query by.
         Returns:
             list[OfficeHoursTicketDetails]: List of all of a user's `OfficeHoursTicketDetails` in an OHsection
         """
@@ -70,12 +83,12 @@ class OfficeHoursTicketService:
         return None
 
     def get_tickets_by_event(
-        self, subject: User, event_id: int
+        self, subject: User, oh_event_id: int
     ) -> list[OfficeHoursTicketDetails]:
         """Retrieves all office hours tickets in an event from the table.
         Args:
             subject: a valid User model representing the currently logged in User
-            event_id: ID of the event to query by.
+            oh_event_id: ID of the event to query by.
         Returns:
             list[OfficeHoursTicketDetails]: List of all `OfficeHoursTicketDetails` in an OHEvent
         """


### PR DESCRIPTION
### Add OH ticket API and Service skeleton

Add OH ticket API endpoints with new models

- create, update (for students editing), update state, get by section id, get by section id and user, get by event

Add Service files skeleton — func defs + starter thoughts

- all function bodies are WIP/TODO
- changed `update` ticket API route to take in non-draft model, so that the service can use an id from the db
- OHTicketService: create, get tickets by section, get tickets by section and user, get tickets by event, update, & update state
