### PR TITLE
374 active reservations Ambassador View

### DIFF
--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -463,6 +463,8 @@ class ReservationService:
         """
         office_hours = self._policy_svc.office_hours(date=date)
         for room_id, hours in office_hours.items():
+            if room_id not in reserved_date_map:
+                continue
             for start, end in hours:
                 start_idx = max(self._idx_calculation(start, operating_hours_start), 0)
                 end_idx = min(

--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -1037,7 +1037,7 @@ class ReservationService:
             self._session.query(ReservationEntity)
             .join(ReservationEntity.users)
             .filter(
-                ReservationEntity.start >= now - timedelta(minutes=10),
+                ReservationEntity.end > now,
                 ReservationEntity.state.in_(
                     (
                         ReservationState.CONFIRMED,

--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -342,14 +342,9 @@ class ReservationService:
                 )
                 end_idx = self._idx_calculation(reservation.end, operating_hours_start)
 
-                if start_idx < 0 or end_idx > operating_hours_duration:
+                if end_idx < current_time_idx:
                     continue
-
-                # Gray out previous time slots for today only
-                if date.date() == current_time.date():
-                    if end_idx < current_time_idx:
-                        continue
-                    start_idx = max(current_time_idx, start_idx)
+                start_idx = max(current_time_idx, start_idx)
 
                 for idx in range(start_idx, end_idx):
                     # Currently only assuming single user.


### PR DESCRIPTION
# !! Active Reservations for AMBASSADOR VIEW (NOT Coworking)!!
This PR updates the filtering criteria on the backend for getting all reservations for the **AMBASSADOR VIEW** (apologies for the branch name, there was a small misunderstanding). Active reservations used to disappear from the Active section after a certain duration. Now all active reservations show up for their full duration and only disappear until the end time is reached or the student checks out/ is checked out.

Yuvraj has also made the following changes:
Fixed the table to show booked out slots when the start time slot has been dynamically purged from the table. This prevents conflicting reservations.

There was a bug where past reservations would have a start time outside the table due to the table being dynamic. This caused the reservation to not show up at all and let people double book the room for the same timeslot. 

This PR will address that bug and closes #353 