### PR TITLE
Hot-fix for bug in front-end with desk drop-in prereservations

### DIFF
--- a/backend/services/coworking/policy.py
+++ b/backend/services/coworking/policy.py
@@ -29,7 +29,7 @@ class PolicyService:
 
     def walkin_window(self, _subject: User) -> timedelta:
         """How far into the future can walkins be reserved?"""
-        return timedelta(minutes=30)
+        return timedelta(minutes=10)
 
     def walkin_initial_duration(self, _subject: User) -> timedelta:
         """When making a walkin, this sets how long the initial reservation is for."""

--- a/frontend/src/app/coworking/room-reservation/room-reservation.service.ts
+++ b/frontend/src/app/coworking/room-reservation/room-reservation.service.ts
@@ -31,8 +31,11 @@ export class RoomReservationService extends ReservationService {
     r: Reservation
   ) => {
     let now = new Date();
+    let soon = new Date(
+      Date.now() + 10 /* minutes */ * 60 /* seconds */ * 1000 /* milliseconds */
+    );
     const activeStates = ['CONFIRMED', 'CHECKED_IN'];
-    return r.start <= now && r.end > now && activeStates.includes(r.state);
+    return r.start <= soon && r.end > now && activeStates.includes(r.state);
   };
 
   constructor(http: HttpClient) {

--- a/frontend/src/app/coworking/widgets/dropin-availability-card/dropin-availability-card.widget.ts
+++ b/frontend/src/app/coworking/widgets/dropin-availability-card/dropin-availability-card.widget.ts
@@ -33,18 +33,23 @@ class SeatCategory {
            to server and client sharing the same system clock, but experienced in
            prod on day 0 with many laptops having slightly drifted system clocks. */
     const now = new Date(Date.now() + epsilon);
+    const preReservableAt = new Date(
+      Date.now() + 10 /*minutes*/ * 60 /*seconds*/ * 1000 /*milliseconds*/
+    ); // Currently set by backend/services/coworking/policy.py
     if (seat.availability[0].start <= now) {
       this.seats_available_now.push(seat);
       if (this.seats_available_now.length === 1) {
         this.reservable_now = true;
         this.next_available = seat;
       }
-    } else {
+    } else if (seat.availability[0].start <= preReservableAt) {
       this.seats_available_soon.push(seat);
       if (!this.reservable_now && this.seats_available_soon.length === 1) {
         this.reservable_soon = true;
         this.next_available = seat;
       }
+    } else {
+      // Ignore seats that are not pre-reservable
     }
   }
 


### PR DESCRIPTION
There has been a rarely encountered, but long-standing bug in the front-end of the drop-in UI. The bug was when a group of seats was not reservable except for in the future, we would advertise "reservable in X minutes" but clicking the button would lead to an error (bad reservation request) if the time period was beyond the pre-reservation time window (previously 30 minutes ahead, dropping down to 10 for now).

With the move to room reservations, this bug becomes more common because we are still showing the drop-in seat selection widget when the XL is closed. Pulling the site up ahead of opening, shows a view like this (shown after clicking one of the options): 
<img width="488" alt="Screenshot 2024-03-18 at 8 39 20 AM" src="https://github.com/unc-csxl/csxl.unc.edu/assets/31329/bcfc0246-d5de-4331-b8ad-61c6727eb49e">

This PR prevents the drop-in widget from advertising seats as reservable in the future when outside of the pre-reservation window which is reduced to 10 minutes.

This is only a hot-fix, ultimately the better UX would be to advertise when the seats are next pre-reservable. I'll create a separate issue for that.