### PR TITLE
Create COMP 423 Project Showcase Page

### DIFF
--- a/backend/api/showcase.py
+++ b/backend/api/showcase.py
@@ -1,0 +1,40 @@
+"""423 Showcase API
+
+API Route used to supply data for the 423 project showcase.
+
+"""
+
+from fastapi import APIRouter, Depends
+
+from ..services import ShowcaseService
+from ..api.authentication import registered_user
+from ..models.user import User
+from ..models.showcase_project import ShowcaseProject
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+api = APIRouter(prefix="/api/showcase")
+openapi_tags = {
+    "name": "COMP 423 Showcase",
+    "description": "Showcasing the amazing projects created by COMP 423 students!",
+}
+
+
+@api.get("", response_model=list[ShowcaseProject], tags=["COMP 423 Showcase"])
+def get_projects(
+    subject: User = Depends(registered_user),
+    showcase_service: ShowcaseService = Depends(),
+) -> list[ShowcaseProject]:
+    """
+    Get all COMP 423 projects.
+
+    Parameters:
+        showcase_service: a valid ShowcaseService
+
+    Returns:
+        list[ShowcaseProject]: All projects
+    """
+    # Return all organizations
+    return showcase_service.all()

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from .api import (
     user,
     room,
     application,
+    showcase,
 )
 from .api.coworking import status, reservation, ambassador, operating_hours
 from .api.academics import term, course, section
@@ -54,6 +55,7 @@ app = FastAPI(
         health.openapi_tags,
         admin_users.openapi_tags,
         admin_roles.openapi_tags,
+        showcase.openapi_tags,
     ],
 )
 
@@ -79,6 +81,7 @@ feature_apis = [
     section,
     room,
     application,
+    showcase,
 ]
 
 for feature_api in feature_apis:

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -30,6 +30,7 @@ from .event_registration import (
     NewEventRegistration,
 )
 from .registration_type import RegistrationType
+from .showcase_project import *
 
 __authors__ = ["Kris Jordan"]
 __copyright__ = "Copyright 2023"

--- a/backend/models/showcase_project.py
+++ b/backend/models/showcase_project.py
@@ -8,15 +8,9 @@ __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
 
-class ProjectType(Enum):
-    NEWS_FEED = "XL News Feed / Announcements"
-    STUDENT_ORGS = "Student Organization Memberships / Members-only Features"
-    SEATING = "Interactive Seating Chart / Map Widget"
-    XL_DISPLAY = "XL Digital Display System"
-    OTHER = "Other"
-
-
 class ShowcaseProject(BaseModel):
     team_name: str
-    type: ProjectType
+    type: str
     members: list[str]
+    video_url: str
+    deployment_url: str

--- a/backend/models/showcase_project.py
+++ b/backend/models/showcase_project.py
@@ -1,0 +1,22 @@
+"""Definition for a COMP 423 project for showcasing."""
+
+from pydantic import BaseModel
+from enum import Enum
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+
+class ProjectType(Enum):
+    NEWS_FEED = "XL News Feed / Announcements"
+    STUDENT_ORGS = "Student Organization Memberships / Members-only Features"
+    SEATING = "Interactive Seating Chart / Map Widget"
+    XL_DISPLAY = "XL Digital Display System"
+    OTHER = "Other"
+
+
+class ShowcaseProject(BaseModel):
+    team_name: str
+    type: ProjectType
+    members: list[str]

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -6,3 +6,4 @@ from .organization import OrganizationService
 from .event import EventService
 from .exceptions import ResourceNotFoundException, UserPermissionException
 from .room import RoomService
+from .showcase import ShowcaseService

--- a/backend/services/showcase.py
+++ b/backend/services/showcase.py
@@ -1,0 +1,43 @@
+"""
+The Organizations Service allows the API to show COMP 423 projects.
+"""
+
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..database import db_session
+from ..models.showcase_project import ProjectType
+from ..models.showcase_project import ShowcaseProject
+from ..models import User
+from .permission import PermissionService
+
+from .exceptions import ResourceNotFoundException
+
+from ..test.services.showcase.showcase_data import projects
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+
+class ShowcaseService:
+    """Service that exposes COMP 423 showcase data"""
+
+    def __init__(
+        self,
+        session: Session = Depends(db_session),
+        permission: PermissionService = Depends(),
+    ):
+        """Initializes the `OrganizationService` session, and `PermissionService`"""
+        self._session = session
+        self._permission = permission
+
+    def all(self) -> list[ShowcaseProject]:
+        """
+        Retrieves all projects.
+
+        Returns:
+            list[ShowcaseProject]: List of all `ShowcaseProject`s
+        """
+        return projects

--- a/backend/services/showcase.py
+++ b/backend/services/showcase.py
@@ -7,7 +7,6 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..database import db_session
-from ..models.showcase_project import ProjectType
 from ..models.showcase_project import ShowcaseProject
 from ..models import User
 from .permission import PermissionService
@@ -40,4 +39,5 @@ class ShowcaseService:
         Returns:
             list[ShowcaseProject]: List of all `ShowcaseProject`s
         """
+
         return projects

--- a/backend/test/services/fixtures.py
+++ b/backend/test/services/fixtures.py
@@ -10,6 +10,7 @@ from ...services import (
     OrganizationService,
     EventService,
     RoomService,
+    ShowcaseService,
 )
 
 __authors__ = ["Kris Jordan", "Ajay Gandecha"]
@@ -61,3 +62,9 @@ def event_svc_integration(session: Session, user_svc_integration: UserService):
 def room_svc(session: Session):
     """RoomService fixture."""
     return RoomService(session, PermissionService(session))
+
+
+@pytest.fixture()
+def showcase_svc(session: Session):
+    """ShowcaseService fixture."""
+    return ShowcaseService(session, PermissionService(session))

--- a/backend/test/services/showcase/__init__.py
+++ b/backend/test/services/showcase/__init__.py
@@ -1,0 +1,1 @@
+# Treat as a package

--- a/backend/test/services/showcase/showcase_data.py
+++ b/backend/test/services/showcase/showcase_data.py
@@ -9,61 +9,69 @@ __license__ = "MIT"
 
 # Do not try this at home.
 
-DATA = """A1,Deysi Morales-Magadan,Luis Rivera Gonzalez,Bailey Van Wormer, , ,XL News Feed / Announcements
-A2,Giovanna Chen,Michelle Nguyen,Nadine Hughes, , ,XL News Feed / Announcements
-A3,Lalitha Vadrevu,Pallavi Sastry,Advika Ganesh,Erin Ma, ,Student Organization Memberships / Members-only Features
-A4,Prithvi Adiga,Trinh Kieu,Maria Thomas,Maddie Dai, ,XL News Feed / Announcements
-A5,Shaina Patel,Daisy Azagba,Sherly Lin,Alicia Bao, ,XL Digital Display System
-A6,Asim Raja,Alexandra Marum,William Chesser,Aristotle Bernard, ,XL Digital Display System
-A7,Jake Rogers,Saishreeya Kantamsetty,Ellie Kim,Upasana Lamsal, ,Interactive Seating Chart / Map Widget
-A9,Jack Huo,Jack Geng,Arnav Thakar,Jeff Zhuo, ,Interactive Seating Chart / Map Widget
-B1,Ishmael Percy,Alphonzo Dixon Iii,Jayson Mbugua,Embrey Morton, ,XL News Feed / Announcements
-B2,Gaines Diseker,Evan Flynn,Chris Odondi,Heri Ongechi, ,Student Organization Memberships / Members-only Features
-B4,Aryan Choudhary,Thomas Carriero,Lucas Jorgensen,Madelyn Drummonds, ,XL News Feed / Announcements
-B5,Noah Weaver,Ethan Crook,Jahnavi Kumar, , ,Interactive Seating Chart / Map Widget
-B6,Ryan Bowers,Arul Gundam,Nathan Kelete,Sanyukta Lamsal, ,XL News Feed / Announcements
-B7,Caitlyn Kim,Harin Lim,Hong Liu, , ,Interactive Seating Chart / Map Widget
-B8,Yawen Deng,Ying Hu,,,,XL News Feed / Announcements
-B9,Mustafa Aljumayli,Hope Fauble,Chloe Gee,Matthew Loynes, ,XL News Feed / Announcements
-C1,Niyaz Shakeel,Raheq Hassan,Ayah Abdul-Haqq,Mostafa Edris, ,Student Organization Memberships / Members-only Features
-C2,Wisdom Okwen,Austin Campbell,Evan Murray,Scott Hoover, ,XL News Feed / Announcements
-C3,Indira Van Kanegan,Olivia Xiao,Maya Mcpartland,Niah O'Briant, ,XL News Feed / Announcements
-C4,Venkata Mantri,Aaron Wang,Sujay Bhilegaonkar,Sam Bisaria, ,XL News Feed / Announcements
-C5,Michael Diaz,Calvin Courbois,Miles Murphy,Justin Rivera, ,XL News Feed / Announcements
-C6,Gregory Glasby Iii,Luis Villa Jr,Connor Vines,Adrian Lanier, ,Student Organization Memberships / Members-only Features
-C7,Manav Katarey,Joshua Grosser,Saman Sahebi,Jake Mareno, ,Student Organization Memberships / Members-only Features
-C9,Isaac Tran,Justin Guo,Aaron Zhao,Brian Pov, ,XL News Feed / Announcements
-D1,Bodhi Harmony,Jason Manning,Cole Whaley,Danny Wang, ,Interactive Seating Chart / Map Widget
-D2,Thomas Voglesonger,Wei Jiang,Ivan Wu,Benjamin Zhang, ,Interactive Seating Chart / Map Widget
-D3,Ahmad Raiyan,Nawfal Mohamed,Zaid Kamdar,Denizhan Kilic, ,XL News Feed / Announcements
-D4,Nicholas Sanaie,Tyler Roth,Tanner Macpherson,Mark Maio Jr, ,XL News Feed / Announcements
-D5,Jeremy Wang,Abhinav Mayreddy,Jeffrey Zhang,Samyuktha Vipin, ,XL News Feed / Announcements
-D6,Xiaolong Huang,Chinmay Avsarkar,Luis Fajardo Jr,Kalen Byrd, ,XL News Feed / Announcements
-D7,Vincent Li,Yuzhe Liu,Sarang Myoung,Diamoah Ngwayah Jr,Girish Rengadurai,XL News Feed / Announcements
-D9,Rishi Ranabothu,Prajwal Moharana,Jayden Lim,Swagat Adhikary, ,Interactive Seating Chart / Map Widget
-E1,Norah Binny,Chasity Davis,Evan Menendez,Brian Britt, ,Student Organization Memberships / Members-only Features
-E2,Aryaman Sonkiya,Naveen Prabhu,Aum Kendapadi,Samanyu Dixit, ,Interactive Seating Chart / Map Widget
-E3,Thomas Kung,Leon Tran,Ryan Nguyen, , ,XL News Feed / Announcements
-E4,Logan Richter,Benjamin Sears,Sean Murphy Jr,Brandon Lozano, ,XL News Feed / Announcements
-E5,Armaan Punj,Thomas Smith,Raymond Zou,Harry Hong, ,Student Organization Memberships / Members-only Features
-E5,Armaan Punj,Harry Hong,Thomas Smith,Raymond Zou, ,Student Organization Memberships / Members-only Features
-E6,Jinjing Tan,Andre Rosado,,, ,XL News Feed / Announcements
-E7,Bennett Mangum,Emmalyn Foster,Hunter Hamrick,Albert He, ,Student Organization Memberships / Members-only Features
-E9,Connor Goodwin,Samuel Gilmore,Caden Alford, , ,XL Digital Display System
-F1,Emilee Liggins,Jeremy Chen,Rohan Kumar, , ,XL Digital Display System
-F2,Anish Kompella,Aditya Krishna,Robert Wittmann, , ,XL News Feed / Announcements
-F3,Jake Terrill,Lukas Dendrolivanos,Eric Le,David Ezeude, ,XL News Feed / Announcements
-F4,Daniel Naranjo,Vihit Nanduri,Harshith Manepalli,Alexander Machalicky, ,XL News Feed / Announcements"""
+DATA = """A1,Deysi Morales-Magadan,Luis Rivera Gonzalez,Bailey Van Wormer,Sajan Patel, ,Other: CSXL Lost and Found,https://youtu.be/Hp3kcNHN-Bw,https://final-team-a1-comp590-140-24sp-bvanwo.apps.unc.edu/auth/as/amy/888888888
+A2,Giovanna Chen,Michelle Nguyen,Nadine Hughes, , ,XL News Feed / Announcements,https://youtu.be/826CZNE6djI,https://csxl-team-a2-comp590-24s.apps.unc.edu/news
+A3,Lalitha Vadrevu,Pallavi Sastry,Advika Ganesh,Erin Ma, ,Student Organization Memberships / Members-only Features,https://youtu.be/wJDfkW_sXgM?si=0JRxgRlifP7SWLCr,https://csxl-team-a3-comp590-24s.apps.unc.edu/
+A4,Prithvi Adiga,Trinh Kieu,Maria Thomas,Maddie Dai, ,XL News Feed / Announcements,https://youtu.be/c3ZwTti0kp0,https://csxl-team-a4-comp590-24s.apps.cloudapps.unc.edu/news
+A5,Shaina Patel,Daisy Azagba,Sherly Lin,Alicia Bao, ,XL Digital Display System,https://youtu.be/6j08ktdk5eY,https://final-team-a5-comp590-140-24sp-sherly1.apps.unc.edu
+A6,Asim Raja,Alexandra Marum,William Chesser,Aristotle Bernard, ,Other: Course Planner,https://youtu.be/m3JZOwOt21k,https://final-team-a6-comp590-140-24sp-bchesser.apps.unc.edu/academics/planner
+A7,Jake Rogers,Saishreeya Kantamsetty,Ellie Kim,Upasana Lamsal, ,Interactive Seating Chart / Map Widget,https://youtu.be/apgRX7fywMc,https://final-team-a7-comp590-140-24sp-cellie.apps.unc.edu/
+A9,Jack Huo,Jack Geng,Arnav Thakar,Jeff Zhuo, ,Interactive Seating Chart / Map Widget,https://youtu.be/NaVdG8Nnnvs,https://csxl-team-a9-comp590-24s.apps.unc.edu
+B1,Ishmael Percy,Alphonzo Dixon Iii,Jayson Mbugua,Embrey Morton, ,XL News Feed / Announcements,https://youtu.be/_eoMg1URLKY,https://csxl-team-b1-comp590-140-24sp-embreezy.apps.unc.edu/
+B2,Gaines Diseker,Evan Flynn,Chris Odondi,Heri Ongechi, ,Student Organization Memberships / Members-only Features,https://youtu.be/-HsEyvy73pY,https://csxl-team-b2-comp590-24s.apps.unc.edu/profile
+B4,Aryan Choudhary,Thomas Carriero,Lucas Jorgensen,Madelyn Drummonds, ,XL News Feed / Announcements,https://www.youtube.com/watch?v=ABvNvN3q-0U,https://csxl-team-b4-comp590-24s.apps.unc.edu/profile/edit
+B5,Noah Weaver,Ethan Crook,Jahnavi Kumar, , ,Other: Personal Showcase,https://www.youtube.com/watch?v=5HTkijZrJAc,https://csxl-team-b5-comp590-24s.apps.unc.edu
+B6,Ryan Bowers,Arul Gundam,Nathan Kelete,Sanyukta Lamsal, ,XL News Feed / Announcements,https://www.youtube.com/watch?v=5TGjfkX4d00&ab_channel=ArulGundam,https://csxl-team-b6-comp590-24s.apps.unc.edu/news
+B7,Caitlyn Kim,Harin Lim,Hong Liu, , ,Interactive Seating Chart / Map Widget,https://www.youtube.com/watch?v=WDWRKJ05rIQ,https://csxl-team-b7-comp590-24s.apps.unc.edu/coworking
+B8,Yawen Deng,Ying Hu,,,,XL News Feed / Announcements,https://youtu.be/X2txUI2gSEI,https://csxl-team-b8-comp590-24s.apps.unc.edu
+B9,Mustafa Aljumayli,Hope Fauble,Chloe Gee,Matthew Loynes, ,XL News Feed / Announcements,https://youtu.be/hviVCYsW510,https://csxl-team-b9-comp590-24s.apps.unc.edu/newsfeed
+C1,Niyaz Shakeel,Raheq Hassan,Ayah Abdul-Haqq,Mostafa Edris, ,Student Organization Memberships / Members-only Features,https://www.youtube.com/watch?v=lGyR1AgyR-U,https://csxl-team-c1-comp590-24s.apps.cloudapps.unc.edu/
+C2,Wisdom Okwen,Austin Campbell,Evan Murray,Scott Hoover, ,XL News Feed / Announcements,https://youtu.be/sozO9m0PrXg?si=12dFCFtndr59wMSa,https://final-team-c2-comp590-140-24sp-evanesce.apps.unc.edu/announcements
+C3,Indira Van Kanegan,Olivia Xiao,Maya Mcpartland,Niah O'Briant, ,XL News Feed / Announcements,https://youtu.be/hg7IAqQ7Y2I ,https://csxl-team-c3-comp590-24s.apps.unc.edu/news 
+C4,Venkata Mantri,Aaron Wang,Sujay Bhilegaonkar,Sam Bisaria, ,XL News Feed / Announcements,https://www.youtube.com/watch?v=sOkgRWpttkg,https://csxl-team-c4-comp590-24s.apps.unc.edu/
+C5,Michael Diaz,Calvin Courbois,Miles Murphy,Justin Rivera, ,XL News Feed / Announcements,https://youtu.be/wA_bOIabJR8,https://csxl-team-c5-comp590-24s.apps.unc.edu/
+C6,Gregory Glasby Iii,Luis Villa Jr,Connor Vines,Adrian Lanier, ,Student Organization Memberships / Members-only Features,https://www.youtube.com/watch?v=zPVB2ZGEAJQ&ab_channel=TraceGlasby,https://csxl-team-c6-comp590-24s.apps.unc.edu
+C7,Manav Katarey,Joshua Grosser,Saman Sahebi,Jake Mareno, ,Student Organization Memberships / Members-only Features,https://youtu.be/oj_RawH4tm4,https://csxl-team-c7-comp590-24s.apps.unc.edu
+C9,Isaac Tran,Justin Guo,Aaron Zhao,Brian Pov, ,XL News Feed / Announcements,https://youtu.be/ywE9wOJeq1E,https://test-comp590-140-24sp-aaroz.apps.unc.edu/
+D1,Bodhi Harmony,Jason Manning,Cole Whaley,Danny Wang, ,Interactive Seating Chart / Map Widget,https://youtu.be/Cnw_bpsJrlk,https://csxl-team-d1-comp590-24s.apps.unc.edu
+D2,Thomas Voglesonger,Wei Jiang,Ivan Wu,Benjamin Zhang, ,Interactive Seating Chart / Map Widget,https://youtu.be/9qCM0vRHXFw,https://csxl-team-d2-comp590-24s.apps.unc.edu
+D3,Ahmad Raiyan,Nawfal Mohamed,Zaid Kamdar,Denizhan Kilic, ,XL News Feed / Announcements,https://youtu.be/a5n45blgjFA,https://csxl-team-d3-comp590-24s.apps.unc.edu/announcement
+D4,Nicholas Sanaie,Tyler Roth,Tanner Macpherson,Mark Maio Jr, ,XL News Feed / Announcements,https://www.youtube.com/watch?v=1TSD6CjXgcg,https://csxl-team-d4-comp590-24s.apps.unc.edu/
+D5,Jeremy Wang,Abhinav Mayreddy,Jeffrey Zhang,Samyuktha Vipin, ,XL News Feed / Announcements,https://youtu.be/C7IIIdFiRtQ,https://final-d5-comp590-140-24sp-zhangja.apps.unc.edu
+D6,Xiaolong Huang,Chinmay Avsarkar,Luis Fajardo Jr,Kalen Byrd, ,XL News Feed / Announcements,https://youtu.be/lwIth0VWjL8,https://final-team-d6-comp590-140-24sp-kalen.apps.unc.edu/auth/as/rhona/999999999
+D7,Vincent Li,Yuzhe Liu,Sarang Myoung,Diamoah Ngwayah Jr,Girish Rengadurai,XL News Feed / Announcements,https://www.youtube.com/watch?v=2Ox8uJyA1a8,https://csxl-team-d7-comp590-24s.apps.unc.edu
+D9,Rishi Ranabothu,Prajwal Moharana,Jayden Lim,Swagat Adhikary, ,Other: Course Planner,https://youtu.be/Tw9g_4Nc_28,https://csxl-team-d9-comp590-24s.apps.unc.edu/about
+E1,Norah Binny,Chasity Davis,Evan Menendez,Brian Britt, ,Student Organization Memberships / Members-only Features,https://youtu.be/lwa97dDYZtg?si=SmFAdI-_1m3uFVB6,https://csxl-team-e1-comp590-24s.apps.unc.edu
+E2,Aryaman Sonkiya,Naveen Prabhu,Aum Kendapadi,Samanyu Dixit, ,Interactive Seating Chart / Map Widget,https://youtu.be/Kfa5kfnc-GA,https://csxl-team-e2-comp590-24s.apps.unc.edu/
+E3,Thomas Kung,Leon Tran,Ryan Nguyen, , ,XL News Feed / Announcements,https://youtu.be/axR-XDQcCI4,https://csxl-team-e3-comp590-24s.apps.unc.edu/
+E4,Logan Richter,Benjamin Sears,Sean Murphy Jr,Brandon Lozano, ,XL News Feed / Announcements,https://youtu.be/9j0I7uCu7Lk,https://final-team-e4-comp590-140-24sp-sirlogan.apps.unc.edu/news
+E5,Armaan Punj,Thomas Smith,Raymond Zou,Harry Hong, ,Student Organization Memberships / Members-only Features,https://youtu.be/K8ekY9EvCv4,https://csxl-team-e5-comp590-140-24sp-tss.apps.unc.edu/about
+E6,Jinjing Tan,Andre Rosado,,, ,XL News Feed / Announcements,https://youtu.be/msfCG1e99TI,https://csxl-team-e6a-comp590-24s.apps.unc.edu/
+E7,Bennett Mangum,Emmalyn Foster,Hunter Hamrick,Albert He, ,Student Organization Memberships / Members-only Features,https://youtu.be/bEkhTi3po0c,https://csxl-team-e7-comp590-24s.apps.unc.edu/
+E9,Connor Goodwin,Samuel Gilmore,Caden Alford, , ,XL Digital Display System,https://www.youtube.com/watch?v=qv16jUALlV0,https://csxl-team-e9-comp590-24s.apps.unc.edu/coworking
+F1,Emilee Liggins,Jeremy Chen,Rohan Kumar, , ,XL Digital Display System,https://youtu.be/bxhsJFAgZKE,
+F2,Anish Kompella,Aditya Krishna,Robert Wittmann, , ,XL News Feed / Announcements,https://youtu.be/IMLeyqRDl3A,https://csxl-team-f2-comp590-140-24sp-adi3kris.apps.unc.edu/homepage
+F3,Jake Terrill,Lukas Dendrolivanos,Eric Le,David Ezeude, ,XL News Feed / Announcements,https://youtu.be/ZFjLiHgJ2Zw,https://final-team-f3-comp590-140-24sp-ericle.apps.unc.edu/newsfeed
+F4,Daniel Naranjo,Vihit Nanduri,Harshith Manepalli,Alexander Machalicky, ,XL News Feed / Announcements,https://youtu.be/pX89__edJwU,https://csxl-team-f4-comp590-24s.apps.unc.edu"""
 
 projects: list[ShowcaseProject] = []
 
 # Parse the data.
 for line in DATA.split("\n"):
     items = line.split(",")
+    print(items)
     team_name = items[0]
-    type = items[-1]
-    team_members = [member for member in items[1:-1] if member != " "]
+    type = items[-3]
+    video = items[-2]
+    deployment = items[-1]
+    team_members = [member for member in items[1:-3] if member != " "]
 
-    new_project = ShowcaseProject(team_name=team_name, type=type, members=team_members)
+    new_project = ShowcaseProject(
+        team_name=team_name,
+        type=type,
+        members=team_members,
+        video_url=video,
+        deployment_url=deployment,
+    )
 
     projects.append(new_project)

--- a/backend/test/services/showcase/showcase_data.py
+++ b/backend/test/services/showcase/showcase_data.py
@@ -1,0 +1,69 @@
+import pytest
+
+from sqlalchemy.orm import Session
+from ....models.showcase_project import *
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+# Do not try this at home.
+
+DATA = """A1,Deysi Morales-Magadan,Luis Rivera Gonzalez,Bailey Van Wormer, , ,XL News Feed / Announcements
+A2,Giovanna Chen,Michelle Nguyen,Nadine Hughes, , ,XL News Feed / Announcements
+A3,Lalitha Vadrevu,Pallavi Sastry,Advika Ganesh,Erin Ma, ,Student Organization Memberships / Members-only Features
+A4,Prithvi Adiga,Trinh Kieu,Maria Thomas,Maddie Dai, ,XL News Feed / Announcements
+A5,Shaina Patel,Daisy Azagba,Sherly Lin,Alicia Bao, ,XL Digital Display System
+A6,Asim Raja,Alexandra Marum,William Chesser,Aristotle Bernard, ,XL Digital Display System
+A7,Jake Rogers,Saishreeya Kantamsetty,Ellie Kim,Upasana Lamsal, ,Interactive Seating Chart / Map Widget
+A9,Jack Huo,Jack Geng,Arnav Thakar,Jeff Zhuo, ,Interactive Seating Chart / Map Widget
+B1,Ishmael Percy,Alphonzo Dixon Iii,Jayson Mbugua,Embrey Morton, ,XL News Feed / Announcements
+B2,Gaines Diseker,Evan Flynn,Chris Odondi,Heri Ongechi, ,Student Organization Memberships / Members-only Features
+B4,Aryan Choudhary,Thomas Carriero,Lucas Jorgensen,Madelyn Drummonds, ,XL News Feed / Announcements
+B5,Noah Weaver,Ethan Crook,Jahnavi Kumar, , ,Interactive Seating Chart / Map Widget
+B6,Ryan Bowers,Arul Gundam,Nathan Kelete,Sanyukta Lamsal, ,XL News Feed / Announcements
+B7,Caitlyn Kim,Harin Lim,Hong Liu, , ,Interactive Seating Chart / Map Widget
+B8,Yawen Deng,Ying Hu,,,,XL News Feed / Announcements
+B9,Mustafa Aljumayli,Hope Fauble,Chloe Gee,Matthew Loynes, ,XL News Feed / Announcements
+C1,Niyaz Shakeel,Raheq Hassan,Ayah Abdul-Haqq,Mostafa Edris, ,Student Organization Memberships / Members-only Features
+C2,Wisdom Okwen,Austin Campbell,Evan Murray,Scott Hoover, ,XL News Feed / Announcements
+C3,Indira Van Kanegan,Olivia Xiao,Maya Mcpartland,Niah O'Briant, ,XL News Feed / Announcements
+C4,Venkata Mantri,Aaron Wang,Sujay Bhilegaonkar,Sam Bisaria, ,XL News Feed / Announcements
+C5,Michael Diaz,Calvin Courbois,Miles Murphy,Justin Rivera, ,XL News Feed / Announcements
+C6,Gregory Glasby Iii,Luis Villa Jr,Connor Vines,Adrian Lanier, ,Student Organization Memberships / Members-only Features
+C7,Manav Katarey,Joshua Grosser,Saman Sahebi,Jake Mareno, ,Student Organization Memberships / Members-only Features
+C9,Isaac Tran,Justin Guo,Aaron Zhao,Brian Pov, ,XL News Feed / Announcements
+D1,Bodhi Harmony,Jason Manning,Cole Whaley,Danny Wang, ,Interactive Seating Chart / Map Widget
+D2,Thomas Voglesonger,Wei Jiang,Ivan Wu,Benjamin Zhang, ,Interactive Seating Chart / Map Widget
+D3,Ahmad Raiyan,Nawfal Mohamed,Zaid Kamdar,Denizhan Kilic, ,XL News Feed / Announcements
+D4,Nicholas Sanaie,Tyler Roth,Tanner Macpherson,Mark Maio Jr, ,XL News Feed / Announcements
+D5,Jeremy Wang,Abhinav Mayreddy,Jeffrey Zhang,Samyuktha Vipin, ,XL News Feed / Announcements
+D6,Xiaolong Huang,Chinmay Avsarkar,Luis Fajardo Jr,Kalen Byrd, ,XL News Feed / Announcements
+D7,Vincent Li,Yuzhe Liu,Sarang Myoung,Diamoah Ngwayah Jr,Girish Rengadurai,XL News Feed / Announcements
+D9,Rishi Ranabothu,Prajwal Moharana,Jayden Lim,Swagat Adhikary, ,Interactive Seating Chart / Map Widget
+E1,Norah Binny,Chasity Davis,Evan Menendez,Brian Britt, ,Student Organization Memberships / Members-only Features
+E2,Aryaman Sonkiya,Naveen Prabhu,Aum Kendapadi,Samanyu Dixit, ,Interactive Seating Chart / Map Widget
+E3,Thomas Kung,Leon Tran,Ryan Nguyen, , ,XL News Feed / Announcements
+E4,Logan Richter,Benjamin Sears,Sean Murphy Jr,Brandon Lozano, ,XL News Feed / Announcements
+E5,Armaan Punj,Thomas Smith,Raymond Zou,Harry Hong, ,Student Organization Memberships / Members-only Features
+E5,Armaan Punj,Harry Hong,Thomas Smith,Raymond Zou, ,Student Organization Memberships / Members-only Features
+E6,Jinjing Tan,Andre Rosado,,, ,XL News Feed / Announcements
+E7,Bennett Mangum,Emmalyn Foster,Hunter Hamrick,Albert He, ,Student Organization Memberships / Members-only Features
+E9,Connor Goodwin,Samuel Gilmore,Caden Alford, , ,XL Digital Display System
+F1,Emilee Liggins,Jeremy Chen,Rohan Kumar, , ,XL Digital Display System
+F2,Anish Kompella,Aditya Krishna,Robert Wittmann, , ,XL News Feed / Announcements
+F3,Jake Terrill,Lukas Dendrolivanos,Eric Le,David Ezeude, ,XL News Feed / Announcements
+F4,Daniel Naranjo,Vihit Nanduri,Harshith Manepalli,Alexander Machalicky, ,XL News Feed / Announcements"""
+
+projects: list[ShowcaseProject] = []
+
+# Parse the data.
+for line in DATA.split("\n"):
+    items = line.split(",")
+    team_name = items[0]
+    type = items[-1]
+    team_members = [member for member in items[1:-1] if member != " "]
+
+    new_project = ShowcaseProject(team_name=team_name, type=type, members=team_members)
+
+    projects.append(new_project)

--- a/backend/test/services/showcase/showcase_test.py
+++ b/backend/test/services/showcase/showcase_test.py
@@ -1,0 +1,22 @@
+"""Tests for the ShowcaseService class."""
+
+import pytest
+
+# Tested Dependencies
+from ....services.showcase import ShowcaseService
+
+# Fixture
+from ..fixtures import showcase_svc
+
+# Data Models for Fake Data Inserted in Setup
+from .showcase_data import projects
+
+__authors__ = ["Ajay Gandecha"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+
+def test_list(showcase_svc: ShowcaseService):
+    all = showcase_svc.all()
+
+    assert len(all) == len(projects)

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -5,11 +5,13 @@ import { GateComponent } from './gate/gate.component';
 import { HomeComponent } from './home/home.component';
 import { ProfileEditorComponent } from './profile/profile-editor/profile-editor.component';
 import { AboutComponent } from './about/about.component';
+import { ShowcaseComponent } from './showcase/showcase.component';
 
 const routes: Routes = [
   HomeComponent.Route,
   AboutComponent.Route,
   GateComponent.Route,
+  ShowcaseComponent.Route,
   {
     path: 'coworking',
     title: 'Cowork in the XL',

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatStepperModule } from '@angular/material/stepper';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatChipsModule } from '@angular/material/chips';
 
 /* Application Specific */
 import { AppRoutingModule } from './app-routing.module';
@@ -42,6 +43,8 @@ import { AboutComponent } from './about/about.component';
 import { GateComponent } from './gate/gate.component';
 import { ProfileEditorComponent } from './profile/profile-editor/profile-editor.component';
 import { SharedModule } from './shared/shared.module';
+import { ShowcaseComponent } from './showcase/showcase.component';
+import { MatTableModule } from '@angular/material/table';
 
 @NgModule({
   declarations: [
@@ -51,7 +54,8 @@ import { SharedModule } from './shared/shared.module';
     ErrorDialogComponent,
     HomeComponent,
     AboutComponent,
-    GateComponent
+    GateComponent,
+    ShowcaseComponent
   ],
   imports: [
     /* Angular */
@@ -80,6 +84,8 @@ import { SharedModule } from './shared/shared.module';
     MatToolbarModule,
     MatTooltipModule,
     MatCheckboxModule,
+    MatChipsModule,
+    MatTableModule,
     FormsModule,
     RouterModule,
     SharedModule,

--- a/frontend/src/app/navigation/navigation.component.html
+++ b/frontend/src/app/navigation/navigation.component.html
@@ -26,6 +26,8 @@
           </picture>
         </a>
         <div *ngIf="profile$ | async as profile; else unauthenticated">
+          <a mat-list-item routerLink="/showcase">COMP 423 Showcase</a>
+          <mat-divider></mat-divider>
           <a mat-list-item routerLink="/coworking">Coworking</a>
           <a mat-list-item routerLink="/events">Events</a>
           <a mat-list-item routerLink="/organizations">Organizations</a>

--- a/frontend/src/app/showcase/showcase.component.css
+++ b/frontend/src/app/showcase/showcase.component.css
@@ -1,0 +1,24 @@
+
+.deployment-button {
+    margin-left: 8px;
+}
+
+.mat-mdc-card {
+    max-width: 100%;
+}
+
+.row {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.link-buttons {
+    margin-left: auto;
+}
+
+#deploy-button {
+    margin-left: 8px;
+}

--- a/frontend/src/app/showcase/showcase.component.html
+++ b/frontend/src/app/showcase/showcase.component.html
@@ -1,0 +1,72 @@
+<mat-card class="content" appearance="outlined">
+  <mat-card-content>
+    <mat-card-subtitle
+      >Welcome to the COMP 423 Project Showcase!</mat-card-subtitle
+    >
+    <p>
+      This page is dedicated to celebrating the amazing projects and
+      accomplishments of the students in
+      <strong>COMP 423: Foundations of Software Engineering</strong> this
+      semester (Spring 2024).
+    </p>
+    <p>
+      Students' final projects were to add new features to the
+      <strong>CSXL site</strong> -
+      <em>the same one you are using right now!</em> This was an ambitious goal.
+      Throughout the entire semester, students learned full-stack software
+      engineering from the ground up, learning frontend tools like Angular, REST
+      APIs, persisting data in databases, deploying projects to the Cloud, and
+      perhaps most importantly, working in teams.
+    </p>
+    <p>
+      This showcase page groups projects based on their chosen topic! Scroll to
+      browse through the amazing work students completed. Kris and the entire
+      COMP 423 UTA Team are extremely proud of the work these students completed
+      this semester.
+    </p>
+  </mat-card-content>
+</mat-card>
+
+<mat-card
+  class="content"
+  appearance="outlined"
+  *ngFor="let type of projects.keys()">
+  <mat-card-header>
+    <mat-card-title>{{ type }}</mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <!-- Table -->
+    <table mat-table [dataSource]="projects.get(type) ?? []">
+      <ng-container matColumnDef="Team">
+        <th mat-header-cell *matHeaderCellDef>Team</th>
+        <td mat-cell *matCellDef="let element">{{ element.team_name }}</td>
+      </ng-container>
+      <ng-container matColumnDef="Members">
+        <th mat-header-cell *matHeaderCellDef>Members</th>
+        <td mat-cell *matCellDef="let element">
+          {{ convertListToText(element.members) }}
+        </td>
+      </ng-container>
+      <ng-container matColumnDef="Links">
+        <th mat-header-cell *matHeaderCellDef></th>
+        <td mat-cell *matCellDef="let element">
+          <div class="row">
+            <div class="link-buttons">
+              <a [href]="element.video_url" target="_blank">
+                <button mat-stroked-button>Demo</button>
+              </a>
+              <a
+                [href]="element.deployment_url"
+                target="_blank"
+                id="deploy-button">
+                <button mat-stroked-button>Deployment</button>
+              </a>
+            </div>
+          </div>
+        </td>
+      </ng-container>
+      <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+      <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+    </table>
+  </mat-card-content>
+</mat-card>

--- a/frontend/src/app/showcase/showcase.component.ts
+++ b/frontend/src/app/showcase/showcase.component.ts
@@ -1,0 +1,52 @@
+import { Component } from '@angular/core';
+import { showcaseResolver } from './showcase.resolver';
+import { ActivatedRoute } from '@angular/router';
+import { ShowcaseProject } from './showcaseproject.model';
+
+@Component({
+  selector: 'app-showcase',
+  templateUrl: './showcase.component.html',
+  styleUrls: ['./showcase.component.css']
+})
+export class ShowcaseComponent {
+  /** Route information */
+  public static Route = {
+    path: 'showcase',
+    title: 'COMP 423 Showcase',
+    component: ShowcaseComponent,
+    canActivate: [],
+    resolve: { projects: showcaseResolver }
+  };
+
+  projects: Map<String, ShowcaseProject[]> = new Map();
+
+  public displayedColumns: string[] = ['Team', 'Members', 'Links'];
+
+  constructor(private route: ActivatedRoute) {
+    /** Initialize data from resolvers. */
+    const data = this.route.snapshot.data as {
+      projects: ShowcaseProject[];
+    };
+
+    data.projects.forEach((project) => {
+      let list = this.projects.get(project.type) ?? [];
+      list.push(project);
+      this.projects.set(project.type, list);
+    });
+
+    console.log(this.projects);
+  }
+
+  convertListToText(names: string[]): string {
+    let str = '';
+
+    for (let name of names) {
+      if (name != '') {
+        str += name;
+        str += ', ';
+      }
+    }
+
+    return str.slice(0, -2);
+  }
+}

--- a/frontend/src/app/showcase/showcase.resolver.ts
+++ b/frontend/src/app/showcase/showcase.resolver.ts
@@ -1,0 +1,21 @@
+/**
+ * The Showcase Resolver allows projects to be injected into the routes
+ * of components.
+ *
+ * @author Ajay Gandecha
+ * @copyright 2024
+ * @license MIT
+ */
+
+import { inject } from '@angular/core';
+import { ResolveFn } from '@angular/router';
+import { ShowcaseProject } from './showcaseproject.model';
+import { ShowcaseService } from './showcase.service';
+
+/** This resolver injects the list of projects into the project component. */
+export const showcaseResolver: ResolveFn<ShowcaseProject[] | undefined> = (
+  route,
+  state
+) => {
+  return inject(ShowcaseService).getProjects();
+};

--- a/frontend/src/app/showcase/showcase.service.ts
+++ b/frontend/src/app/showcase/showcase.service.ts
@@ -1,0 +1,27 @@
+/**
+ * The Showcase Service abstracts HTTP requests to the backend
+ * from the components.
+ *
+ * @author Ajay Gandecha
+ * @copyright 2024
+ * @license MIT
+ */
+
+import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { ShowcaseProject } from './showcaseproject.model';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ShowcaseService {
+  constructor(protected http: HttpClient) {}
+
+  /** Returns all of the projects using the backend HTTP get request.
+   * @returns {Observable<Organization[]>}
+   */
+  getProjects(): Observable<ShowcaseProject[]> {
+    return this.http.get<ShowcaseProject[]>('/api/showcase');
+  }
+}

--- a/frontend/src/app/showcase/showcaseproject.model.ts
+++ b/frontend/src/app/showcase/showcaseproject.model.ts
@@ -1,0 +1,17 @@
+/**
+ * The ShowcaseProject Model defines the shape of ShowcaseProject data
+ * retrieved from the Showcase Service and the API.
+ *
+ * @author Ajay Gandecha
+ * @copyright 2024
+ * @license MIT
+ */
+
+/** Interface for the Showcase Project */
+export interface ShowcaseProject {
+  team_name: string;
+  type: string;
+  members: string[];
+  video_url: string;
+  deployment_url: string;
+}


### PR DESCRIPTION
This pull request adds a new, temporary COMP 423 Project Showcase to showcase the amazing projects that have been completed this semester!

Idea courtesy of @aliciasbao and another student in the class!

## New Additions
* Creation of a new `ShowcaseService` and relevant model.
* Adds a new GET API route `/api/showcase` accessible only to members logged in.
* Adds a new page at `/showcase` to show off projects!
* No database table added (data is supplied as raw text - marked as "don't try this at home"), so no migration needed.

## Testing
* The frontend was tested with `honcho start`.
* Yes, I made a unit test for the service, and it is at 100% test coverage 🤪 