### PR TITLE
Get Academics Test Coverage to 100%

### DIFF
--- a/backend/test/services/academics/section_data.py
+++ b/backend/test/services/academics/section_data.py
@@ -80,6 +80,28 @@ edited_comp_110 = Section(
     override_description="",
 )
 
+edited_comp_110_with_room = Section(
+    id=2,
+    course_id=course_data.comp_110.id,
+    number="002",
+    term_id=term_data.f_23.id,
+    meeting_pattern="MW 1:30PM - 2:45PM",
+    override_title="",
+    override_description="",
+    lecture_room=virtual_room,
+)
+
+edited_comp_301_with_room = Section(
+    id=3,
+    course_id=course_data.comp_301.id,
+    number="001",
+    term_id=term_data.f_23.id,
+    meeting_pattern="TTh 8:00AM - 9:15AM",
+    override_title="",
+    override_description="",
+    lecture_room=virtual_room,
+)
+
 new_section = Section(
     id=4,
     course_id=course_data.comp_110.id,
@@ -88,6 +110,17 @@ new_section = Section(
     meeting_pattern="MW 1:30PM - 2:45PM",
     override_title="",
     override_description="",
+)
+
+new_section_with_lecture_room = Section(
+    id=4,
+    course_id=course_data.comp_110.id,
+    number="003",
+    term_id=term_data.f_23.id,
+    meeting_pattern="MW 1:30PM - 2:45PM",
+    override_title="",
+    override_description="",
+    lecture_room=virtual_room,
 )
 
 ta = SectionMemberEntity(
@@ -107,18 +140,9 @@ room_assignment_110_002 = (
     virtual_room.id,
     RoomAssignmentType.LECTURE_ROOM,
 )
-room_assignment_301_001 = (
-    comp_301_001.id,
-    virtual_room.id,
-    RoomAssignmentType.LECTURE_ROOM,
-)
 
 sections = [comp_101_001, comp_101_002, comp_301_001]
-assignments = [
-    room_assignment_110_001,
-    room_assignment_110_002,
-    room_assignment_301_001,
-]
+assignments = [room_assignment_110_001, room_assignment_110_002]
 comp_110_sections = [comp_101_001, comp_101_002]
 
 

--- a/backend/test/services/academics/section_test.py
+++ b/backend/test/services/academics/section_test.py
@@ -104,6 +104,21 @@ def test_create_as_root(section_svc: SectionService):
     assert section.id == section_data.new_section.id
 
 
+def test_create_with_lecture_room(section_svc: SectionService):
+    permission_svc = create_autospec(PermissionService)
+    section_svc._permission_svc = permission_svc
+
+    section = section_svc.create(
+        user_data.root, section_data.new_section_with_lecture_room
+    )
+
+    permission_svc.enforce.assert_called_with(
+        user_data.root, "academics.section.create", "section/"
+    )
+    assert isinstance(section, SectionDetails)
+    assert section.id == section_data.new_section.id
+
+
 def test_create_as_user(section_svc: SectionService):
     with pytest.raises(UserPermissionException):
         section = section_svc.create(user_data.user, section_data.new_section)
@@ -121,6 +136,34 @@ def test_update_as_root(section_svc: SectionService):
     )
     assert isinstance(section, SectionDetails)
     assert section.id == section_data.edited_comp_110.id
+
+
+def test_update_with_lecture_room_with_previous_assignment(section_svc: SectionService):
+    permission_svc = create_autospec(PermissionService)
+    section_svc._permission_svc = permission_svc
+
+    section = section_svc.update(user_data.root, section_data.edited_comp_110_with_room)
+
+    permission_svc.enforce.assert_called_with(
+        user_data.root, "academics.section.update", f"section/{section.id}"
+    )
+    assert isinstance(section, SectionDetails)
+    assert section.id == section_data.edited_comp_110_with_room.id
+
+
+def test_update_with_lecture_room_without_previous_assignment(
+    section_svc: SectionService,
+):
+    permission_svc = create_autospec(PermissionService)
+    section_svc._permission_svc = permission_svc
+
+    section = section_svc.update(user_data.root, section_data.edited_comp_301_with_room)
+
+    permission_svc.enforce.assert_called_with(
+        user_data.root, "academics.section.update", f"section/{section.id}"
+    )
+    assert isinstance(section, SectionDetails)
+    assert section.id == section_data.edited_comp_301_with_room.id
 
 
 def test_update_as_root_not_found(section_svc: SectionService):


### PR DESCRIPTION
This small PR adds more Pytests to get the tests for `SectionService` in the academics feature to 100% coverage.
