### PR TITLE
Refactor logic for graying out timeslots

### DIFF
--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -382,7 +382,9 @@ class ReservationService:
         minutes = dt.minute
 
         if round_up:
-            if minutes < 30:
+            if minutes == 0:
+                to_add = timedelta(minutes=0)
+            elif minutes < 30:
                 to_add = timedelta(minutes=(30 - minutes))
             else:
                 to_add = timedelta(minutes=(60 - minutes))

--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -323,10 +323,12 @@ class ReservationService:
         for room in rooms:
             time_slots_for_room = [0] * operating_hours_duration
 
-            # Making slots up till current time gray
-            if date.date() == current_time.date():
-                for i in range(0, current_time_idx):
-                    time_slots_for_room[i] = RoomState.UNAVAILABLE.value
+            # # Making slots up till current time gray
+            # This code no longer required, but may be required in the future. 
+            # Please keep this here for now.
+            # if date.date() == current_time.date():
+            #     for i in range(0, current_time_idx):
+            #         time_slots_for_room[i] = RoomState.UNAVAILABLE.value
 
             if room.id == "SN156":
                 reservations = self._query_xl_reservations_by_date_for_user(date, subject)

--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -298,8 +298,13 @@ class ReservationService:
             )
 
         # Extract the start time and end time for operating hours rounded to the closest half hour
-        operating_hours_start = self._round_to_closest_half_hour(
-            operating_hours_on_date.start, round_up=True
+        operating_hours_start = max(
+            self._round_to_closest_half_hour(
+                operating_hours_on_date.start, round_up=True
+            ),
+            self._round_to_closest_half_hour(
+                datetime.now(), round_up=False
+            )
         )
         operating_hours_end = self._round_to_closest_half_hour(
             operating_hours_on_date.end, round_up=False

--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -312,7 +312,7 @@ class ReservationService:
         )
 
         # Need current time to gray out slots in the past on that day.
-        current_time = datetime.now()
+        current_time = self._round_to_closest_half_hour(datetime.now())
         current_time_idx = (
             self._idx_calculation(current_time, operating_hours_start) + 1
         )
@@ -519,7 +519,6 @@ class ReservationService:
         Returns:
             Sequence[RoomDetails]: A sequence of RoomDetails models representing all the reservable rooms, excluding room 'SN156'.
         """
-
         rooms = (
             self._session.query(RoomEntity)
             .where(RoomEntity.reservable == True)

--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -312,10 +312,8 @@ class ReservationService:
         )
 
         # Need current time to gray out slots in the past on that day.
-        current_time = self._round_to_closest_half_hour(datetime.now())
-        current_time_idx = (
-            self._idx_calculation(current_time, operating_hours_start) + 1
-        )
+        current_time = datetime.now()
+        current_time_idx = self._idx_calculation(current_time, operating_hours_start)
 
         for room in rooms:
             time_slots_for_room = [0] * operating_hours_duration

--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -360,8 +360,8 @@ class ReservationService:
             reserved_date_map[room.id] = time_slots_for_room
 
         self._transform_date_map_for_unavailable(reserved_date_map)
-        # if "SN156" in reserved_date_map:
-        #     del reserved_date_map["SN156"]
+        if "SN156" in reserved_date_map:
+            del reserved_date_map["SN156"]
         self._transform_date_map_for_officehours(
             date, reserved_date_map, operating_hours_start, operating_hours_duration
         )

--- a/backend/test/services/coworking/reservation/get_map_current_reservations_test.py
+++ b/backend/test/services/coworking/reservation/get_map_current_reservations_test.py
@@ -118,16 +118,25 @@ def test_query_confirmed_reservations_by_date_and_room(
     reservation_svc: ReservationService, time: dict[str, datetime]
 ):
     """Test getting all reservations for a particular date."""
-    reservations = reservation_svc._query_confirmed_reservations_by_date_and_room(time[TOMORROW], 'SN135')
+    reservations = reservation_svc._query_confirmed_reservations_by_date_and_room(time[NOW], None)
     assert True
     #TODO: Add in better assert statements here. 
 
 def test_get_reservable_rooms(reservation_svc: ReservationService):
+    # Hardcoded for now, and this might change depending on which rooms are labeled as reservable.
     rooms = reservation_svc._get_reservable_rooms()
     assert rooms[0].id == 'SN135' and rooms[0].reservable is True
     assert rooms[1].id == 'SN137' and rooms[1].reservable is True
     assert rooms[2].id == 'SN139' and rooms[2].reservable is True
     assert rooms[3].id == 'SN141' and rooms[3].reservable is True
+
+
+def test_query_xl_reservations_by_date_for_user(reservation_svc: ReservationService, time: dict[str, datetime]):
+    reservations = reservation_svc._query_xl_reservations_by_date_for_user(time[NOW], user_data.user)
+    assert len(reservations) == 1
+    assert reservations[0].room is None
+    assert reservations[0].users[0].first_name == 'Sally'
+
 
 def test_get_map_reserved_times_by_date(
     reservation_svc: ReservationService, time: dict[str, datetime]

--- a/backend/test/services/coworking/reservation/get_map_current_reservations_test.py
+++ b/backend/test/services/coworking/reservation/get_map_current_reservations_test.py
@@ -99,13 +99,28 @@ def test_idx_calculation(reservation_svc: ReservationService):
     assert reservation_svc._idx_calculation(time_3, oh_start) == 7
 
 
+def test_round_idx_calculation(reservation_svc: ReservationService):
+    time = datetime.now().replace(hour=10, minute=0)
+    time2 = datetime.now().replace(hour=18, minute=0)
+    time3 = datetime.now().replace(hour=10, minute=1)
+    time4 = datetime.now().replace(hour=18, minute=14)
+    rounded_time = reservation_svc._round_to_closest_half_hour(time, True)
+    rounded_time2 = reservation_svc._round_to_closest_half_hour(time2, False)
+    rounded_time3 = reservation_svc._round_to_closest_half_hour(time3, True)
+    rounded_time4 = reservation_svc._round_to_closest_half_hour(time4, False)
+
+    assert rounded_time.hour == 10 and rounded_time.minute == 0
+    assert rounded_time2.hour == 18 and rounded_time2.minute == 0
+    assert rounded_time3.hour == 10 and rounded_time3.minute == 30
+    assert rounded_time4.hour == 18 and rounded_time4.minute == 0 
+
 def test_query_confirmed_reservations_by_date_and_room(
     reservation_svc: ReservationService, time: dict[str, datetime]
 ):
     """Test getting all reservations for a particular date."""
     reservations = reservation_svc._query_confirmed_reservations_by_date_and_room(time[TOMORROW], 'SN135')
     assert True
-    #TODO: Add in better assert statements here.
+    #TODO: Add in better assert statements here. 
 
 def test_get_reservable_rooms(reservation_svc: ReservationService):
     rooms = reservation_svc._get_reservable_rooms()

--- a/frontend/src/app/coworking/room-reservation/reservation-table.service.ts
+++ b/frontend/src/app/coworking/room-reservation/reservation-table.service.ts
@@ -27,7 +27,7 @@ export class ReservationTableService {
   private profile: Profile | undefined;
   private profileSubscription!: Subscription;
 
-  private EndingOperationalHour: number = 17;
+  private EndingOperationalHour: number = 18;
 
   static readonly MAX_RESERVATION_CELL_LENGTH: number = 4; // rule for how long a reservation can be consecutively
 


### PR DESCRIPTION
This PR closes #340 and makes some progress towards #341 

-  Round down to the nearest half hour instead of rounding up to the nearest half hour when deleting past timeslots.
- Time slots should be grayed out during the time when a person has a drop-in reservation to the XL.
- Addressed the issue with room reservations table starting at 10:30 am rather than 10:00 am. This was a small edge case that I had missed while implementing the `round_to_closest_half_hour()` helper function, i.e. when minute is exactly 0. 
- We are no longer graying out past timeslots anymore and instead just choose to not display them anymore. This was easy to change since the table is now dynamic and no longer static.