### PR TITLE
Make User Lookup widget more generic

### DIFF
--- a/frontend/src/app/event/event-editor/event-editor.component.html
+++ b/frontend/src/app/event/event-editor/event-editor.component.html
@@ -2,10 +2,7 @@
 <form
   [formGroup]="eventForm"
   (ngSubmit)="onSubmit()"
-  *ngIf="
-    (adminPermission$ | async) || this.event.is_organizer;
-    else unauthenticated
-  ">
+  *ngIf="enabled$ | async; else unauthenticated">
   <mat-card>
     <!-- Header -->
     <mat-card-header>
@@ -70,9 +67,10 @@
 
       <!-- User Selection / Organizers Form Control -->
       <user-lookup
-        [profile]="this.profile"
-        [users]="this.organizers"
-        [adminPermission]="this.adminPermission$ | async"></user-lookup>
+        label="Organizers"
+        [profile]="profile"
+        [users]="organizers"
+        [disabled]="(enabled$ | async) === false"></user-lookup>
     </mat-card-content>
 
     <!-- Cancel and Save Buttons -->

--- a/frontend/src/app/event/event-editor/event-editor.component.ts
+++ b/frontend/src/app/event/event-editor/event-editor.component.ts
@@ -15,7 +15,7 @@ import { EventService } from '../event.service';
 import { profileResolver } from '../../profile/profile.resolver';
 import { Profile, PublicProfile } from '../../profile/profile.service';
 import { OrganizationService } from '../../organization/organization.service';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 import { eventDetailResolver } from '../event.resolver';
 import { PermissionService } from 'src/app/permission.service';
 import { organizationDetailResolver } from 'src/app/organization/organization.resolver';
@@ -48,7 +48,7 @@ export class EventEditorComponent {
   public profile: Profile | null = null;
 
   /** Stores whether the user has admin permission over the current organization. */
-  public adminPermission$: Observable<boolean>;
+  public enabled$: Observable<boolean>;
 
   /** Store organizers */
   public organizers: PublicProfile[] = [];
@@ -121,11 +121,13 @@ export class EventEditorComponent {
       Validators.min(this.event.registration_count)
     );
 
-    // Set permission value
-    this.adminPermission$ = this.permission.check(
-      'organization.events.update',
-      `organization/${this.organization!.id}`
-    );
+    // Should the edit form be enabled?
+    this.enabled$ = this.permission
+      .check(
+        'organization.events.update',
+        `organization/${this.organization!.id}`
+      )
+      .pipe(map((permission) => permission || this.event.is_organizer));
 
     // Set the organizers
     // If no organizers already, set current user as organizer

--- a/frontend/src/app/shared/user-lookup/user-lookup.widget.html
+++ b/frontend/src/app/shared/user-lookup/user-lookup.widget.html
@@ -1,9 +1,9 @@
 <mat-form-field class="form-field" appearance="outline" color="accent">
-  <mat-label>Organizers</mat-label>
+  <mat-label>{{ this.label }}</mat-label>
   <mat-chip-grid
     #chipGrid
     aria-label="Choose people"
-    [disabled]="!this.adminPermission">
+    [disabled]="this.disabled">
     <mat-chip-row *ngFor="let user of users" (removed)="onUserRemoved(user)">
       <img
         *ngIf="user.github_avatar"
@@ -24,7 +24,10 @@
       [matChipInputFor]="chipGrid"
       matInput
       [matAutocomplete]="auto"
-      [formControl]="userLookup" />
+      [formControl]="userLookup"
+      *ngIf="
+        this.maxSelected === null || this.users.length < this.maxSelected
+      " />
     <mat-autocomplete
       #auto="matAutocomplete"
       (optionSelected)="onUserAdded($event)">

--- a/frontend/src/app/shared/user-lookup/user-lookup.widget.ts
+++ b/frontend/src/app/shared/user-lookup/user-lookup.widget.ts
@@ -27,9 +27,11 @@ import { ProfileService, PublicProfile } from 'src/app/profile/profile.service';
   styleUrls: ['./user-lookup.widget.css']
 })
 export class UserLookup implements OnInit {
-  @Input() profile!: Profile | null;
-  @Input() users!: PublicProfile[];
-  @Input() adminPermission!: boolean | null;
+  @Input() label: string = 'Users';
+  @Input() maxSelected: number | null = null;
+  @Input() profile: Profile | null = null;
+  @Input() users: PublicProfile[] = [];
+  @Input() disabled: boolean | null = false;
 
   userLookup = new FormControl();
 
@@ -49,7 +51,7 @@ export class UserLookup implements OnInit {
   }
 
   ngOnInit() {
-    if (!this.adminPermission) {
+    if (this.disabled) {
       this.userLookup.disable();
     }
   }
@@ -68,7 +70,6 @@ export class UserLookup implements OnInit {
       };
       this.users.push(organizer);
     }
-
     this.usersInput.nativeElement.value = '';
     this.userLookup.setValue('');
   }


### PR DESCRIPTION
The User Lookup widget has a few characteristics that are specific to its initial use in the EventEditorComponent. This PR makes the component more generic and refactors a few minor improvements:

1. Make the control label an input of the control
2. Use a notion of the control being "disabled" rather than have it based on some "adminPermission" which made sense in the context of EventEditorComponent
3. Add an optional `maxSelected` input property which is `null` by default. If set to a number, the control prevents the addition of more users. (My new use case for this widget elsewhere is a select one.)

Since this involved refactoring some of the `event-editor.component.html` file, I made some small improvements there, as well.