### PR TITLE
Fix Broken Academic Tests

### DIFF
--- a/backend/test/services/academics/course_data.py
+++ b/backend/test/services/academics/course_data.py
@@ -75,7 +75,7 @@ new_course = Course(
 )
 
 
-courses = [comp_110, comp_210, comp_211, comp_301, comp_311, new_course]
+courses = [comp_110, comp_210, comp_211, comp_301, comp_311]
 
 
 def insert_fake_data(session: Session):

--- a/backend/test/services/academics/section_data.py
+++ b/backend/test/services/academics/section_data.py
@@ -134,7 +134,7 @@ edited_comp_301_with_room = Section(
 
 new_section = Section(
     id=7,
-    course_id=course_data.new_course.id,
+    course_id=course_data.comp_110.id,
     number="003",
     term_id=term_data.f_23.id,
     meeting_pattern="MW 1:30PM - 2:45PM",
@@ -143,7 +143,7 @@ new_section = Section(
 )
 
 new_section_with_lecture_room = Section(
-    id=4,
+    id=8,
     course_id=course_data.comp_110.id,
     number="003",
     term_id=term_data.f_23.id,
@@ -208,7 +208,6 @@ sections = [
     comp_211_001,
     comp_301_001,
     comp_311_001,
-    new_section,
 ]
 assignments = [
     room_assignment_110_001,
@@ -217,7 +216,6 @@ assignments = [
     room_assignment_211_001,
     room_assignment_301_001,
     room_assignment_311_001,
-    room_assignment_423_001,
 ]
 comp_110_sections = [comp_101_001, comp_101_002]
 

--- a/backend/test/services/academics/section_test.py
+++ b/backend/test/services/academics/section_test.py
@@ -116,7 +116,7 @@ def test_create_with_lecture_room(section_svc: SectionService):
         user_data.root, "academics.section.create", "section/"
     )
     assert isinstance(section, SectionDetails)
-    assert section.id == section_data.new_section.id
+    assert section.id == section_data.new_section_with_lecture_room.id
 
 
 def test_create_as_user(section_svc: SectionService):


### PR DESCRIPTION
Somewhere along the way in one of the recent PRs, the academics tests broke. This PR fixes this by reversing some of the changes done to the academics test data! All tests now pass.

*This PR closes #435*