### PR TITLE
Add Reopening Time to OH Panel, Make OH Panel Responsive

### DIFF
--- a/frontend/src/app/coworking/coworking.module.ts
+++ b/frontend/src/app/coworking/coworking.module.ts
@@ -10,7 +10,7 @@ import { CoworkingDropInCard } from './widgets/dropin-availability-card/dropin-a
 import { MatListModule } from '@angular/material/list';
 import {
   CoworkingHoursCard,
-  FirstLetterCapitalPipe
+  OperatingHoursCapitalizationPipe
 } from './widgets/operating-hours-panel/operating-hours-panel.widget';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatTableModule } from '@angular/material/table';
@@ -51,7 +51,7 @@ import { AmbassadorRoomListComponent } from './ambassador-home/ambassador-room/l
     NewReservationPageComponent,
     DateSelector,
     OperatingHoursDialog,
-    FirstLetterCapitalPipe
+    OperatingHoursCapitalizationPipe
   ],
   imports: [
     CommonModule,

--- a/frontend/src/app/coworking/coworking.module.ts
+++ b/frontend/src/app/coworking/coworking.module.ts
@@ -8,7 +8,10 @@ import { MatCardModule } from '@angular/material/card';
 import { CoworkingReservationCard } from './widgets/coworking-reservation-card/coworking-reservation-card';
 import { CoworkingDropInCard } from './widgets/dropin-availability-card/dropin-availability-card.widget';
 import { MatListModule } from '@angular/material/list';
-import { CoworkingHoursCard } from './widgets/operating-hours-panel/operating-hours-panel.widget';
+import {
+  CoworkingHoursCard,
+  FirstLetterCapitalPipe
+} from './widgets/operating-hours-panel/operating-hours-panel.widget';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatTableModule } from '@angular/material/table';
 import { ReservationComponent } from './reservation/reservation.component';
@@ -47,7 +50,8 @@ import { AmbassadorRoomListComponent } from './ambassador-home/ambassador-room/l
     ConfirmReservationComponent,
     NewReservationPageComponent,
     DateSelector,
-    OperatingHoursDialog
+    OperatingHoursDialog,
+    FirstLetterCapitalPipe
   ],
   imports: [
     CommonModule,

--- a/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.css
+++ b/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.css
@@ -23,6 +23,7 @@
   margin-right: 8px;
   padding: 0 16px;
   color: white;
+  width: fit-content;
 }
 
 .open .badge {
@@ -42,4 +43,25 @@
   display: flex;
   flex-direction: row;
   width: 100%;
+}
+
+button {
+  margin-left: auto;
+}
+
+@media only screen and (max-width: 900px) {
+  .header-row {
+    flex-direction: column;
+    align-items: baseline;
+  }
+
+  .mat-mdc-card-title {
+    display: flex;
+    flex-direction: column;
+  }
+
+  button {
+    margin-left: 0;
+  }
+  
 }

--- a/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.html
+++ b/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.html
@@ -16,7 +16,7 @@
             >Reopens
             {{
               operatingHours[0]!.start
-                | date: "EEEE (dd/MM) 'at' h:mma"
+                | date: "EEEE (MM/dd) 'at' h:mma"
                 | firstLetterCapital
             }}</span
           >

--- a/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.html
+++ b/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.html
@@ -13,11 +13,11 @@
         <mat-card-title class="hours-title closed">
           <span class="badge">Closed</span>
           <span *ngIf="operatingHours.length > 0"
-            >Reopens
+            >Open 
             {{
               operatingHours[0]!.start
-                | date: "EEEE (MM/dd) 'at' h:mma"
-                | firstLetterCapital
+                | date: "EEE, MMM d 'at' h:mma"
+                | operatingHoursCapitalizationPipe
             }}</span
           >
         </mat-card-title>

--- a/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.html
+++ b/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.html
@@ -1,20 +1,30 @@
 <mat-card appearance="outlined">
   <mat-card-header class="header">
-    <mat-card-title
-      class="hours-title open"
-      *ngIf="openOperatingHours; else closed">
-      <div class="header-row">
-        <span class="badge">Open</span>
-        until {{ openOperatingHours!.end | date: 'h:mma' | lowercase }}
-      </div>
-    </mat-card-title>
-    <ng-template #closed>
-      <mat-card-title class="hours-title closed"
-        ><span class="badge">Closed</span></mat-card-title
-      >
-    </ng-template>
-    <button mat-stroked-button id="hours-button" (click)="openDialog()">
-      All Hours
-    </button>
+    <div class="header-row">
+      <mat-card-title
+        class="hours-title open"
+        *ngIf="openOperatingHours; else closed">
+        <div class="header-row">
+          <span class="badge">Open</span>
+          until {{ openOperatingHours!.end | date: 'h:mma' | lowercase }}
+        </div>
+      </mat-card-title>
+      <ng-template #closed>
+        <mat-card-title class="hours-title closed">
+          <span class="badge">Closed</span>
+          <span *ngIf="operatingHours.length > 0"
+            >Reopens
+            {{
+              operatingHours[0]!.start
+                | date: "EEEE (dd/MM) 'at' h:mma"
+                | firstLetterCapital
+            }}</span
+          >
+        </mat-card-title>
+      </ng-template>
+      <button mat-stroked-button id="hours-button" (click)="openDialog()">
+        All Hours
+      </button>
+    </div>
   </mat-card-header>
 </mat-card>

--- a/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.ts
+++ b/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.ts
@@ -2,6 +2,7 @@ import { Component, Input } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { OperatingHours } from 'src/app/coworking/coworking.models';
 import { OperatingHoursDialog } from '../operating-hours-dialog/operating-hours-dialog.widget';
+import { Pipe, PipeTransform } from '@angular/core';
 
 @Component({
   selector: 'coworking-operating-hours-panel',
@@ -18,5 +19,16 @@ export class CoworkingHoursCard {
     const dialogRef = this.dialog.open(OperatingHoursDialog, {
       data: this.operatingHours
     });
+  }
+}
+
+/** Local pipe that capitalizes the first letter of the string. */
+@Pipe({
+  name: 'firstLetterCapital'
+})
+export class FirstLetterCapitalPipe implements PipeTransform {
+  transform(sentence: string | null | undefined): string {
+    if (!sentence) return '';
+    return sentence[0].toUpperCase() + sentence.substring(1).toLowerCase();
   }
 }

--- a/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.ts
+++ b/frontend/src/app/coworking/widgets/operating-hours-panel/operating-hours-panel.widget.ts
@@ -24,11 +24,21 @@ export class CoworkingHoursCard {
 
 /** Local pipe that capitalizes the first letter of the string. */
 @Pipe({
-  name: 'firstLetterCapital'
+  name: 'operatingHoursCapitalizationPipe'
 })
-export class FirstLetterCapitalPipe implements PipeTransform {
+export class OperatingHoursCapitalizationPipe implements PipeTransform {
   transform(sentence: string | null | undefined): string {
     if (!sentence) return '';
-    return sentence[0].toUpperCase() + sentence.substring(1).toLowerCase();
+    let newSentence = '';
+    sentence.split(' ').forEach((segment) => {
+      if (segment != 'at') {
+        newSentence +=
+          segment[0].toUpperCase() + segment.substring(1).toLowerCase();
+      } else {
+        newSentence += segment;
+      }
+      newSentence += ' ';
+    });
+    return newSentence.trimEnd();
   }
 }


### PR DESCRIPTION
This pulls request adds reopening time to the Operating Hours Panel in the Coworking page, as well as makes the OH panel responsive on mobile devices. Now, when on mobile, the OH panel becomes a column flex view with proper alignment, rather than a horizontal row flex view.

## Preview on Desktop:

<img width="1424" alt="Screenshot 2024-04-01 at 9 34 04 AM" src="https://github.com/unc-csxl/csxl.unc.edu/assets/17516747/b47c2da8-b4fc-4451-ab53-084922f7199e">

## Preview on Mobile:

<img width="396" alt="Screenshot 2024-04-01 at 9 34 26 AM" src="https://github.com/unc-csxl/csxl.unc.edu/assets/17516747/e643b924-410e-40d0-b5de-5038192875e4">
