### PR TITLE
399 add checkin time to avoid cancellation verbiage

### DIFF
--- a/frontend/src/app/coworking/widgets/coworking-reservation-card/coworking-reservation-card.html
+++ b/frontend/src/app/coworking/widgets/coworking-reservation-card/coworking-reservation-card.html
@@ -50,6 +50,10 @@
         >
       </h3>
 
+      <p *ngIf="reservation.state == 'CONFIRMED'">Check-in between {{ reservation.start|date:'shortTime' }} and {{
+        checkinDeadline(reservation.start,reservation.end)|date:'shortTime' }} to avoid cancellation.
+      </p>
+
       <mat-divider></mat-divider>
       <!-- check to see if this is a room reservation -->
       <ng-container *ngIf="reservation.seats.length > 0">

--- a/frontend/src/app/coworking/widgets/coworking-reservation-card/coworking-reservation-card.ts
+++ b/frontend/src/app/coworking/widgets/coworking-reservation-card/coworking-reservation-card.ts
@@ -49,8 +49,8 @@ export class CoworkingReservationCard implements OnInit {
     this.draftConfirmationDeadline$ = this.initDraftConfirmationDeadline();
   }
 
-  checkinDeadline(reservationStart: Date): Date {
-    return new Date(reservationStart.getTime() + 10 * 60 * 1000);
+  checkinDeadline(reservationStart: Date, reservationEnd: Date): Date {
+    return new Date(Math.min(reservationStart.getTime() + 10 * 60 * 1000, reservationEnd.getTime()));
   }
 
   cancel() {


### PR DESCRIPTION
Closes #399 

This is a short PR that will add back the checkin times for confirmed reservations. 
There was also an addition to the "checkinDeadline" method within coworking-card.ts where it makes the checkin deadline deadline the minimum of the start time + 10 and the end of the reservation so the deadline wouldn't display past the reservation's end time.