### PR TITLE
Profile Page Improvements

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -9,13 +9,18 @@ import { AboutComponent } from './about/about.component';
 const routes: Routes = [
   HomeComponent.Route,
   AboutComponent.Route,
-  ProfileEditorComponent.Route,
   GateComponent.Route,
   {
     path: 'coworking',
     title: 'Cowork in the XL',
     loadChildren: () =>
       import('./coworking/coworking.module').then((m) => m.CoworkingModule)
+  },
+  {
+    path: 'profile',
+    title: 'Profile',
+    loadChildren: () =>
+      import('./profile/profile.module').then((m) => m.ProfileModule)
   },
   {
     path: 'academics',

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -50,8 +50,7 @@ import { SharedModule } from './shared/shared.module';
     ErrorDialogComponent,
     HomeComponent,
     AboutComponent,
-    GateComponent,
-    ProfileEditorComponent
+    GateComponent
   ],
   imports: [
     /* Angular */

--- a/frontend/src/app/profile/profile-editor/profile-editor.component.html
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.html
@@ -59,78 +59,10 @@
       </mat-form-field>
     </mat-card-content>
     <mat-card-actions>
+      <button mat-stroked-button routerLink="/profile">CANCEL</button>
       <button mat-stroked-button type="submit" [disabled]="profileForm.invalid">
         Save
       </button>
     </mat-card-actions>
   </mat-card>
 </form>
-
-<mat-card *ngIf="profile.id" appearance="outlined">
-  <div *ngIf="profile.github !== ''; else associate_github">
-    <mat-card-header>
-      <img mat-card-avatar [src]="profile.github_avatar" />
-      <mat-card-title
-        >GitHub /
-        <a
-          id="github_link"
-          href="https://github.com/{{ profile.github }}"
-          target="_blank">
-          {{ profile.github }}
-        </a></mat-card-title
-      >
-    </mat-card-header>
-    <mat-card-actions>
-      <button mat-stroked-button (click)="unlinkGitHub()">Unlink GitHub</button>
-    </mat-card-actions>
-  </div>
-  <ng-template #associate_github>
-    <mat-card-header>
-      <mat-card-title>Link Your GitHub Account</mat-card-title>
-    </mat-card-header>
-    <mat-card-actions>
-      <button mat-stroked-button (click)="linkWithGitHub()">
-        Link with GitHub
-      </button>
-    </mat-card-actions>
-  </ng-template>
-</mat-card>
-
-<mat-card *ngIf="profile.id" appearance="outlined">
-  <mat-card-title style="margin-left: 10px; margin-top: 10px">
-    Community Agreement</mat-card-title
-  >
-  <mat-card-actions class="token">
-    <button
-      class="agreement-button"
-      mat-stroked-button
-      type="button"
-      (click)="openAgreementDialog()">
-      View Agreement
-    </button>
-  </mat-card-actions>
-</mat-card>
-
-<mat-card *ngIf="profile.id" appearance="outlined">
-  <mat-card-actions class="token">
-    <button
-      class="display"
-      mat-stroked-button
-      type="submit"
-      (click)="displayToken()">
-      {{ showToken ? 'Hide Bearer Token' : 'Display Bearer Token' }}
-    </button>
-    <button
-      class="cancel-button"
-      mat-stroked-button
-      type="submit"
-      (click)="copyToken()">
-      Copy
-    </button>
-  </mat-card-actions>
-  <div *ngIf="showToken">
-    <mat-card-content class="token" *ngIf="token">
-      <code>{{ token }}</code></mat-card-content
-    >
-  </div>
-</mat-card>

--- a/frontend/src/app/profile/profile-editor/profile-editor.component.html
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.html
@@ -21,7 +21,7 @@
         <mat-label>First Name</mat-label>
         <input
           matInput
-          placeholder="Jane"
+          placeholder="First Name"
           formControlName="first_name"
           name="first_name"
           required />
@@ -30,7 +30,7 @@
         <mat-label>Last Name</mat-label>
         <input
           matInput
-          placeholder="Doe"
+          placeholder="Last Name"
           formControlName="last_name"
           name="last_name"
           required />
@@ -40,7 +40,7 @@
         <input
           matInput
           type="email"
-          placeholder="jane.doe@unc.edu"
+          placeholder="email@unc.edu"
           formControlName="email"
           name="email"
           required />
@@ -59,7 +59,7 @@
       </mat-form-field>
     </mat-card-content>
     <mat-card-actions>
-      <button mat-stroked-button routerLink="/profile">CANCEL</button>
+      <button mat-stroked-button routerLink="/profile">Cancel</button>
       <button mat-stroked-button type="submit" [disabled]="profileForm.invalid">
         Save
       </button>

--- a/frontend/src/app/profile/profile-editor/profile-editor.component.ts
+++ b/frontend/src/app/profile/profile-editor/profile-editor.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { ActivatedRoute, Route } from '@angular/router';
+import { ActivatedRoute, Route, Router } from '@angular/router';
 import { isAuthenticated } from 'src/app/gate/gate.guard';
 import { profileResolver } from '../profile.resolver';
 import { Profile, ProfileService } from '../profile.service';
@@ -15,7 +15,7 @@ import { MatDialog } from '@angular/material/dialog';
 })
 export class ProfileEditorComponent implements OnInit {
   public static Route: Route = {
-    path: 'profile',
+    path: 'edit',
     component: ProfileEditorComponent,
     title: 'Profile',
     canActivate: [isAuthenticated],
@@ -38,7 +38,8 @@ export class ProfileEditorComponent implements OnInit {
     protected formBuilder: FormBuilder,
     protected profileService: ProfileService,
     protected snackBar: MatSnackBar,
-    protected dialog: MatDialog
+    protected dialog: MatDialog,
+    private router: Router
   ) {
     const form = this.profileForm;
     form.get('first_name')?.addValidators(Validators.required);
@@ -69,15 +70,6 @@ export class ProfileEditorComponent implements OnInit {
     });
   }
 
-  displayToken(): void {
-    this.showToken = !this.showToken;
-  }
-
-  copyToken(): void {
-    navigator.clipboard.writeText(this.token);
-    this.snackBar.open('Token Copied', '', { duration: 2000 });
-  }
-
   onSubmit(): void {
     if (this.profileForm.valid) {
       Object.assign(this.profile, this.profileForm.value);
@@ -98,30 +90,11 @@ export class ProfileEditorComponent implements OnInit {
   }
 
   private onSuccess(profile: Profile) {
+    this.router.navigate(['/profile']);
     this.snackBar.open('Profile Saved', '', { duration: 2000 });
   }
 
   private onError(err: any) {
     console.error('How to handle this?');
-  }
-
-  linkWithGitHub(): void {
-    this.profileService.getGitHubOAuthLoginURL().subscribe((url) => {
-      window.location.href = url;
-    });
-  }
-
-  unlinkGitHub() {
-    this.profileService.unlinkGitHub().subscribe({
-      next: () => (this.profile.github = '')
-    });
-  }
-
-  openAgreementDialog(): void {
-    const dialogRef = this.dialog.open(CommunityAgreement, {
-      autoFocus: 'dialog'
-    });
-    this.profileService.profile$.subscribe();
-    dialogRef.afterClosed().subscribe();
   }
 }

--- a/frontend/src/app/profile/profile-page/profile-page.component.css
+++ b/frontend/src/app/profile/profile-page/profile-page.component.css
@@ -1,0 +1,70 @@
+/** 
+* profile-page.component.css 
+* 
+* The profile page should include basic information about the user, the
+* user's organizations, and the user's past/upcoming events in a simple,
+* easily navigable manner. Major details about events should be
+* expandable so the screen is not overcrowded.
+*
+*/
+
+.mat-mdc-card {
+  margin: 15px 0px !important;
+}
+
+.container {
+  padding-left: 24px;
+  padding-top: 24px;
+  -ms-overflow-style: none;
+  /* Internet Explorer 10+ */
+  scrollbar-width: none;
+  /* Firefox */
+}
+
+.container::-webkit-scrollbar {
+  display: none;
+  /* Safari and Chrome */
+}
+
+.profile-grid {
+  display: grid;
+  grid-template-columns: 480px auto;
+  margin-top: 4px;
+  row-gap: 15px;
+  column-gap: 24px;
+  width: inherit;
+}
+
+.events-card-container {
+  grid-area: span 2;
+}
+
+.token-button {
+  margin-right: 1rem;
+}
+
+.token-text {
+  word-wrap: break-word;
+}
+
+@media (prefers-color-scheme: light) {
+  #github_link {
+    color: black;
+  }
+}
+
+/** Make cards display in one column, with the event card appearing last */
+@media only screen and (max-device-width: 730px) {
+  .profile-grid {
+    display: grid;
+    padding: 24px;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
+    row-gap: 15px;
+    column-gap: 24px;
+  }
+
+  .events-card-container {
+    order: 1;
+  }
+}

--- a/frontend/src/app/profile/profile-page/profile-page.component.css
+++ b/frontend/src/app/profile/profile-page/profile-page.component.css
@@ -56,6 +56,7 @@
 }
 
 .token-text {
+  width: 450px;
   word-wrap: break-word;
 }
 

--- a/frontend/src/app/profile/profile-page/profile-page.component.css
+++ b/frontend/src/app/profile/profile-page/profile-page.component.css
@@ -39,12 +39,17 @@
   grid-area: span 2;
 }
 
-.token-button {
-  margin-right: 1rem;
-}
-
 .token-text {
   word-wrap: break-word;
+}
+
+.profile-management-actions {
+  display: grid;
+  justify-content: center;
+  grid-template-columns: auto auto;
+  column-gap: 20px;
+  row-gap: 10px;
+  margin-bottom: 10px;
 }
 
 @media (prefers-color-scheme: light) {

--- a/frontend/src/app/profile/profile-page/profile-page.component.css
+++ b/frontend/src/app/profile/profile-page/profile-page.component.css
@@ -39,17 +39,31 @@
   grid-area: span 2;
 }
 
+.section-title {
+  font-size: large;
+  font-weight: 500;
+  margin: 16px 0px 5px 0px;
+}
+
+.action-buttons {
+  display: flex;
+  flex-grow: inherit;
+}
+
+.action-button {
+  width: fit-content;
+  margin-right: 10px;
+}
+
 .token-text {
   word-wrap: break-word;
 }
 
 .profile-management-actions {
-  display: grid;
-  justify-content: center;
-  grid-template-columns: auto auto;
-  column-gap: 20px;
-  row-gap: 10px;
-  margin-bottom: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  padding: 0 16px 16px 16px;
 }
 
 @media (prefers-color-scheme: light) {

--- a/frontend/src/app/profile/profile-page/profile-page.component.html
+++ b/frontend/src/app/profile/profile-page/profile-page.component.html
@@ -6,86 +6,63 @@
     <div class="left-column">
       <div class="profile-card-container">
         <profile-about-card [profile]="profile" />
-      </div>
-      <mat-card *ngIf="profile.id" appearance="outlined">
-        <div *ngIf="profile.github !== ''; else associate_github">
+        <mat-card class="profile-management">
           <mat-card-header>
-            <img mat-card-avatar [src]="profile.github_avatar" />
-            <mat-card-title
-              >GitHub /
-              <a
-                id="github_link"
-                href="https://github.com/{{ profile.github }}"
-                target="_blank">
-                {{ profile.github }}
-              </a></mat-card-title
+            <mat-card-title>Profile Actions</mat-card-title>
+          </mat-card-header>
+          <mat-card-actions class="profile-management-actions">
+            <div *ngIf="profile.github !== ''; else associate_github">
+              <button
+                class="token-button"
+                mat-stroked-button
+                (click)="unlinkGitHub()">
+                Unlink GitHub
+              </button>
+            </div>
+            <ng-template #associate_github>
+              <button
+                class="token-button"
+                mat-stroked-button
+                (click)="linkWithGitHub()">
+                Link with GitHub
+              </button>
+            </ng-template>
+            <button
+              class="token-button"
+              mat-stroked-button
+              type="button"
+              (click)="openAgreementDialog()">
+              View Community Agreement
+            </button>
+            <button
+              class="token-button"
+              mat-stroked-button
+              type="submit"
+              (click)="displayToken()">
+              {{ showToken ? 'Hide Bearer Token' : 'Display Bearer Token' }}
+            </button>
+            <button
+              class="token-button"
+              mat-stroked-button
+              type="submit"
+              (click)="copyToken()">
+              Copy Bearer Token
+            </button>
+          </mat-card-actions>
+          <div *ngIf="showToken">
+            <mat-card-content class="token-text" *ngIf="token">
+              <code>{{ token }}</code></mat-card-content
             >
-          </mat-card-header>
-          <mat-card-actions>
-            <button mat-stroked-button (click)="unlinkGitHub()">
-              Unlink GitHub
-            </button>
-          </mat-card-actions>
-        </div>
-        <ng-template #associate_github>
-          <mat-card-header>
-            <mat-card-title>Link Your GitHub Account</mat-card-title>
-          </mat-card-header>
-          <mat-card-actions>
-            <button mat-stroked-button (click)="linkWithGitHub()">
-              Link with GitHub
-            </button>
-          </mat-card-actions>
-        </ng-template>
-      </mat-card>
+          </div>
+        </mat-card>
+      </div>
 
-      <mat-card *ngIf="profile.id" appearance="outlined">
-        <mat-card-header>
-          <mat-card-title>Auth Bearer Token</mat-card-title>
-        </mat-card-header>
-        <mat-card-actions>
-          <button
-            class="token-button"
-            mat-stroked-button
-            type="submit"
-            (click)="displayToken()">
-            {{ showToken ? 'Hide Token' : 'Display Token' }}
-          </button>
-          <button
-            class="token-button"
-            mat-stroked-button
-            type="submit"
-            (click)="copyToken()">
-            Copy
-          </button>
-        </mat-card-actions>
-        <div *ngIf="showToken">
-          <mat-card-content class="token-text" *ngIf="token">
-            <code>{{ token }}</code></mat-card-content
-          >
-        </div>
-      </mat-card>
-      <mat-card *ngIf="profile.id" appearance="outlined">
-        <mat-card-title style="margin-left: 10px; margin-top: 10px">
-          Community Agreement</mat-card-title
-        >
-        <mat-card-actions class="token">
-          <button
-            class="agreement-button"
-            mat-stroked-button
-            type="button"
-            (click)="openAgreementDialog()">
-            View Agreement
-          </button>
-        </mat-card-actions>
-      </mat-card>
-    </div>
-
-    <!-- Event Registrations Card -->
-    <!-- <div class="events-card-container">
+      <!-- Event Registrations Card -->
+      <!-- <div class="events-card-container">
     <profile-events-card
       [events]="events"
       (cancelRegistrationButtonPressedEvent)="cancelRegistration($event)" />
   </div> -->
+    </div>
   </div>
 </div>

--- a/frontend/src/app/profile/profile-page/profile-page.component.html
+++ b/frontend/src/app/profile/profile-page/profile-page.component.html
@@ -62,22 +62,15 @@
                   Copy Bearer Token
                 </button>
               </div>
+              <div class="token-text">
+                <p *ngIf="showToken && token">
+                  <code>{{ token }}</code>
+                </p>
+              </div>
             </div>
           </mat-card-actions>
-          <div *ngIf="showToken">
-            <mat-card-content class="token-text" *ngIf="token">
-              <code>{{ token }}</code></mat-card-content
-            >
-          </div>
         </mat-card>
       </div>
-
-      <!-- Event Registrations Card -->
-      <!-- <div class="events-card-container">
-    <profile-events-card
-      [events]="events"
-      (cancelRegistrationButtonPressedEvent)="cancelRegistration($event)" />
-  </div> -->
     </div>
   </div>
 </div>

--- a/frontend/src/app/profile/profile-page/profile-page.component.html
+++ b/frontend/src/app/profile/profile-page/profile-page.component.html
@@ -11,43 +11,58 @@
             <mat-card-title>Profile Actions</mat-card-title>
           </mat-card-header>
           <mat-card-actions class="profile-management-actions">
-            <div *ngIf="profile.github !== ''; else associate_github">
-              <button
-                class="token-button"
-                mat-stroked-button
-                (click)="unlinkGitHub()">
-                Unlink GitHub
-              </button>
+            <div class="action-section">
+              <p class="section-title">Github</p>
+              <div class="action-buttons">
+                <div *ngIf="profile.github !== ''; else associate_github">
+                  <button
+                    class="action-button"
+                    mat-stroked-button
+                    (click)="unlinkGitHub()">
+                    Unlink GitHub
+                  </button>
+                </div>
+                <ng-template #associate_github>
+                  <button
+                    class="action-button"
+                    mat-stroked-button
+                    (click)="linkWithGitHub()">
+                    Link with GitHub
+                  </button>
+                </ng-template>
+              </div>
             </div>
-            <ng-template #associate_github>
-              <button
-                class="token-button"
-                mat-stroked-button
-                (click)="linkWithGitHub()">
-                Link with GitHub
-              </button>
-            </ng-template>
-            <button
-              class="token-button"
-              mat-stroked-button
-              type="button"
-              (click)="openAgreementDialog()">
-              View Community Agreement
-            </button>
-            <button
-              class="token-button"
-              mat-stroked-button
-              type="submit"
-              (click)="displayToken()">
-              {{ showToken ? 'Hide Bearer Token' : 'Display Bearer Token' }}
-            </button>
-            <button
-              class="token-button"
-              mat-stroked-button
-              type="submit"
-              (click)="copyToken()">
-              Copy Bearer Token
-            </button>
+            <div class="action-section">
+              <p class="section-title">Community Agreement</p>
+              <div class="action-buttons">
+                <button
+                  class="action-button"
+                  mat-stroked-button
+                  type="button"
+                  (click)="openAgreementDialog()">
+                  View Community Agreement
+                </button>
+              </div>
+            </div>
+            <div class="action-section">
+              <p class="section-title">Auth Bearer Token</p>
+              <div class="action-buttons">
+                <button
+                  class="action-button"
+                  mat-stroked-button
+                  type="submit"
+                  (click)="displayToken()">
+                  {{ showToken ? 'Hide Bearer Token' : 'Display Bearer Token' }}
+                </button>
+                <button
+                  class="action-button"
+                  mat-stroked-button
+                  type="submit"
+                  (click)="copyToken()">
+                  Copy Bearer Token
+                </button>
+              </div>
+            </div>
           </mat-card-actions>
           <div *ngIf="showToken">
             <mat-card-content class="token-text" *ngIf="token">

--- a/frontend/src/app/profile/profile-page/profile-page.component.html
+++ b/frontend/src/app/profile/profile-page/profile-page.component.html
@@ -1,0 +1,91 @@
+<!-- HTML Structure of Profile Page -->
+
+<div class="container">
+  <div class="profile-grid">
+    <!-- Profile Information Card -->
+    <div class="left-column">
+      <div class="profile-card-container">
+        <profile-about-card [profile]="profile" />
+      </div>
+      <mat-card *ngIf="profile.id" appearance="outlined">
+        <div *ngIf="profile.github !== ''; else associate_github">
+          <mat-card-header>
+            <img mat-card-avatar [src]="profile.github_avatar" />
+            <mat-card-title
+              >GitHub /
+              <a
+                id="github_link"
+                href="https://github.com/{{ profile.github }}"
+                target="_blank">
+                {{ profile.github }}
+              </a></mat-card-title
+            >
+          </mat-card-header>
+          <mat-card-actions>
+            <button mat-stroked-button (click)="unlinkGitHub()">
+              Unlink GitHub
+            </button>
+          </mat-card-actions>
+        </div>
+        <ng-template #associate_github>
+          <mat-card-header>
+            <mat-card-title>Link Your GitHub Account</mat-card-title>
+          </mat-card-header>
+          <mat-card-actions>
+            <button mat-stroked-button (click)="linkWithGitHub()">
+              Link with GitHub
+            </button>
+          </mat-card-actions>
+        </ng-template>
+      </mat-card>
+
+      <mat-card *ngIf="profile.id" appearance="outlined">
+        <mat-card-header>
+          <mat-card-title>Auth Bearer Token</mat-card-title>
+        </mat-card-header>
+        <mat-card-actions>
+          <button
+            class="token-button"
+            mat-stroked-button
+            type="submit"
+            (click)="displayToken()">
+            {{ showToken ? 'Hide Token' : 'Display Token' }}
+          </button>
+          <button
+            class="token-button"
+            mat-stroked-button
+            type="submit"
+            (click)="copyToken()">
+            Copy
+          </button>
+        </mat-card-actions>
+        <div *ngIf="showToken">
+          <mat-card-content class="token-text" *ngIf="token">
+            <code>{{ token }}</code></mat-card-content
+          >
+        </div>
+      </mat-card>
+      <mat-card *ngIf="profile.id" appearance="outlined">
+        <mat-card-title style="margin-left: 10px; margin-top: 10px">
+          Community Agreement</mat-card-title
+        >
+        <mat-card-actions class="token">
+          <button
+            class="agreement-button"
+            mat-stroked-button
+            type="button"
+            (click)="openAgreementDialog()">
+            View Agreement
+          </button>
+        </mat-card-actions>
+      </mat-card>
+    </div>
+
+    <!-- Event Registrations Card -->
+    <!-- <div class="events-card-container">
+    <profile-events-card
+      [events]="events"
+      (cancelRegistrationButtonPressedEvent)="cancelRegistration($event)" />
+  </div> -->
+  </div>
+</div>

--- a/frontend/src/app/profile/profile-page/profile-page.component.ts
+++ b/frontend/src/app/profile/profile-page/profile-page.component.ts
@@ -1,0 +1,95 @@
+/**
+ * The Profile Page displays information about the user.
+ *
+ * @author Jade Keegan, Aziz Al-Shayef
+ * @copyright 2024
+ * @license MIT
+ */
+
+import { Component } from '@angular/core';
+import { ActivatedRoute, Route, Router } from '@angular/router';
+import { isAuthenticated } from 'src/app/gate/gate.guard';
+import { profileResolver } from '../profile.resolver';
+import { Profile, ProfileService } from '../profile.service';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatDialog } from '@angular/material/dialog';
+import { CommunityAgreement } from 'src/app/shared/community-agreement/community-agreement.widget';
+
+@Component({
+  selector: 'app-profile-page',
+  templateUrl: './profile-page.component.html',
+  styleUrls: ['./profile-page.component.css']
+})
+export class ProfilePageComponent {
+  public static Route: Route = {
+    path: '',
+    component: ProfilePageComponent,
+    title: 'Profile Page',
+    canActivate: [isAuthenticated],
+    resolve: {
+      profile: profileResolver
+    }
+  };
+
+  profile: Profile;
+
+  /** Bearer Token Fields */
+  public token: string;
+  public showToken: boolean = false;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    protected profileService: ProfileService,
+    protected snackBar: MatSnackBar,
+    protected dialog: MatDialog
+  ) {
+    /** Get currently-logged-in user. */
+    const data = this.route.snapshot.data as {
+      profile: Profile;
+    };
+    this.profile = data.profile;
+
+    /** Switch to Profile Editor Page if the user hasn't saved their information yet. */
+    if (this.profile.first_name == '') {
+      this.router.navigate(['/profile/edit']);
+    }
+
+    /** Get bearer token from local storage. */
+    this.token = `${localStorage.getItem('bearerToken')}`;
+  }
+
+  /** Display Bearer Token */
+  displayToken(): void {
+    this.showToken = !this.showToken;
+  }
+
+  /** Copy Bearer Token to Clipboard */
+  copyToken(): void {
+    navigator.clipboard.writeText(this.token);
+    this.snackBar.open('Token Copied', '', { duration: 2000 });
+  }
+
+  /** Go to GitHub authorization page to link account to GH. */
+  linkWithGitHub(): void {
+    this.profileService.getGitHubOAuthLoginURL().subscribe((url) => {
+      window.location.href = url;
+    });
+  }
+
+  /** Remove GitHub connection. */
+  unlinkGitHub() {
+    this.profileService.unlinkGitHub().subscribe({
+      next: () => (this.profile.github = '')
+    });
+  }
+
+  /** Open Community Agreement Dialog */
+  openAgreementDialog(): void {
+    const dialogRef = this.dialog.open(CommunityAgreement, {
+      autoFocus: 'dialog'
+    });
+    this.profileService.profile$.subscribe();
+    dialogRef.afterClosed().subscribe();
+  }
+}

--- a/frontend/src/app/profile/profile-routing.module.ts
+++ b/frontend/src/app/profile/profile-routing.module.ts
@@ -1,0 +1,24 @@
+/**
+ * The Profile Routing Module holds all of the routes that are children
+ * to the path /profile/...
+ *
+ * @author Jade Keegan
+ * @copyright 2023
+ * @license MIT
+ */
+
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { ProfileEditorComponent } from './profile-editor/profile-editor.component';
+import { ProfilePageComponent } from './profile-page/profile-page.component';
+
+const routes: Routes = [
+  ProfileEditorComponent.Route,
+  ProfilePageComponent.Route
+];
+
+@NgModule({
+  imports: [RouterModule.forChild(routes)],
+  exports: [RouterModule]
+})
+export class ProfileRoutingModule {}

--- a/frontend/src/app/profile/profile.module.ts
+++ b/frontend/src/app/profile/profile.module.ts
@@ -1,3 +1,14 @@
+/**
+ * The Prfoile Module couples all features of the Profile Page feature
+ * into a single unit that can be loaded at once. This decreases load time
+ * for the overall application and decouples this feature from other features
+ * in the application.
+ *
+ * @author Jade Keegan
+ * @copyright 2023
+ * @license MIT
+ */
+
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
@@ -17,36 +28,17 @@ import { FormsModule } from '@angular/forms';
 import { ReactiveFormsModule } from '@angular/forms';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatChipsModule } from '@angular/material/chips';
-import { MatCheckboxModule } from '@angular/material/checkbox';
-
-/* UI Widgets */
-import { SocialMediaIcon } from '../shared/social-media-icon/social-media-icon.widget';
-import { SearchBar } from './search-bar/search-bar.widget';
-import { EventCard } from './event-card/event-card.widget';
 import { RouterModule } from '@angular/router';
-import { EventList } from './event-list/event-list.widget';
-import { UserLookup } from './user-lookup/user-lookup.widget';
-import { CommunityAgreement } from './community-agreement/community-agreement.widget';
-
-import { UserChipList } from './user-chip-list/user-chip-list.widget';
-import { ProfileAboutCard } from './profile-about-card/profile-about-card.widget';
+import { SharedModule } from '../shared/shared.module';
+import { ProfilePageComponent } from './profile-page/profile-page.component';
+import { ProfileEditorComponent } from './profile-editor/profile-editor.component';
+import { ProfileRoutingModule } from './profile-routing.module';
 
 @NgModule({
-  declarations: [
-    SocialMediaIcon,
-    SearchBar,
-    EventCard,
-    EventList,
-    UserLookup,
-    UserChipList,
-    CommunityAgreement,
-    ProfileAboutCard
-  ],
+  declarations: [ProfilePageComponent, ProfileEditorComponent],
   imports: [
     CommonModule,
     MatTabsModule,
-    MatChipsModule,
     MatTableModule,
     MatCardModule,
     MatDialogModule,
@@ -57,21 +49,13 @@ import { ProfileAboutCard } from './profile-about-card/profile-about-card.widget
     MatPaginatorModule,
     MatListModule,
     MatAutocompleteModule,
-    MatCheckboxModule,
     FormsModule,
     ReactiveFormsModule,
     MatIconModule,
     MatTooltipModule,
-    RouterModule
-  ],
-  exports: [
-    SocialMediaIcon,
-    SearchBar,
-    EventCard,
-    EventList,
-    UserLookup,
-    UserChipList,
-    ProfileAboutCard
+    ProfileRoutingModule,
+    RouterModule,
+    SharedModule
   ]
 })
-export class SharedModule {}
+export class ProfileModule {}

--- a/frontend/src/app/shared/profile-about-card/profile-about-card.widget.css
+++ b/frontend/src/app/shared/profile-about-card/profile-about-card.widget.css
@@ -48,17 +48,27 @@
   -webkit-box-orient: vertical;
 }
 
+.user-info-label {
+  font-weight: 500;
+  margin-bottom: 0;
+}
+
+.user-info-detail {
+  margin-top: 4px;
+  margin-bottom: 10px;
+}
+
+.contact-info {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
 .mat-mdc-card-avatar {
   margin-bottom: 0 !important;
 }
 
 .mdc-list-group__subheader {
   margin: 0;
-}
-
-.user-info-label {
-  font-weight: 500;
-  margin-bottom: 0;
 }
 
 .mdc-list-item {
@@ -73,8 +83,4 @@
 
 .mat-mdc-list-base {
   padding: 0;
-}
-
-.user-info-detail {
-  margin-top: 4px;
 }

--- a/frontend/src/app/shared/profile-about-card/profile-about-card.widget.css
+++ b/frontend/src/app/shared/profile-about-card/profile-about-card.widget.css
@@ -1,0 +1,80 @@
+.mat-mdc-card {
+  margin: 0 !important;
+  max-width: 100%;
+}
+
+.profile-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.mdc-list-item--with-two-lines .mdc-list-item__primary-text,
+.mdc-list-item--with-three-lines .mdc-list-item__primary-text {
+  margin-bottom: 0;
+}
+
+.left-header-info {
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.user-avatar {
+  min-width: 40px;
+  max-width: 40px;
+  min-height: 40px;
+  max-height: 40px;
+  margin-right: 1rem;
+  margin-top: 0;
+  margin-bottom: 0;
+  background-color: #4786c6;
+  vertical-align: middle;
+  justify-content: center;
+  text-align: center;
+  line-height: 40px;
+  border-radius: 100%;
+}
+
+.user-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  /* number of lines to show */
+  line-clamp: 1;
+  -webkit-box-orient: vertical;
+}
+
+.mat-mdc-card-avatar {
+  margin-bottom: 0 !important;
+}
+
+.mdc-list-group__subheader {
+  margin: 0;
+}
+
+.user-info-label {
+  font-weight: 500;
+  margin-bottom: 0;
+}
+
+.mdc-list-item {
+  padding: 0 !important;
+  display: flex;
+  align-items: baseline;
+}
+
+.mdc-list-group__subheader {
+  margin: 0;
+}
+
+.mat-mdc-list-base {
+  padding: 0;
+}
+
+.user-info-detail {
+  margin-top: 4px;
+}

--- a/frontend/src/app/shared/profile-about-card/profile-about-card.widget.html
+++ b/frontend/src/app/shared/profile-about-card/profile-about-card.widget.html
@@ -29,9 +29,26 @@
 
   <!-- Profile Personal Information -->
   <mat-card-content class="user-info">
-    <p class="user-info-label">Email</p>
-    <p class="user-info-detail">{{ profile.email }}</p>
     <p class="user-info-label">Pronouns</p>
     <p class="user-info-detail">{{ profile.pronouns }}</p>
+
+    <div class="contact-info">
+      <div>
+        <p class="user-info-label">Email</p>
+        <p class="user-info-detail">{{ profile.email }}</p>
+      </div>
+
+      <div>
+        <p *ngIf="profile.github !== ''" class="user-info-label">Github</p>
+        <p *ngIf="profile.github !== ''" class="user-info-detail">
+          <a
+            id="github_link"
+            href="https://github.com/{{ profile.github }}"
+            target="_blank">
+            {{ profile.github }}
+          </a>
+        </p>
+      </div>
+    </div>
   </mat-card-content>
 </mat-card>

--- a/frontend/src/app/shared/profile-about-card/profile-about-card.widget.html
+++ b/frontend/src/app/shared/profile-about-card/profile-about-card.widget.html
@@ -1,0 +1,37 @@
+<mat-card appearance="outlined">
+  <!-- Profile Card Header (Avatar, Name, Edit) -->
+  <mat-card-header class="profile-header">
+    <div class="left-header-info">
+      <!-- Profile Image -->
+      <img
+        *ngIf="profile.github_avatar; else default"
+        matChipAvatar
+        [src]="profile.github_avatar" />
+      <ng-template #default>
+        <p *ngIf="profile.first_name && profile.last_name" class="user-avatar">
+          {{ profile.first_name.charAt(0) }}{{ profile.last_name.charAt(0) }}
+        </p>
+      </ng-template>
+
+      <!-- Username -->
+      <mat-card-title class="user-name"
+        >{{ profile.first_name }} {{ profile.last_name }}</mat-card-title
+      >
+    </div>
+
+    <!-- Button to Open Profile Editor Page -->
+    <a routerLink="/profile/edit">
+      <button mat-icon-button color="basic">
+        <mat-icon>edit</mat-icon>
+      </button>
+    </a>
+  </mat-card-header>
+
+  <!-- Profile Personal Information -->
+  <mat-card-content class="user-info">
+    <p class="user-info-label">Email</p>
+    <p class="user-info-detail">{{ profile.email }}</p>
+    <p class="user-info-label">Pronouns</p>
+    <p class="user-info-detail">{{ profile.pronouns }}</p>
+  </mat-card-content>
+</mat-card>

--- a/frontend/src/app/shared/profile-about-card/profile-about-card.widget.html
+++ b/frontend/src/app/shared/profile-about-card/profile-about-card.widget.html
@@ -45,7 +45,7 @@
             id="github_link"
             href="https://github.com/{{ profile.github }}"
             target="_blank">
-            {{ profile.github }}
+            <span>&#64;</span>{{ profile.github }}
           </a>
         </p>
       </div>

--- a/frontend/src/app/shared/profile-about-card/profile-about-card.widget.ts
+++ b/frontend/src/app/shared/profile-about-card/profile-about-card.widget.ts
@@ -1,0 +1,22 @@
+/**
+ * The Profile About Card displays profile specific information
+ * about a user, such as name, pfp, pronouns, and email.
+ *
+ * @author Jade Keegan
+ * @copyright 2024
+ * @license MIT
+ */
+
+import { Component, Input } from '@angular/core';
+import { Profile } from '../../models.module';
+
+@Component({
+  selector: 'profile-about-card',
+  templateUrl: './profile-about-card.widget.html',
+  styleUrls: ['./profile-about-card.widget.css']
+})
+export class ProfileAboutCard {
+  @Input() profile!: Profile;
+
+  constructor() {}
+}


### PR DESCRIPTION
This PR provides implementation for a dedicated Profile Page for CSXL users instead of the current Profile Editor. Moved from the old `profile-page` branch due to merge conflicts.

# Major Changes
- Created a profile module to contain the new Profile Page and Profile Editor.
- Created a new Profile Page component and associated HTML and CSS files, which includes a button route to the Profile Editor.
- Created a new User Profile Card widget to display a users name, profile picture, email, and pronouns.
- Moved Github Link and Bearer Token to Profile Page and made minor changes to the styling.
- Created a "Profile Actions" card for github link, community agreement, and auth bearer token.

# Developer Concerns
- Want to add a list of user events to the profile page, but would rather get this merged in first as the user event pagination will be quite involved. Further, I want to add a filter to the event pagination by organization as well in the same branch/commit, so would prefer to move that away from "profile page" concerns.