### PR TITLE
Change Dockerfile to use yarn instead of npm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM node:18 as build
 COPY ./frontend/package.json /workspace/frontend/package.json
 COPY ./frontend/angular.json /workspace/frontend/angular.json
 WORKDIR /workspace/frontend
-ENV NODE_OPTIONS=--max_old_space_size=8000
-RUN npm install -g @angular/cli && npm install
+RUN npm install -g yarn --force
+RUN yarn global add @angular/cli
+RUN yarn install
 ENV SHELL=/bin/bash
 RUN ng analytics disable
 COPY ./frontend/src /workspace/frontend/src


### PR DESCRIPTION
This PR includes changes to the deployment Dockerfile to use yarn in place of npm during the build stage. This should fix the issue with the old `npm install` command maxing the RAM out and breaking the build.

Closes issue #392 