### PR TITLE
Fix Academics Home and Section Dropdown to Use Outlined Style

### DIFF
--- a/frontend/src/app/academics/academics-home/academics-home.component.html
+++ b/frontend/src/app/academics/academics-home/academics-home.component.html
@@ -1,4 +1,4 @@
-<mat-card>
+<mat-card appearance="outlined">
   <mat-card-header>
     <mat-card-title> Computer Science Courses at UNC </mat-card-title>
   </mat-card-header>

--- a/frontend/src/app/academics/section-offerings/section-offerings.component.html
+++ b/frontend/src/app/academics/section-offerings/section-offerings.component.html
@@ -4,7 +4,7 @@
       <mat-card-title
         >{{ displayTerm.value.name }} Course Offerings</mat-card-title
       >
-      <mat-form-field style="margin-left: auto">
+      <mat-form-field style="margin-left: auto" appearance="outline">
         <mat-label>Select Term</mat-label>
         <mat-select [formControl]="displayTerm">
           <mat-option *ngFor="let term of terms" [value]="term">{{


### PR DESCRIPTION
This small PR updates the academics home page card and the section dropdown in the section page to use the Material outlined style.