### PR TITLE
Add Markdown Processing to Event Description (#158)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,8 @@
         "@angular/platform-browser-dynamic": "~15.2.10",
         "@angular/router": "~15.2.10",
         "@auth0/angular-jwt": "~5.1.2",
+        "dompurify": "^3.1.0",
+        "marked": "^12.0.2",
         "rxjs": "~7.8.0",
         "tslib": "~2.3.0",
         "zone.js": "~0.12.0"
@@ -32,6 +34,7 @@
         "@angular-eslint/template-parser": "~15.2.1",
         "@angular/cli": "~15.2.10",
         "@angular/compiler-cli": "~15.2.10",
+        "@types/dompurify": "^3.0.5",
         "@types/jasmine": "~4.3.0",
         "@typescript-eslint/eslint-plugin": "5.48.2",
         "@typescript-eslint/parser": "5.48.2",
@@ -4443,6 +4446,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/dompurify": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/dompurify/-/dompurify-3.0.5.tgz",
+      "integrity": "sha512-1Wg0g3BtQF7sSb27fJQAKck1HECM6zV1EB66j8JH9i3LCjYabJa0FSdiSgsD5K/RbrsR0SiraKacLB+T8ZVYAg==",
+      "dev": true,
+      "dependencies": {
+        "@types/trusted-types": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "8.21.2",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.21.2.tgz",
@@ -4609,6 +4621,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.10",
@@ -6849,6 +6867,11 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.0.tgz",
+      "integrity": "sha512-yoU4rhgPKCo+p5UrWWWNKiIq+ToGqmVVhk0PmMYBK4kRsR3/qhemNFL8f6CFmBd4gMwm3F4T7HBoydP5uY07fA=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -10383,6 +10406,17 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/marked": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-12.0.2.tgz",
+      "integrity": "sha512-qXUm7e/YKFoqFPYPa3Ukg9xlI5cyAtGmyEIzMfW//m6kXwCy2Ps9DYf5ioijFKQ8qyuscrHoY04iJGctu2Kg0Q==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/media-typer": {
       "version": "0.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,8 @@
     "@angular/platform-browser-dynamic": "~15.2.10",
     "@angular/router": "~15.2.10",
     "@auth0/angular-jwt": "~5.1.2",
+    "dompurify": "^3.1.0",
+    "marked": "^12.0.2",
     "rxjs": "~7.8.0",
     "tslib": "~2.3.0",
     "zone.js": "~0.12.0"
@@ -36,6 +38,7 @@
     "@angular-eslint/template-parser": "~15.2.1",
     "@angular/cli": "~15.2.10",
     "@angular/compiler-cli": "~15.2.10",
+    "@types/dompurify": "^3.0.5",
     "@types/jasmine": "~4.3.0",
     "@typescript-eslint/eslint-plugin": "5.48.2",
     "@typescript-eslint/parser": "5.48.2",

--- a/frontend/src/app/event/event-details/event-details.component.html
+++ b/frontend/src/app/event/event-details/event-details.component.html
@@ -1,6 +1,9 @@
 <div class="container">
   <div class="events-grid">
-    <event-detail-card [event]="event" [profile]="this.profile" />
+    <event-detail-card
+      [event]="event"
+      [descriptionHTML]="eventDescriptionHTML"
+      [profile]="this.profile" />
 
     <event-users-list
       *ngIf="(this.adminPermission$ | async) || this.event.is_organizer"

--- a/frontend/src/app/event/event-details/event-details.component.ts
+++ b/frontend/src/app/event/event-details/event-details.component.ts
@@ -19,6 +19,8 @@ import {
 import { Event } from '../event.model';
 import { Observable, of } from 'rxjs';
 import { PermissionService } from 'src/app/permission.service';
+import * as marked from 'marked';
+import * as DOMPurify from 'dompurify';
 
 /** Injects the event's name to adjust the title. */
 let titleResolver: ResolveFn<string> = (route: ActivatedRouteSnapshot) => {
@@ -47,6 +49,7 @@ export class EventDetailsComponent {
 
   /** Store Event */
   public event!: Event;
+  public eventDescriptionHTML: string = '';
 
   /** Store the currently-logged-in user's profile.  */
   public profile: Profile;
@@ -63,6 +66,9 @@ export class EventDetailsComponent {
     };
     this.profile = data.profile;
     this.event = data.event;
+    this.eventDescriptionHTML = DOMPurify.sanitize(
+      marked.parse(this.event.description) as string
+    );
 
     // Admin Permission if has the actual permission or is event organizer
     this.adminPermission$ = this.permission.check(

--- a/frontend/src/app/event/event-editor/event-editor.component.html
+++ b/frontend/src/app/event/event-editor/event-editor.component.html
@@ -10,38 +10,60 @@
       <mat-card-title *ngIf="event.id !== null">Update Event</mat-card-title>
     </mat-card-header>
 
-        <!-- Event Name -->
-        <mat-card-content>
-            <mat-form-field appearance="outline" color="accent">
-                <mat-label>Event Name</mat-label>
-                <input matInput placeholder="New Event" formControlName="name" name="name" required />
-            </mat-form-field>
+    <!-- Event Name -->
+    <mat-card-content>
+      <mat-form-field appearance="outline" color="accent">
+        <mat-label>Event Name</mat-label>
+        <input
+          matInput
+          placeholder="New Event"
+          formControlName="name"
+          name="name"
+          required />
+      </mat-form-field>
 
-            <!-- Start Time -->
-            <mat-form-field appearance="outline" color="accent">
-                <input matInput type="datetime-local" placeholder="Start Time" formControlName="time" name="time"
-                    required />
-            </mat-form-field>
+      <!-- Start Time -->
+      <mat-form-field appearance="outline" color="accent">
+        <input
+          matInput
+          type="datetime-local"
+          placeholder="Start Time"
+          formControlName="time"
+          name="time"
+          required />
+      </mat-form-field>
 
-            <!-- Location -->
-            <mat-form-field appearance="outline" color="accent">
-                <mat-label>Location</mat-label>
-                <input matInput placeholder="The Pit" formControlName="location" name="location" required />
-            </mat-form-field>
+      <!-- Location -->
+      <mat-form-field appearance="outline" color="accent">
+        <mat-label>Location</mat-label>
+        <input
+          matInput
+          placeholder="The Pit"
+          formControlName="location"
+          name="location"
+          required />
+      </mat-form-field>
 
-            <!-- Description -->
-            <mat-form-field appearance="outline" color="accent">
-                <mat-label>Description</mat-label>
-                <textarea matInput placeholder="Event description here." formControlName="description"
-                    name="description"></textarea>
-            </mat-form-field>
+      <!-- Description -->
+      <mat-form-field appearance="outline" color="accent">
+        <mat-label>Description</mat-label>
+        <textarea
+          matInput
+          placeholder="Event description here."
+          formControlName="description"
+          name="description"></textarea>
+      </mat-form-field>
 
-            <!-- Registration Limit -->
-            <mat-form-field appearance="outline" color="accent">
-                <mat-label>Registration Limit</mat-label>
-                <input type="number" matInput placeholder="Registration limit here."
-                    formControlName="registration_limit" name="registration_limit" />
-            </mat-form-field>
+      <!-- Registration Limit -->
+      <mat-form-field appearance="outline" color="accent">
+        <mat-label>Registration Limit</mat-label>
+        <input
+          type="number"
+          matInput
+          placeholder="Registration limit here."
+          formControlName="registration_limit"
+          name="registration_limit" />
+      </mat-form-field>
 
       <!-- User Selection / Organizers Form Control -->
       <user-lookup
@@ -50,20 +72,20 @@
         [disabled]="(enabled$ | async) === false"></user-lookup>
     </mat-card-content>
 
-        <!-- Cancel and Save Buttons -->
-        <mat-card-actions>
-            <button mat-stroked-button type="button" (click)="onCancel()">
-                Cancel
-            </button>
+    <!-- Cancel and Save Buttons -->
+    <mat-card-actions>
+      <button mat-stroked-button type="button" (click)="onCancel()">
+        Cancel
+      </button>
 
-            <button mat-stroked-button type="submit" [disabled]="eventForm.invalid">
-                Save
-            </button>
-        </mat-card-actions>
-    </mat-card>
+      <button mat-stroked-button type="submit" [disabled]="eventForm.invalid">
+        Save
+      </button>
+    </mat-card-actions>
+  </mat-card>
 </form>
 
 <!-- Message for Non-Authenicated Users -->
 <ng-template #unauthenticated>
-    You do not have permission to view this page
+  You do not have permission to view this page
 </ng-template>

--- a/frontend/src/app/event/event-editor/event-editor.component.ts
+++ b/frontend/src/app/event/event-editor/event-editor.component.ts
@@ -20,7 +20,7 @@ import { eventDetailResolver } from '../event.resolver';
 import { PermissionService } from 'src/app/permission.service';
 import { organizationDetailResolver } from 'src/app/organization/organization.resolver';
 import { Organization } from 'src/app/organization/organization.model';
-import { Event, RegistrationType } from '../event.model';
+import { Event } from '../event.model';
 import { DatePipe } from '@angular/common';
 
 @Component({

--- a/frontend/src/app/event/event-page/event-page.component.html
+++ b/frontend/src/app/event/event-page/event-page.component.html
@@ -40,6 +40,7 @@
       <div class="details-column">
         <event-detail-card
           [event]="selectedEvent!"
+          [descriptionHTML]="selectedEventDescriptionHTML!"
           [profile]="this.profile"
           *ngIf="selectedEvent" />
       </div>

--- a/frontend/src/app/event/event-page/event-page.component.ts
+++ b/frontend/src/app/event/event-page/event-page.component.ts
@@ -30,6 +30,8 @@ import {
   filter,
   tap
 } from 'rxjs';
+import * as marked from 'marked';
+import * as DOMPurify from 'dompurify';
 
 @Component({
   selector: 'app-event-page',
@@ -73,6 +75,7 @@ export class EventPageComponent implements OnInit, OnDestroy {
 
   /** Store the selected Event */
   public selectedEvent: Event | null = null;
+  public selectedEventDescriptionHTML: string = '';
 
   /** Store the currently-logged-in user's profile.  */
   public profile: Profile;
@@ -110,6 +113,9 @@ export class EventPageComponent implements OnInit, OnDestroy {
     // Initialize the initially selected event
     if (data.page.items.length > 0) {
       this.selectedEvent = this.page.items[0];
+      this.selectedEventDescriptionHTML = DOMPurify.sanitize(
+        marked.parse(this.selectedEvent.description) as string
+      );
     }
 
     this.searchUpdate
@@ -212,6 +218,9 @@ export class EventPageComponent implements OnInit, OnDestroy {
    */
   onEventCardClicked(event: Event) {
     this.selectedEvent = event;
+    this.selectedEventDescriptionHTML = DOMPurify.sanitize(
+      marked.parse(this.selectedEvent.description) as string
+    );
   }
 
   showEvents(isPrevious: boolean) {

--- a/frontend/src/app/event/widgets/event-detail-card/event-detail-card.widget.css
+++ b/frontend/src/app/event/widgets/event-detail-card/event-detail-card.widget.css
@@ -1,3 +1,7 @@
+a {
+  color: #4786c6;
+}
+
 .event-detail-card {
   padding: 4px 16px;
   margin: 0;

--- a/frontend/src/app/event/widgets/event-detail-card/event-detail-card.widget.html
+++ b/frontend/src/app/event/widgets/event-detail-card/event-detail-card.widget.html
@@ -64,9 +64,7 @@
   <mat-divider class="padded-divider" />
 
   <!-- Description -->
-  <div class="event-description">
-    <p>{{ event.description }}</p>
-  </div>
+  <div class="event-description" [innerHTML]="descriptionHTML"></div>
 
   <!-- Organizers -->
   <div

--- a/frontend/src/app/event/widgets/event-detail-card/event-detail-card.widget.ts
+++ b/frontend/src/app/event/widgets/event-detail-card/event-detail-card.widget.ts
@@ -15,8 +15,6 @@ import { Observable } from 'rxjs';
 import { PermissionService } from 'src/app/permission.service';
 import { Profile } from 'src/app/models.module';
 import { Router } from '@angular/router';
-import * as marked from 'marked';
-import * as DOMPurify from 'dompurify';
 
 @Component({
   selector: 'event-detail-card',
@@ -26,9 +24,10 @@ import * as DOMPurify from 'dompurify';
 export class EventDetailCard implements OnInit {
   /** The event for the event card to display */
   @Input() event!: Event;
+  @Input() descriptionHTML!: string;
   @Input() profile!: Profile;
+
   adminPermission$!: Observable<boolean>;
-  descriptionHTML!: string;
 
   /** Constructs the widget */
   constructor(
@@ -42,11 +41,6 @@ export class EventDetailCard implements OnInit {
     this.adminPermission$ = this.permission.check(
       'organization.events.*',
       `organization/${this.event.organization_id!}`
-    );
-
-    // Convert event description markdown text to HTML for innerHTML.
-    this.descriptionHTML = DOMPurify.sanitize(
-      marked.parse(this.event.description) as string
     );
   }
 

--- a/frontend/src/app/event/widgets/event-detail-card/event-detail-card.widget.ts
+++ b/frontend/src/app/event/widgets/event-detail-card/event-detail-card.widget.ts
@@ -15,6 +15,8 @@ import { Observable } from 'rxjs';
 import { PermissionService } from 'src/app/permission.service';
 import { Profile } from 'src/app/models.module';
 import { Router } from '@angular/router';
+import * as marked from 'marked';
+import * as DOMPurify from 'dompurify';
 
 @Component({
   selector: 'event-detail-card',
@@ -26,6 +28,7 @@ export class EventDetailCard implements OnInit {
   @Input() event!: Event;
   @Input() profile!: Profile;
   adminPermission$!: Observable<boolean>;
+  descriptionHTML!: string;
 
   /** Constructs the widget */
   constructor(
@@ -39,6 +42,11 @@ export class EventDetailCard implements OnInit {
     this.adminPermission$ = this.permission.check(
       'organization.events.*',
       `organization/${this.event.organization_id!}`
+    );
+
+    // Convert event description markdown text to HTML for innerHTML.
+    this.descriptionHTML = DOMPurify.sanitize(
+      marked.parse(this.event.description) as string
     );
   }
 


### PR DESCRIPTION
This PR adds markdown processing to the event descriptions using installed `marked` and `dompurify` modules. `marked` is used to parse the event description and convert it to HTML, while `dompurify` is used to sanitize the produced HTML.

## Developer Concerns
- Should we use `Text` instead of `String` for our event description to allow for more characters in the description? String is restricted to 255 I believe. (Didn't want to make this change yet as (I think) it would require a small migration)
- May need to edit global styles for things to ensure that colors/etc look good still!