### PR TITLE
Fix front-end issue with draft drop-in reservation

### DIFF
--- a/frontend/src/app/coworking/room-reservation/room-reservation.service.ts
+++ b/frontend/src/app/coworking/room-reservation/room-reservation.service.ts
@@ -34,7 +34,7 @@ export class RoomReservationService extends ReservationService {
     let soon = new Date(
       Date.now() + 10 /* minutes */ * 60 /* seconds */ * 1000 /* milliseconds */
     );
-    const activeStates = ['CONFIRMED', 'CHECKED_IN'];
+    const activeStates = ['DRAFT', 'CONFIRMED', 'CHECKED_IN'];
     return r.start <= soon && r.end > now && activeStates.includes(r.state);
   };
 


### PR DESCRIPTION
Due to some changes that merged with room reservations, when creating a drop-in reservation and navigating back (intentionally or not) to home you would not see the draft reservation anymore because it was filtered from the home page. This meant a draft reservation was created but could not be cancelled by user or ambassador. This PR fixes this issue by making the draft of a drop-in visible on the home page. No changes in behavior for room reservations.