### PR TITLE
Get Organization / Event Test Coverage to 100%

### DIFF
--- a/backend/services/exceptions.py
+++ b/backend/services/exceptions.py
@@ -19,13 +19,6 @@ class UserPermissionException(Exception):
         super().__init__(f"Not authorized to perform `{action}` on `{resource}`")
 
 
-class OrganizationNotFoundException(Exception):
-    """OrganizationNotFoundException is raised when trying to access an organization that does not exist."""
-
-    def __init__(self, id: str):
-        super().__init__(f"No organization found matching slug/id: {id}")
-
-
 class EventRegistrationException(Exception):
     """EventRegistrationException is raised when a user attempts to register and cannot (i.e., when the event is full)."""
 

--- a/backend/test/services/event/event_test.py
+++ b/backend/test/services/event/event_test.py
@@ -107,6 +107,15 @@ def test_list(event_svc_integration: EventService):
     assert len(fetched_events.items) == 1
 
 
+def test_list_filter(event_svc_integration: EventService):
+    """Test that a paginated list of events can be produced."""
+    pagination_params = EventPaginationParams(filter="Workshop")
+    fetched_events = event_svc_integration.get_paginated_events(
+        pagination_params, ambassador
+    )
+    assert len(fetched_events.items) == 1
+
+
 def test_list_unauthenticated(event_svc_integration: EventService):
     """Test that a paginated list of events can be produced for unauthenticated users."""
     pagination_params = EventPaginationParams(
@@ -120,6 +129,16 @@ def test_list_unauthenticated(event_svc_integration: EventService):
     )
     fetched_events = event_svc_integration.get_paginated_events(pagination_params)
     assert len(fetched_events.items) == 1
+
+
+def test_get_events_in_time_range(event_svc_integration: EventService):
+    """Test that a list of events can be produced for a valid time range."""
+    range = TimeRange(
+        start=date_maker(days_in_future=1, hour=0, minutes=0),
+        end=date_maker(days_in_future=3, hour=0, minutes=0),
+    )
+    events = event_svc_integration.get_events_in_time_range(range, root)
+    assert len(events) == 3
 
 
 def test_create_enforces_permission(event_svc_integration: EventService):

--- a/backend/test/services/organization/organization_test.py
+++ b/backend/test/services/organization/organization_test.py
@@ -25,6 +25,7 @@ from .organization_test_data import (
     to_add,
     cads,
     new_cads,
+    to_add_conflicting_id,
 )
 from ..user_data import root, user
 
@@ -81,6 +82,17 @@ def test_create_organization_as_root(organization_svc_integration: OrganizationS
     assert created_organization.id is not None
 
 
+def test_create_organization_id_already_exists(
+    organization_svc_integration: OrganizationService,
+):
+    """Test that the root user is able to create new organizations when an extraneous ID is provided."""
+    created_organization = organization_svc_integration.create(
+        root, to_add_conflicting_id
+    )
+    assert created_organization is not None
+    assert created_organization.id is not None
+
+
 def test_create_organization_as_user(organization_svc_integration: OrganizationService):
     """Test that any user is *unable* to create new organizations."""
     with pytest.raises(UserPermissionException):
@@ -106,6 +118,14 @@ def test_update_organization_as_user(organization_svc_integration: OrganizationS
     """Test that any user is *unable* to update new organizations."""
     with pytest.raises(UserPermissionException):
         organization_svc_integration.update(user, new_cads)
+
+
+def test_update_organization_does_not_exist(
+    organization_svc_integration: OrganizationService,
+):
+    """Test updating an organization that does not exist."""
+    with pytest.raises(ResourceNotFoundException):
+        organization_svc_integration.update(root, to_add)
 
 
 def test_delete_enforces_permission(organization_svc_integration: OrganizationService):
@@ -134,3 +154,11 @@ def test_delete_organization_as_user(organization_svc_integration: OrganizationS
     """Test that any user is *unable* to delete organizations."""
     with pytest.raises(UserPermissionException):
         organization_svc_integration.delete(user, cads.slug)
+
+
+def test_delete_organization_does_not_exist(
+    organization_svc_integration: OrganizationService,
+):
+    """Test deleting an organization that does not exist."""
+    with pytest.raises(ResourceNotFoundException):
+        organization_svc_integration.delete(root, to_add.slug)

--- a/backend/test/services/organization/organization_test_data.py
+++ b/backend/test/services/organization/organization_test_data.py
@@ -83,6 +83,23 @@ to_add = Organization(
     public=True,
 )
 
+to_add_conflicting_id = Organization(
+    id=2,
+    name="Android Development Club",
+    shorthand="Android Club",
+    slug="android-club",
+    logo="https://1000logos.net/wp-content/uploads/2016/10/Android-Logo.png",
+    short_description="UNC Chapel Hill's Android development team.",
+    long_description="We make super cool Android apps for the UNC CS department.",
+    website="",
+    email="",
+    instagram="",
+    linked_in="",
+    youtube="",
+    heel_life="",
+    public=True,
+)
+
 new_cads = Organization(
     id=1,
     name="Carolina Analytics & Data Science Club",


### PR DESCRIPTION
This small PR adds more Pytests to get the tests for `OrganizationService` and `EventService` to 100%.

This PR also removes the unused `OrganizationNotFoundException`, which was causing the exceptions to not hit 100% test coverage.