### PR TITLE
Fix conflicting room reservations bug

### DIFF
--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -4,7 +4,7 @@ from fastapi import Depends
 from datetime import datetime, timedelta
 from random import random
 from typing import Sequence
-from sqlalchemy import or_
+from sqlalchemy import or_, and_
 from sqlalchemy.orm import Session, joinedload
 from backend.entities.room_entity import RoomEntity
 
@@ -32,7 +32,7 @@ from .policy import PolicyService
 from .operating_hours import OperatingHoursService
 from ..permission import PermissionService
 
-__authors__ = ["Kris Jordan", "Matt Vu","Yuvraj Jain"]
+__authors__ = ["Kris Jordan", "Matt Vu", "Yuvraj Jain"]
 __copyright__ = "Copyright 2023"
 __license__ = "MIT"
 
@@ -272,7 +272,7 @@ class ReservationService:
         """
         reserved_date_map: dict[str, list[int]] = {}
 
-        # Query DB to get reservable rooms. 
+        # Query DB to get reservable rooms.
         rooms = self._get_reservable_rooms()
 
         # Generate a 1 day time range to get operating hours on date.
@@ -302,9 +302,7 @@ class ReservationService:
             self._round_to_closest_half_hour(
                 operating_hours_on_date.start, round_up=True
             ),
-            self._round_to_closest_half_hour(
-                datetime.now(), round_up=False
-            )
+            self._round_to_closest_half_hour(datetime.now(), round_up=False),
         )
         operating_hours_end = self._round_to_closest_half_hour(
             operating_hours_on_date.end, round_up=False
@@ -324,14 +322,16 @@ class ReservationService:
             time_slots_for_room = [0] * operating_hours_duration
 
             # # Making slots up till current time gray
-            # This code no longer required, but may be required in the future. 
+            # This code no longer required, but may be required in the future.
             # Please keep this here for now.
             # if date.date() == current_time.date():
             #     for i in range(0, current_time_idx):
             #         time_slots_for_room[i] = RoomState.UNAVAILABLE.value
 
             if room.id == "SN156":
-                reservations = self._query_xl_reservations_by_date_for_user(date, subject)
+                reservations = self._query_xl_reservations_by_date_for_user(
+                    date, subject
+                )
             else:
                 reservations = self._query_confirmed_reservations_by_date_and_room(
                     date, room.id
@@ -530,7 +530,7 @@ class ReservationService:
                     [ReservationState.CANCELLED, ReservationState.CHECKED_OUT]
                 ),
                 ReservationEntity.room == None,
-                UserEntity.id == subject.id
+                UserEntity.id == subject.id,
             )
             .order_by(ReservationEntity.start)
             .all()
@@ -552,7 +552,7 @@ class ReservationService:
         """
         rooms = (
             self._session.query(RoomEntity)
-            .where(or_(RoomEntity.reservable == True, RoomEntity.id == 'SN156'))
+            .where(or_(RoomEntity.reservable == True, RoomEntity.id == "SN156"))
             .order_by(RoomEntity.id)
             .all()
         )
@@ -838,7 +838,7 @@ class ReservationService:
         #             )
 
         # Look at the seats - match bounds of assigned seat's availability
-        # TODO: Fetch all seats
+        seat_entities = []
         if request.room is None:
             seats: list[Seat] = SeatEntity.get_models_from_identities(
                 self._session, request.seats
@@ -862,9 +862,10 @@ class ReservationService:
             seat_entities = [self._session.get(SeatEntity, seat_availability[0].id)]
             bounds = seat_availability[0].availability[0]
         else:
-            seat_entities = []
-
-        room_id = request.room.id if request.room else None
+            # Prevent double booking a room
+            conflicts = self._fetch_conflicting_room_reservations(request)
+            if len(conflicts) > 0:
+                raise ReservationException("The requested room is no longer available.")
 
         draft = ReservationEntity(
             state=ReservationState.DRAFT,
@@ -872,7 +873,7 @@ class ReservationService:
             end=bounds.end,
             users=user_entities,
             walkin=is_walkin,
-            room_id=room_id,
+            room_id=request.room.id if request.room else None,
             seats=seat_entities,
         )
 
@@ -1149,3 +1150,26 @@ class ReservationService:
             if len(seat.availability) > 0:
                 available_seats.append(seat)
         return available_seats
+
+    def _fetch_conflicting_room_reservations(
+        self, request: ReservationRequest
+    ) -> list[ReservationEntity]:
+        """Given a ReservationRequest, return a list of conflicting reservation entities, if any."""
+        return (
+            self._session.query(ReservationEntity)
+            .filter(
+                and_(
+                    ReservationEntity.start < request.end,
+                    ReservationEntity.end > request.start,
+                ),
+                ReservationEntity.state.in_(
+                    (
+                        ReservationState.DRAFT,
+                        ReservationState.CONFIRMED,
+                        ReservationState.CHECKED_IN,
+                    )
+                ),
+                ReservationEntity.room_id == request.room.id,
+            )
+            .all()
+        )

--- a/backend/services/organization.py
+++ b/backend/services/organization.py
@@ -131,7 +131,11 @@ class OrganizationService:
         )
 
         # Query the organization with matching id
-        obj = self._session.get(OrganizationEntity, organization.id)
+        obj = (
+            self._session.get(OrganizationEntity, organization.id)
+            if organization.id
+            else None
+        )
 
         # Check if result is null
         if obj is None:

--- a/backend/test/services/coworking/reservation/draft_test.py
+++ b/backend/test/services/coworking/reservation/draft_test.py
@@ -144,10 +144,9 @@ def test_draft_reservation_future(reservation_svc: ReservationService):
     start = operating_hours_data.future.start
     end = operating_hours_data.future.start + future_reservation_limit
     reservation = reservation_svc.draft_reservation(
-        user_data.user,
+        user_data.ambassador,
         reservation_data.test_request(
             {
-                "users": [UserIdentity(**user_data.user.model_dump())],
                 "seats": [
                     SeatIdentity(**seat.model_dump())
                     for seat in seat_data.reservable_seats
@@ -192,7 +191,8 @@ def test_draft_reservation_all_closed_seats(reservation_svc: ReservationService)
                         SeatIdentity(
                             **reservation_data.reservation_1.seats[0].model_dump()
                         ),
-                    ]
+                    ],
+                    "end": reservation_data.reservation_1.end + timedelta(minutes=8),
                 }
             ),
         )
@@ -205,7 +205,10 @@ def test_draft_reservation_has_reservation_conflict(
         reservation = reservation_svc.draft_reservation(
             user_data.user,
             reservation_data.test_request(
-                {"users": [UserIdentity(**user_data.user.model_dump())]}
+                {
+                    "users": [UserIdentity(**user_data.user.model_dump())],
+                    "end": datetime.now() + TEN_MINUTES,
+                }
             ),
         )
 

--- a/backend/test/services/coworking/reservation/reservation_data.py
+++ b/backend/test/services/coworking/reservation/reservation_data.py
@@ -46,7 +46,7 @@ def instantiate_global_models(time: dict[str, datetime]):
     reservation_1 = Reservation(
         id=1,
         start=time[THIRTY_MINUTES_AGO],
-        end=time[IN_THIRTY_MINUTES],
+        end=time[IN_TEN_MINUTES],
         created_at=time[THIRTY_MINUTES_AGO],
         updated_at=time[THIRTY_MINUTES_AGO],
         walkin=False,

--- a/backend/test/services/coworking/reservation/seat_availability_test.py
+++ b/backend/test/services/coworking/reservation/seat_availability_test.py
@@ -99,7 +99,7 @@ def test_seat_availability_with_reservation(
     reservation_svc: ReservationService, time: dict[str, datetime]
 ):
     """Test data has one of the reservable seats reserved."""
-    today = TimeRange(start=time[NOW], end=time[IN_THIRTY_MINUTES])
+    today = TimeRange(start=time[NOW], end=time[IN_TEN_MINUTES])
     available_seats = reservation_svc.seat_availability(
         seat_data.reservable_seats, today
     )

--- a/backend/test/services/coworking/time.py
+++ b/backend/test/services/coworking/time.py
@@ -1,4 +1,5 @@
 """Commonly used time constants for testing purposes."""
+
 import pytest
 from datetime import datetime, timedelta
 
@@ -11,6 +12,7 @@ ZERO_TIME = timedelta(0)
 TIME_EPSILON = timedelta(seconds=5)  # Used for testing tolerances
 ONE_MINUTE = timedelta(minutes=1)
 FIVE_MINUTES = timedelta(minutes=5)
+TEN_MINUTES = timedelta(minutes=10)
 THIRTY_MINUTES = timedelta(minutes=30)
 ONE_HOUR = timedelta(hours=1)
 ONE_DAY = timedelta(days=1)
@@ -24,6 +26,7 @@ AN_HOUR_AGO = "AN_HOUR_AGO"
 THIRTY_MINUTES_AGO = "THIRTY_MINUTES_AGO"
 # Future
 MIDNIGHT_TOMORROW = "MIDNIGHT_TOMORROW"
+IN_TEN_MINUTES = "IN_TEN_MINUTES"
 IN_THIRTY_MINUTES = "IN_THIRTY_MINUTES"
 TOMORROW = "TOMORROW"
 IN_ONE_HOUR = "IN_ONE_HOUR"
@@ -58,12 +61,13 @@ def time_data() -> dict[str, datetime]:
         MIDNIGHT_TOMORROW: (now + ONE_DAY).replace(
             hour=0, minute=0, second=0, microsecond=0
         ),
+        IN_TEN_MINUTES: now + TEN_MINUTES,
         IN_THIRTY_MINUTES: now + THIRTY_MINUTES,
         TOMORROW: now + ONE_DAY,
         IN_ONE_HOUR: now + ONE_HOUR,
         IN_TWO_HOURS: now + 2 * ONE_HOUR,
         IN_THREE_HOURS: now + 3 * ONE_HOUR,
-        IN_EIGHT_HOURS: now + 8 * ONE_HOUR
+        IN_EIGHT_HOURS: now + 8 * ONE_HOUR,
     }
 
 


### PR DESCRIPTION
This commit fixes a bug in the backend that permits conflicting room reservations to be made. To avoid the conflict, we check to see if any other existing reservations exist for the room in the given time range. If so, we reject by raising an error. This should generally never arise as the front-end prevents room reservations, however we need to enforce it in the backend, too. Tests are added to correct this.

Some tests were noticed to be broken due to small hotfixes made for production and drop-in reservation limits changed. Additionally, a warning in tests from organization tests was fixed. All tests are passing without warning now.

Finally, this commit makes some minor linting fixes (via `black` formatter).