### PR TITLE
Fix Design of Coworking Hours Button

### DIFF
--- a/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.css
+++ b/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.css
@@ -1,4 +1,6 @@
-.header {
+.mat-mdc-card-header {
+  display: flex;
+  justify-content: space-between;
   padding: 16px;
 }
 
@@ -40,8 +42,4 @@
   display: flex;
   flex-direction: row;
   width: 100%;
-}
-
-#hours-button {
-  margin-left: auto;
 }

--- a/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.html
+++ b/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.html
@@ -6,9 +6,6 @@
       <div class="header-row">
         <span class="badge">Open</span>
         until {{ openOperatingHours!.end | date: 'h:mma' | lowercase }}
-        <button mat-stroked-button id="hours-button" (click)="openDialog()">
-          All Hours
-        </button>
       </div>
     </mat-card-title>
     <ng-template #closed>
@@ -16,5 +13,8 @@
         ><span class="badge">Closed</span></mat-card-title
       >
     </ng-template>
+    <button mat-stroked-button id="hours-button" (click)="openDialog()">
+      All Hours
+    </button>
   </mat-card-header>
 </mat-card>


### PR DESCRIPTION
This small pull request properly right-aligns the "All Hours" button on the coworking home page. In addition, since this information would be valuable off-hours, the button now also appears when the XL is closed.