### PR TITLE
Restrict room reservations during office hour timeslots

### DIFF
--- a/backend/services/coworking/policy.py
+++ b/backend/services/coworking/policy.py
@@ -2,7 +2,7 @@
 
 from fastapi import Depends
 from sqlalchemy.orm import Session
-from datetime import timedelta
+from datetime import timedelta, datetime, time
 from ...database import db_session
 from ...models import User
 
@@ -10,6 +10,13 @@ __authors__ = ["Kris Jordan"]
 __copyright__ = "Copyright 2023"
 __license__ = "MIT"
 
+MONDAY = 0
+TUESDAY = 1
+WEDNESDAY = 2
+THURSDAY = 3
+FRIDAY = 4
+SATURDAY = 5
+SUNDAY = 6
 
 class PolicyService:
     """RoleService is the access layer to the role data model, its members, and permissions.
@@ -62,3 +69,91 @@ class PolicyService:
     
     def non_reservable_rooms(self) -> list[str]:
         return ['404']
+
+    def office_hours(self, date: datetime):
+        day = date.weekday()
+        if day == MONDAY:
+            return {
+                'SN135' : [
+                    (time(hour=16, minute=30), time(hour=17, minute=00)),
+                    ],
+                'SN137' : [
+                    (time(hour=15, minute=00), time(hour=16, minute=30))
+                ],
+                'SN139' : [],
+                'SN141' : [
+                    (time(hour=16, minute=00), time(hour=17, minute=30))
+                ]
+            }
+        elif day == TUESDAY:
+            return {
+                'SN135' : [
+                    (time(hour=14, minute=30), time(hour=16, minute=00)),
+                    (time(hour=11, minute=00), time(hour=12, minute=00))
+                    ],
+                'SN137' : [],
+                'SN139' : [
+                    (time(hour=10, minute=30), time(hour=11, minute=00)),
+                    (time(hour=11, minute=30), time(hour=13, minute=00)),
+                ],
+                'SN141' : [
+                    (time(hour=10, minute=00), time(hour=11, minute=00))
+                ]
+            }
+        elif day == WEDNESDAY:
+            return {
+                'SN135' : [
+                    (time(hour=11, minute=00), time(hour=12, minute=00))
+                    ],
+                'SN137' : [],
+                'SN139' : [
+                    (time(hour=10, minute=30), time(hour=11, minute=00)),
+                    (time(hour=11, minute=30), time(hour=13, minute=00)),
+                    (time(hour=14, minute=30), time(hour=15, minute=00))
+                ],
+                'SN141' : [
+                    (time(hour=10, minute=00), time(hour=11, minute=00))
+                ]
+            }
+        elif day == THURSDAY:
+            return {
+                'SN135' : [
+                    (time(hour=14, minute=30), time(hour=16, minute=00)),
+                    (time(hour=11, minute=00), time(hour=12, minute=00))
+                    ],
+                'SN137' : [],
+                'SN139' : [
+                    (time(hour=10, minute=30), time(hour=11, minute=00)),
+                    (time(hour=11, minute=30), time(hour=13, minute=00)),
+                    (time(hour=14, minute=30), time(hour=15, minute=00))
+                ],
+                'SN141' : []
+            }
+        elif day == FRIDAY:
+            return {
+                'SN135' : [
+                    (time(hour=11, minute=00), time(hour=12, minute=00))
+                    ],
+                'SN137' : [],
+                'SN139' : [
+                    (time(hour=10, minute=30), time(hour=11, minute=00)),
+                    (time(hour=14, minute=30), time(hour=15, minute=00))
+                ],
+                'SN141' : [
+                    (time(hour=10, minute=00), time(hour=11, minute=00))
+                ]
+            }
+        elif day == SATURDAY:
+            return {
+                'SN135' : [],
+                'SN137' : [],
+                'SN139' : [],
+                'SN141' : []
+            }
+        elif day == SUNDAY:
+            return {
+                'SN135' : [],
+                'SN137' : [],
+                'SN139' : [],
+                'SN141' : []
+            }    

--- a/backend/test/services/coworking/reservation/get_map_current_reservations_test.py
+++ b/backend/test/services/coworking/reservation/get_map_current_reservations_test.py
@@ -131,7 +131,7 @@ def test_get_map_reserved_times_by_date(
     """
     test_time = time[NOW]
     reserved_date_map = reservation_svc.get_map_reserved_times_by_date(
-        test_time, user_data.user
+        test_time + timedelta(days=2), user_data.user
     )
 
     reserved_date_map_root = reservation_svc.get_map_reserved_times_by_date(


### PR DESCRIPTION
## Note:

Please review PR #311 before this one, since this builds off of the changes made in that PR.

## Why?

We need some way to block out the rooms when they are being used for Office Hours. That is, Sally student should not be able to reserve a room during a timeslot when it is being used for office hours.

closes #312 

- This PR addresses this issue by graying out the cells when an office hour might be made.
- The office hours are currently hardcoded in the coworking policy. They should be fairly easy to change, but they would require someone to make changes in the codebase to reflect. I had considered developing a frontend and making a table in the backend to keep track of office hour events. But it looks like the 523 group is already going to be working on this feature. So as a temporary solution to prevent both of us on working on the same thing, I decided to put this in place. Please let me know if you can think of something better.