### PR TITLE
Entirely Revert Academics Testing Changes in TA Applications

### DIFF
--- a/backend/test/services/academics/course_data.py
+++ b/backend/test/services/academics/course_data.py
@@ -29,30 +29,12 @@ comp_210 = Course(
     credit_hours=3,
 )
 
-comp_211 = Course(
-    id="comp211",
-    subject_code="COMP",
-    number="211",
-    title="Systems Fundamentals",
-    description="This is 211",
-    credit_hours=3,
-)
-
 comp_301 = Course(
     id="comp301",
     subject_code="COMP",
     number="301",
     title="Foundations of Programming",
     description="Students will learn how to reason about how their code is structured, identify whether a given structure is effective in a given context, and look at ways of organizing units of code that support larger programs. In a nutshell, the primary goal of the course is to equip students with tools and techniques that will help them not only in later courses in the major but also in their careers afterwards.",
-    credit_hours=3,
-)
-
-comp_311 = Course(
-    id="comp311",
-    subject_code="COMP",
-    number="311",
-    title="Computer Organization",
-    description="This is 311",
     credit_hours=3,
 )
 
@@ -74,8 +56,7 @@ new_course = Course(
     credit_hours=3,
 )
 
-
-courses = [comp_110, comp_210, comp_211, comp_301, comp_311]
+courses = [comp_110, comp_210, comp_301]
 
 
 def insert_fake_data(session: Session):

--- a/backend/test/services/academics/section_data.py
+++ b/backend/test/services/academics/section_data.py
@@ -60,39 +60,9 @@ comp_101_002 = Section(
     override_description="",
 )
 
-comp_210_001 = Section(
-    id=3,
-    course_id=course_data.comp_210.id,
-    number="001",
-    term_id=term_data.f_23.id,
-    meeting_pattern="TTh 8:00AM - 9:15AM",
-    override_title="",
-    override_description="",
-)
-
-comp_211_001 = Section(
-    id=4,
-    course_id=course_data.comp_211.id,
-    number="001",
-    term_id=term_data.f_23.id,
-    meeting_pattern="TTh 8:00AM - 9:15AM",
-    override_title="",
-    override_description="",
-)
-
 comp_301_001 = Section(
-    id=5,
+    id=3,
     course_id=course_data.comp_301.id,
-    number="001",
-    term_id=term_data.f_23.id,
-    meeting_pattern="TTh 8:00AM - 9:15AM",
-    override_title="",
-    override_description="",
-)
-
-comp_311_001 = Section(
-    id=6,
-    course_id=course_data.comp_311.id,
     number="001",
     term_id=term_data.f_23.id,
     meeting_pattern="TTh 8:00AM - 9:15AM",
@@ -133,7 +103,7 @@ edited_comp_301_with_room = Section(
 )
 
 new_section = Section(
-    id=7,
+    id=4,
     course_id=course_data.comp_110.id,
     number="003",
     term_id=term_data.f_23.id,
@@ -143,7 +113,7 @@ new_section = Section(
 )
 
 new_section_with_lecture_room = Section(
-    id=8,
+    id=4,
     course_id=course_data.comp_110.id,
     number="003",
     term_id=term_data.f_23.id,
@@ -171,52 +141,8 @@ room_assignment_110_002 = (
     RoomAssignmentType.LECTURE_ROOM,
 )
 
-room_assignment_210_001 = (
-    comp_210_001.id,
-    virtual_room.id,
-    RoomAssignmentType.LECTURE_ROOM,
-)
-
-room_assignment_211_001 = (
-    comp_211_001.id,
-    virtual_room.id,
-    RoomAssignmentType.LECTURE_ROOM,
-)
-
-room_assignment_301_001 = (
-    comp_301_001.id,
-    virtual_room.id,
-    RoomAssignmentType.LECTURE_ROOM,
-)
-
-room_assignment_311_001 = (
-    comp_311_001.id,
-    virtual_room.id,
-    RoomAssignmentType.LECTURE_ROOM,
-)
-
-room_assignment_423_001 = (
-    new_section.id,
-    virtual_room.id,
-    RoomAssignmentType.LECTURE_ROOM,
-)
-
-sections = [
-    comp_101_001,
-    comp_101_002,
-    comp_210_001,
-    comp_211_001,
-    comp_301_001,
-    comp_311_001,
-]
-assignments = [
-    room_assignment_110_001,
-    room_assignment_110_002,
-    room_assignment_210_001,
-    room_assignment_211_001,
-    room_assignment_301_001,
-    room_assignment_311_001,
-]
+sections = [comp_101_001, comp_101_002, comp_301_001]
+assignments = [room_assignment_110_001, room_assignment_110_002]
 comp_110_sections = [comp_101_001, comp_101_002]
 
 

--- a/backend/test/services/academics/section_test.py
+++ b/backend/test/services/academics/section_test.py
@@ -116,7 +116,7 @@ def test_create_with_lecture_room(section_svc: SectionService):
         user_data.root, "academics.section.create", "section/"
     )
     assert isinstance(section, SectionDetails)
-    assert section.id == section_data.new_section_with_lecture_room.id
+    assert section.id == section_data.new_section.id
 
 
 def test_create_as_user(section_svc: SectionService):


### PR DESCRIPTION
This PR entirely reverts all of the testing changes made in the TA Applications feature merge, as these changes broke the tests and also reduced testing coverage. The academics feature is now at 100% coverage and all tests pass.

*This PR closes #438*