### PR TITLE
Fix bug with end_idx logic for future reservations

### DIFF
--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -342,9 +342,10 @@ class ReservationService:
                 )
                 end_idx = self._idx_calculation(reservation.end, operating_hours_start)
 
-                if end_idx < current_time_idx:
-                    continue
-                start_idx = max(current_time_idx, start_idx)
+                if date.date() == current_time.date():
+                    if end_idx < current_time_idx:
+                        continue
+                    start_idx = max(current_time_idx, start_idx)
 
                 for idx in range(start_idx, end_idx):
                     # Currently only assuming single user.
@@ -394,7 +395,7 @@ class ReservationService:
                 to_add = timedelta(minutes=(60 - minutes))
             rounded_dt = dt + to_add
         else:
-            if minutes > 30:
+            if minutes >= 30:
                 to_subtract = timedelta(minutes=(minutes - 30))
             else:
                 to_subtract = timedelta(minutes=minutes)

--- a/backend/test/services/coworking/reservation/get_map_current_reservations_test.py
+++ b/backend/test/services/coworking/reservation/get_map_current_reservations_test.py
@@ -96,7 +96,7 @@ def test_idx_calculation(reservation_svc: ReservationService):
     assert reservation_svc._idx_calculation(time_2, oh_start) == 5
 
     time_3 = datetime.now().replace(hour=13, minute=40)
-    assert reservation_svc._idx_calculation(time_3, oh_start) == 7
+    assert reservation_svc._idx_calculation(time_3, oh_start) == 7    
 
 
 def test_round_idx_calculation(reservation_svc: ReservationService):
@@ -149,9 +149,18 @@ def test_get_map_reserved_times_by_date(
     the reserved_date_map in the debugger.
     """
     test_time = time[NOW]
-    reserved_date_map = reservation_svc.get_map_reserved_times_by_date(
+    reservation_details = reservation_svc.get_map_reserved_times_by_date(
         test_time + timedelta(days=2), user_data.user
     )
+
+    expected_date_map = {
+        'SN135' : [3, 3, 3, 3, 3],
+        'SN137' : [4, 4, 4, 4, 3],
+        'SN139' : [3, 3, 3, 3, 3],
+        'SN141' : [3, 3, 3, 3, 3]
+    }
+
+    assert reservation_details.reserved_date_map == expected_date_map
 
     reserved_date_map_root = reservation_svc.get_map_reserved_times_by_date(
         test_time, user_data.root


### PR DESCRIPTION
The current problem with the code is that at 11 pm, we were not able to see future reservations in red for tomorrow. This was actually a red herring that led me to look at parts of the code that were not responsible for this.

Then suddenly at 12 am, everything started working as intended. This was the biggest hint for me in debugging this.

Basically on line 345, I just had to add in a condition to check that the date I am getting as a param is the same date as today. Only in that case, should I execute the logic of
end_idx < current_time_idx. However, earlier this was being executed for all reservations which is why whenever we had any reservations which had an end time of less than 11 pm (which most reservations do), our function would just skip over them. This also aligns with what we saw at 12 am when everything seemed to work as intended. This is again because most reservations don't have an ending time before 12 am.

Anyway, took me over 60 minutes to add in these 30 chars to fix the bug. So I typed an average of 0.5 char per minute... :,)

closes #383 