### PR TITLE
357 avoid duplication of polling data in coworking home

### DIFF
--- a/backend/api/coworking/reservation.py
+++ b/backend/api/coworking/reservation.py
@@ -49,20 +49,6 @@ def get_reservation(
     return reservation_svc.get_reservation(subject, id)
 
 
-@api.get("/room-reservations/", tags=["Coworking"])
-def get_all_reservations_by_state(
-    state: ReservationState,
-    subject: User = Depends(registered_user),
-    reservation_svc: ReservationService = Depends(),
-) -> Sequence[Reservation]:
-    try:
-        return reservation_svc.get_current_reservations_for_user(
-            subject=subject, focus=subject, state=state
-        )
-    except Exception as e:
-        raise HTTPException(status_code=404, detail=str(e))
-
-
 @api.put("/reservation/{id}", tags=["Coworking"])
 def update_reservation(
     reservation: ReservationPartial,

--- a/docs/specs/room-reservation.md
+++ b/docs/specs/room-reservation.md
@@ -172,29 +172,7 @@ def _query_confirmed_reservations_by_date(
 
 If you want a deeper understanding of how these functions works, we recommened reading [this section.](#future-developers)
 
-## 3. Route to get all upcoming reservations for a user (deprecated)
-
-We added the following code into the backend API layer:
-
-```py3
-@api.get("/room-reservations/", tags=["Coworking"])
-def get_all_reservations_by_state(
-    state: ReservationState,
-    subject: User = Depends(registered_user),
-    reservation_svc: ReservationService = Depends(),
-) -> Sequence[Reservation]:
-    try:
-        return reservation_svc.get_current_reservations_for_user(
-            subject=subject, focus=subject, state=state
-        )
-    except Exception as e:
-        raise HTTPException(status_code=404, detail=str(e))
-
-```
-
-We needed a way to view all upcoming reservations for a given user so that we can display this information. So we added the following API route into the codebase.
-
-## 4. Route to get timeslots of all reservations for all users
+## 3. Route to get timeslots of all reservations for all users
 
 We needed this endpoint because we needed a way for the user to know which timeslots and rooms have already been booked, so that they could make their selection accordingly. We make sure that we only get the time slots and not any private information like names of users who made the reservations. This is the route we added in the `backend/api/coworking/reservation.py` file.
 

--- a/docs/specs/room-reservation.md
+++ b/docs/specs/room-reservation.md
@@ -172,7 +172,7 @@ def _query_confirmed_reservations_by_date(
 
 If you want a deeper understanding of how these functions works, we recommened reading [this section.](#future-developers)
 
-## 3. Route to get all upcoming reservations for a user
+## 3. Route to get all upcoming reservations for a user (deprecated)
 
 We added the following code into the backend API layer:
 
@@ -319,7 +319,7 @@ This preexisting widget is the method by which reservations are displayed to the
 
 For this feature, the backend primarily focuses on identifying available and reserved rooms, and also displays users' reservations. To understand the backend functionality, it's recommended to follow the outlined path where we move top-down i.e, we start at the API layer and move down to the queries that interact with the persistent storage.
 
-### 1. API Layer
+### 1. API Layer (deprecated)
 
 We recommend by checking out the code present in `backend/api/coworking/reservation.py`. Since this is the first layer that interacts with the frontend, it is the best to understand how the code is working. In this file we added the following routes:
 

--- a/frontend/src/app/coworking/coworking-home/coworking-home.component.html
+++ b/frontend/src/app/coworking/coworking-home/coworking-home.component.html
@@ -56,7 +56,7 @@
           <h2 class="heading">Upcoming Reservations</h2>
         </div>
         <div class="upcoming-reservations-container">
-          <ng-container *ngFor="let r of initUpcomingReservations() | async">
+          <ng-container *ngFor="let r of upcomingReservations$ | async">
             <ng-container *ngIf="r?.room?.id">
               <coworking-reservation-card
                 [reservation]="r"

--- a/frontend/src/app/coworking/coworking-home/coworking-home.component.html
+++ b/frontend/src/app/coworking/coworking-home/coworking-home.component.html
@@ -51,7 +51,7 @@
     <div class="upcoming-card-container">
       <!-- Show upcoming room reservations -->
       <ng-container
-        *ngIf="((initUpcomingReservations() | async) ?? []).length > 0">
+        *ngIf="((upcomingReservations$ | async) ?? []).length > 0">
         <div class="reservations-header">
           <h2 class="heading">Upcoming Reservations</h2>
         </div>

--- a/frontend/src/app/coworking/coworking-home/coworking-home.component.html
+++ b/frontend/src/app/coworking/coworking-home/coworking-home.component.html
@@ -51,12 +51,12 @@
     <div class="upcoming-card-container">
       <!-- Show upcoming room reservations -->
       <ng-container
-        *ngIf="((upcomingRoomReservation$ | async) ?? []).length > 0">
+        *ngIf="((initUpcomingReservations() | async) ?? []).length > 0">
         <div class="reservations-header">
           <h2 class="heading">Upcoming Reservations</h2>
         </div>
         <div class="upcoming-reservations-container">
-          <ng-container *ngFor="let r of upcomingRoomReservation$ | async">
+          <ng-container *ngFor="let r of initUpcomingReservations() | async">
             <ng-container *ngIf="r?.room?.id">
               <coworking-reservation-card
                 [reservation]="r"

--- a/frontend/src/app/coworking/coworking-home/coworking-home.component.ts
+++ b/frontend/src/app/coworking/coworking-home/coworking-home.component.ts
@@ -19,7 +19,15 @@ import {
   Reservation,
   SeatAvailability
 } from '../coworking.models';
-import { Observable, Subscription, map, mergeMap, of, timer, catchError } from 'rxjs';
+import {
+  Observable,
+  Subscription,
+  map,
+  mergeMap,
+  of,
+  timer,
+  catchError
+} from 'rxjs';
 import { RoomReservationService } from '../room-reservation/room-reservation.service';
 import { ReservationService } from '../reservation/reservation.service';
 import { MatDialog } from '@angular/material/dialog';
@@ -69,7 +77,6 @@ export class CoworkingPageComponent implements OnInit, OnDestroy {
     this.isOpen$ = this.initIsOpen();
     this.activeReservation$ = this.initActiveReservation();
     this.upcomingReservations$ = this.initUpcomingReservations();
-
   }
 
   /**
@@ -143,25 +150,33 @@ export class CoworkingPageComponent implements OnInit, OnDestroy {
   }
 
   initUpcomingReservations(): Observable<Reservation[]> {
-    const isUpcomingRoomReservation = (r: Reservation) =>
-      !this.coworkingService.findActiveReservationPredicate(r) && !!r && !!r.room
-      && r.state == 'CONFIRMED';
-  
-    return this.status$
-      .pipe(
-        map((status) => {
-          let reservations = status.my_reservations;
-          return reservations.filter((r) => isUpcomingRoomReservation(r));
-        }),
-        catchError((err: Error) => {
-          const message = 'Error while fetching upcoming reservations.';
-          this.snackBar.open(message, '', { duration: 8000 });
-          console.error(err);
-          return of([]);
-        })
-      );
+    const isUpcomingRoomReservation = (reservation: Reservation) => {
+      if (!this.coworkingService.findActiveReservationPredicate(reservation)) {
+        if (
+          reservation &&
+          reservation.room &&
+          reservation.state === 'CONFIRMED'
+        ) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    return this.status$.pipe(
+      map((status) => {
+        let reservations = status.my_reservations;
+        return reservations.filter(isUpcomingRoomReservation);
+      }),
+      catchError((err: Error) => {
+        const message = 'Error while fetching upcoming reservations.';
+        this.snackBar.open(message, '', { duration: 8000 });
+        console.error(err);
+        return of([]);
+      })
+    );
   }
-  
+
   navigateToNewReservation() {
     this.router.navigateByUrl('/coworking/new-reservation');
   }

--- a/frontend/src/app/coworking/coworking-home/coworking-home.component.ts
+++ b/frontend/src/app/coworking/coworking-home/coworking-home.component.ts
@@ -38,6 +38,8 @@ export class CoworkingPageComponent implements OnInit, OnDestroy {
 
   public activeReservation$: Observable<Reservation | undefined>;
 
+  public upcomingReservations$: Observable<Reservation[] | undefined>;
+
   private timerSubscription!: Subscription;
 
   public upcomingRoomReservation$!: Observable<Reservation[]>;
@@ -66,6 +68,8 @@ export class CoworkingPageComponent implements OnInit, OnDestroy {
     this.openOperatingHours$ = this.initNextOperatingHours();
     this.isOpen$ = this.initIsOpen();
     this.activeReservation$ = this.initActiveReservation();
+    this.upcomingReservations$ = this.initUpcomingReservations();
+
   }
 
   /**

--- a/frontend/src/app/coworking/coworking.service.ts
+++ b/frontend/src/app/coworking/coworking.service.ts
@@ -13,7 +13,8 @@ import {
   ReservationJSON,
   SeatAvailability,
   parseCoworkingStatusJSON,
-  parseReservationJSON
+  parseReservationJSON,
+  Reservation
 } from './coworking.models';
 import { ProfileService } from '../profile/profile.service';
 import { Profile } from '../models.module';
@@ -32,6 +33,17 @@ export class CoworkingService implements OnDestroy {
   private profileSubscription!: Subscription;
 
   isCancelExpanded = new BehaviorSubject<boolean>(false);
+
+  public findActiveReservationPredicate: (r: Reservation) => boolean = (
+    r: Reservation
+  ) => {
+    let now = new Date();
+    let soon = new Date(
+      Date.now() + 10 /* minutes */ * 60 /* seconds */ * 1000 /* milliseconds */
+    );
+    const activeStates = ['DRAFT', 'CONFIRMED', 'CHECKED_IN'];
+    return r.start <= soon && r.end > now && activeStates.includes(r.state);
+  };
 
   public constructor(
     protected http: HttpClient,

--- a/frontend/src/app/coworking/reservation/reservation.service.ts
+++ b/frontend/src/app/coworking/reservation/reservation.service.ts
@@ -58,6 +58,18 @@ export class ReservationService {
     );
   }
 
+  checkin(reservation: Reservation) {
+    let endpoint = `/api/coworking/reservation/${reservation.id}`;
+    let payload = { id: reservation.id, state: 'CHECKED_IN' };
+    return this.http.put<ReservationJSON>(endpoint, payload).pipe(
+      map(parseReservationJSON),
+      tap((reservation) => {
+        let rxReservation = this.getRxReservation(reservation.id);
+        rxReservation.set(reservation);
+      })
+    );
+  }
+
   private getRxReservation(id: number): RxReservation {
     let reservation = this.reservations.get(id);
     if (reservation === undefined) {

--- a/frontend/src/app/coworking/room-reservation/confirm-reservation/confirm-reservation.component.ts
+++ b/frontend/src/app/coworking/room-reservation/confirm-reservation/confirm-reservation.component.ts
@@ -44,7 +44,7 @@ export class ConfirmReservationComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     if (this.isConfirmed) return;
     this.roomReservationService
-      .deleteRoomReservation(this.reservation!)
+      .cancel(this.reservation!)
       .subscribe();
   }
 

--- a/frontend/src/app/coworking/room-reservation/new-reservation-page/new-reservation-page.component.ts
+++ b/frontend/src/app/coworking/room-reservation/new-reservation-page/new-reservation-page.component.ts
@@ -27,7 +27,6 @@ export class NewReservationPageComponent implements OnInit {
     resolve: { profile: profileResolver }
   };
 
-  public upcomingRoomReservations$!: Observable<Reservation[]>;
   public numHoursStudyRoomReservations$!: Observable<string>;
 
   constructor(
@@ -46,7 +45,6 @@ export class NewReservationPageComponent implements OnInit {
    */
 
   ngOnInit() {
-    this.initUpdateReservationsList();
     this.getNumHoursStudyRoomReservations();
   }
 
@@ -54,18 +52,6 @@ export class NewReservationPageComponent implements OnInit {
     this.router.navigateByUrl('/coworking/new-reservation');
   }
 
-  initUpdateReservationsList() {
-    this.upcomingRoomReservations$ = this.roomReservationService
-      .getReservationsByState('CONFIRMED')
-      .pipe(
-        catchError((err) => {
-          const message = 'Error while fetching upcoming reservations.';
-          this.snackBar.open(message, '', { duration: 8000 });
-          console.error(err);
-          return of([]);
-        })
-      );
-  }
   getNumHoursStudyRoomReservations() {
     this.numHoursStudyRoomReservations$ =
       this.roomReservationService.getNumHoursStudyRoomReservations();

--- a/frontend/src/app/coworking/room-reservation/room-reservation.service.ts
+++ b/frontend/src/app/coworking/room-reservation/room-reservation.service.ts
@@ -9,109 +9,24 @@
 
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { catchError, map, Observable, of } from 'rxjs';
+import { map, Observable } from 'rxjs';
 import {
   parseReservationJSON,
   Reservation,
   ReservationJSON
 } from '../coworking.models';
 import { ReservationService } from '../reservation/reservation.service';
-import { MatSnackBar } from '@angular/material/snack-bar';
-import { RxUpcomingReservation } from '../rx-coworking-status';
 
 @Injectable({
   providedIn: 'root'
 })
 export class RoomReservationService extends ReservationService {
-  private upcomingReservations: RxUpcomingReservation =
-    new RxUpcomingReservation();
-  public upcomingReservations$: Observable<Reservation[]> =
-    this.upcomingReservations.value$;
-  public findActiveReservationPredicate: (r: Reservation) => boolean = (
-    r: Reservation
-  ) => {
-    let now = new Date();
-    let soon = new Date(
-      Date.now() + 10 /* minutes */ * 60 /* seconds */ * 1000 /* milliseconds */
-    );
-    const activeStates = ['DRAFT', 'CONFIRMED', 'CHECKED_IN'];
-    return r.start <= soon && r.end > now && activeStates.includes(r.state);
-  };
 
   constructor(http: HttpClient) {
     super(http);
   }
 
-  /** Returns all room reservations from the backend database table using the backend HTTP get request.
-   * @returns {Observable<RoomReservation[]>}
-   */
-
-  getReservationsByState(state: string): Observable<Reservation[]> {
-    // Create HttpParams with the state
-    let params = new HttpParams().set('state', state);
-    return this.http
-      .get<ReservationJSON[]>('/api/coworking/room-reservations/', {
-        params
-      })
-      .pipe(map((reservations) => reservations.map(parseReservationJSON)));
-  }
-
-  checkin(reservation: Reservation): Observable<Reservation> {
-    let endpoint = `/api/coworking/reservation/${reservation.id}`;
-    let payload = { id: reservation.id, state: 'CHECKED_IN' };
-    return this.http
-      .put<ReservationJSON>(endpoint, payload)
-      .pipe(map(parseReservationJSON));
-  }
-
-  deleteRoomReservation(reservation: Reservation): Observable<Reservation> {
-    return this.http.delete<Reservation>(
-      `/api/coworking/reservation/${reservation.id}`
-    );
-  }
-
   getNumHoursStudyRoomReservations(): Observable<string> {
     return this.http.get<string>('/api/coworking/user-reservations/');
-  }
-
-  /**
-   * Polls for upcoming room reservations with a 'CONFIRMED' state that are not currently active.
-   *
-   * This method fetches reservations and filters them to find upcoming reservations based on a specific predicate.
-   * The predicate checks that the reservation is not active and that it has a defined room.
-   * In case of an error while fetching reservations, it displays an error message using `MatSnackBar`.
-   *
-   * @param {MatSnackBar} snackBar - The MatSnackBar service used to display notifications or error messages.
-   *
-   * @example
-   * pollUpcomingRoomReservation(this.snackBar);
-   *
-   * @remarks
-   * This method utilizes RxJS operators to process the stream of reservations. The `map` operator is used to filter
-   * reservations based on the provided predicate. The `catchError` operator handles any errors during the fetching process,
-   * displaying an error message and logging the error to the console.
-   *
-   * @returns {void} - This method does not return a value; it sets the upcoming reservations in a state management variable.
-   */
-  pollUpcomingRoomReservation(snackBar: MatSnackBar) {
-    // predicate to determine if this is a non active upcoming room reservation
-    const isUpcomingRoomReservation = (r: Reservation) =>
-      !this.findActiveReservationPredicate(r) && !!r && !!r.room;
-
-    this.getReservationsByState('CONFIRMED')
-      .pipe(
-        map((reservations) =>
-          reservations.filter((r) => isUpcomingRoomReservation(r))
-        ),
-        catchError((err: Error) => {
-          const message = 'Error while fetching upcoming reservations.';
-          snackBar.open(message, '', { duration: 8000 });
-          console.error(err);
-          return of([]);
-        })
-      )
-      .subscribe((upcomingRoomReservations) =>
-        this.upcomingReservations.set(upcomingRoomReservations)
-      );
   }
 }

--- a/frontend/src/app/coworking/rx-coworking-status.ts
+++ b/frontend/src/app/coworking/rx-coworking-status.ts
@@ -8,5 +8,3 @@ import { RxObject } from '../rx-object';
 import { CoworkingStatus, Reservation } from './coworking.models';
 
 export class RxCoworkingStatus extends RxObject<CoworkingStatus> {}
-
-export class RxUpcomingReservation extends RxObject<Reservation[]> {}

--- a/frontend/src/app/coworking/widgets/coworking-reservation-card/coworking-reservation-card.ts
+++ b/frontend/src/app/coworking/widgets/coworking-reservation-card/coworking-reservation-card.ts
@@ -29,7 +29,7 @@ export class CoworkingReservationCard implements OnInit {
 
   constructor(
     public router: Router,
-    public reservationService: RoomReservationService,
+    public roomReservationService: RoomReservationService,
     protected snackBar: MatSnackBar,
     public coworkingService: CoworkingService
   ) {
@@ -54,7 +54,7 @@ export class CoworkingReservationCard implements OnInit {
   }
 
   cancel() {
-    this.reservationService.deleteRoomReservation(this.reservation).subscribe({
+    this.roomReservationService.cancel(this.reservation).subscribe({
       next: () => {
         this.refreshCoworkingHome();
       },
@@ -71,7 +71,7 @@ export class CoworkingReservationCard implements OnInit {
 
   confirm() {
     this.isConfirmed.emit(true);
-    this.reservationService.confirm(this.reservation).subscribe({
+    this.roomReservationService.confirm(this.reservation).subscribe({
       next: () => {
         this.refreshCoworkingHome();
         // this.router.navigateByUrl('/coworking');
@@ -88,7 +88,7 @@ export class CoworkingReservationCard implements OnInit {
   }
 
   checkout() {
-    this.reservationService.checkout(this.reservation).subscribe({
+    this.roomReservationService.checkout(this.reservation).subscribe({
       next: () => this.refreshCoworkingHome(),
       error: (error: Error) => {
         this.snackBar.open(
@@ -102,7 +102,7 @@ export class CoworkingReservationCard implements OnInit {
   }
 
   checkin(): void {
-    this.reservationService.checkin(this.reservation).subscribe({
+    this.roomReservationService.checkin(this.reservation).subscribe({
       next: () => {
         this.refreshCoworkingHome();
       },


### PR DESCRIPTION
closes #357 

All polling will now take place with the RxObject 'RxCoworkingStatus' to avoid duplicate pulling. 
I also went outside the scope of this branch to refactor how the Room Reservation Service was being utilized and removed duplicate Reservation State Change Methods (like cancel Reservation etc) from this child class in effort to utilize the Reservation Service parent class.


Note:
THe original issue: https://github.com/unc-csxl/csxl.unc.edu/issues/357 mentions 'if there is something missing from the status API endpoint, such as the bound of future reservations is too short (worth checking) then we can fix that.'. I was not sure what this was referring to or how to test if this was an issue. Let me know if this is still worth looking into! 