### PR TITLE
Bug Fix and More Padding!

### DIFF
--- a/frontend/src/app/profile/profile-editor/profile-editor.component.ts
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.ts
@@ -86,7 +86,9 @@ export class ProfileEditorComponent implements OnInit {
           disableClose: true,
           autoFocus: 'dialog'
         });
-        dialogRef.afterClosed().subscribe();
+        dialogRef.afterClosed().subscribe((profile) => {
+          this.profile.accepted_community_agreement = true;
+        });
       }
       this.profileService.put(this.profile).subscribe({
         next: (user) => this.onSuccess(user),

--- a/frontend/src/app/shared/community-agreement/community-agreement.widget.html
+++ b/frontend/src/app/shared/community-agreement/community-agreement.widget.html
@@ -275,7 +275,7 @@
         color: white;
         margin-left: 8px;
         margin-top: 12px;
-        margin-bottom: 30px;
+        margin-bottom: 45px;
       "
       (click)="onButtonClick()">
       {{ has_user_agreed ? 'Close' : 'Accept' }}


### PR DESCRIPTION
- Fixed edge case where a newly registered user would have to re-accept community agreement if they click save profile button after accepting community agreement the first time
- Added more padding to the bottom of accept button in dialog box to ensure that the whole button is visible for all layouts of mobile