### PR TITLE
Allow root to create OH Sections

### DIFF
--- a/backend/api/academics/section_member.py
+++ b/backend/api/academics/section_member.py
@@ -6,7 +6,9 @@ from fastapi import APIRouter, Depends, HTTPException
 from ..authentication import registered_user
 
 from ...models.academics.section_member import SectionMember
+from ...models.academics.section_member_details import SectionMemberDetails
 from ...models.office_hours.section import OfficeHoursSection
+from ...models.roster_role import RosterRole
 from ...models import User
 
 from ...services.academics import SectionMemberService
@@ -122,3 +124,25 @@ def check_instructor_memberships(
     """
 
     return section_member_svc.search_instructor_memberships(subject)
+
+
+@api.post(
+    "/instructor/{section_id}/{user_id}",
+    response_model=SectionMember,
+    tags=["Academics"],
+)
+def add_instructor(
+    section_id: int,
+    user_id: int,
+    subject: User = Depends(registered_user),
+    section_member_svc: SectionMemberService = Depends(),
+) -> SectionMemberDetails:
+    """
+    Gets one section by its id
+
+    Returns:
+        SectionDetails: Section with the given ID
+    """
+    return section_member_svc.add_section_member(
+        subject, section_id, user_id, RosterRole.INSTRUCTOR
+    )

--- a/backend/services/academics/section_member.py
+++ b/backend/services/academics/section_member.py
@@ -101,6 +101,36 @@ class SectionMemberService:
 
         return entity.to_flat_model()
 
+    def add_section_member(
+        self, subject: User, section_id: int, user_id: int, member_role: RosterRole
+    ) -> SectionMemberDetails:
+        """Add one member to a section
+
+        Args:
+            subject (User): The user for whom to add section memberships.
+            section_id (int): ID of the section to add a member to.
+            user_id (int): ID of the user to add a member to.
+
+        Returns:
+            SectionMember: Newly created section member.
+
+        Raises:
+            ResourceNotFoundException: If no academic section is found for any of the specified office hours sections.
+        """
+        self._permission_svc.enforce(
+            subject, "academics.section_member.create", f"section/{section_id}"
+        )
+
+        draft = SectionMemberDraft(
+            user_id=user_id, section_id=section_id, member_role=member_role
+        )
+        section_membership = SectionMemberEntity.from_draft_model(draft)
+
+        self._session.add(section_membership)
+        self._session.commit()
+
+        return section_membership.to_details_model()
+
     def add_user_section_memberships_by_oh_sections(
         self,
         subject: User,

--- a/backend/services/office_hours/section.py
+++ b/backend/services/office_hours/section.py
@@ -705,38 +705,6 @@ class OfficeHoursSectionService:
         """
         # TODO
 
-    def _check_membership_by_user_id_section_id(
-        self,
-        user_id: int,
-        section_id: int,
-    ) -> SectionMemberEntity:
-        """Checks if a given user is a member in academic sections and has oh section edit permissions. A UTA/GTA/Instructor has this permission.
-        Note: An Office Hours section can have multiple academic sections assoicated with it.
-        Args:
-            user_id: The id of given User of interest
-            section_id: ID of academic section.
-        Returns:
-            SectionMemberEntity: `SectionMemberEntity` associated with a given user and academic section
-        Raises:
-            PermissionError if user creating event is not a Instructor
-        """
-        # Select SectionMembers where the user id and section id match the given ones
-        query = (
-            select(SectionMemberEntity)
-            .where(SectionMemberEntity.user_id == user_id)
-            .where(SectionMemberEntity.section_id == section_id)
-        )
-        # Find User Academic Section Entity
-        section_member_entity = self._session.scalars(query).one_or_none()
-
-        if section_member_entity is None:
-            raise PermissionError(
-                f"User has to be a Section Member to Create OH Section. Unable To Find Section Member Entity for User with id: {user_id} in the following Academic Sections of ids: {section_id}"
-            )
-
-        # Return entity
-        return section_member_entity
-
     def _check_user_section_membership(
         self,
         user_id: int,

--- a/backend/test/services/academics/section_test.py
+++ b/backend/test/services/academics/section_test.py
@@ -2,16 +2,17 @@
 
 from unittest.mock import create_autospec
 import pytest
+from backend.models.roster_role import RosterRole
 from backend.services.exceptions import (
     ResourceNotFoundException,
     UserPermissionException,
 )
 from backend.services.permission import PermissionService
-from ....services.academics import SectionService
+from ....services.academics import SectionService, SectionMemberService
 from ....models.academics import SectionDetails
 
 # Imported fixtures provide dependencies injected for the tests as parameters.
-from .fixtures import permission_svc, section_svc
+from .fixtures import permission_svc, section_svc, section_member_svc
 
 # Import the setup_teardown fixture explicitly to load entities in database
 from ..core_data import setup_insert_data_fixture as insert_order_0
@@ -231,3 +232,25 @@ def test_get_sections_with_no_office_hours_by_term(section_svc: SectionService):
 
     assert len(sections_with_no_oh) > 0
     assert isinstance(sections_with_no_oh[0], SectionDetails)
+
+
+def test_root_add_section_member(section_member_svc: SectionMemberService):
+    membership = section_member_svc.add_section_member(
+        subject=user_data.root,
+        section_id=section_data.comp_101_001.id,
+        user_id=user_data.root.id,
+        member_role=RosterRole.INSTRUCTOR,
+    )
+    assert membership is not None
+
+
+def test_user_add_section_member(section_member_svc: SectionMemberService):
+
+    with pytest.raises(UserPermissionException):
+        section_member_svc.add_section_member(
+            subject=user_data.student,
+            section_id=section_data.comp_101_001.id,
+            user_id=user_data.root.id,
+            member_role=RosterRole.INSTRUCTOR,
+        )
+        pytest.fail()

--- a/backend/test/services/office_hours/fixtures.py
+++ b/backend/test/services/office_hours/fixtures.py
@@ -38,6 +38,6 @@ def oh_ticket_svc(
 
 
 @pytest.fixture()
-def oh_section_svc(session: Session):
+def oh_section_svc(session: Session, permission_svc: PermissionService):
     """OfficeHoursSectionService fixture."""
-    return OfficeHoursSectionService(session)
+    return OfficeHoursSectionService(session, permission_svc)

--- a/backend/test/services/office_hours/section/create_test.py
+++ b/backend/test/services/office_hours/section/create_test.py
@@ -24,7 +24,6 @@ from ..office_hours_data import fake_data_fixture as insert_order_5
 # Import the fake model data in a namespace for test assertions
 from .. import office_hours_data
 from ...user_data import root
-from .....services.exceptions import UserPermissionException
 
 from ...academics.section_data import (
     user__comp110_instructor,
@@ -109,9 +108,76 @@ def test_create_by_root_multiple_academic_sections_and_linked_to_academic_sectio
     assert oh_section.id == comp210.office_hours_section.id
 
 
+def test_create_by_instructor(
+    oh_section_svc: OfficeHoursSectionService, section_svc: SectionService
+):
+    """Test case to validate creation of an office hours section by an instructor."""
+    oh_section = oh_section_svc.create(
+        user__comp301_instructor,
+        office_hours_data.oh_section_draft,
+        [comp_301_001_current_term.id],
+    )
+
+    assert isinstance(oh_section, OfficeHoursSectionDetails)
+    assert oh_section.title == office_hours_data.oh_section_draft.title
+
+
+def test_create_by_instructor_and_linked_to_academic_section(
+    oh_section_svc: OfficeHoursSectionService, section_svc: SectionService
+):
+    """Test case to validate creation of an office hours section linked to an academic section by an instructor."""
+    oh_section = oh_section_svc.create(
+        user__comp301_instructor,
+        office_hours_data.oh_section_draft,
+        [comp_301_001_current_term.id],
+    )
+
+    assert isinstance(oh_section, OfficeHoursSectionDetails)
+
+    # Check if OH Section Is Linked to Academic Section
+    academic_section = section_svc.get_by_id(comp_301_001_current_term.id)
+    assert oh_section.id == academic_section.office_hours_section.id
+
+
+def test_create_by_instructor_multiple_academic_sections(
+    oh_section_svc: OfficeHoursSectionService,
+):
+    """Test case to validate creation of an office hours section with multiple academic sections by an instructor."""
+    oh_section = oh_section_svc.create(
+        user__comp301_instructor,
+        office_hours_data.oh_section_draft,
+        [comp_301_001_current_term.id, comp_210_001_current_term.id],
+    )
+
+    assert isinstance(oh_section, OfficeHoursSectionDetails)
+    assert oh_section.title == office_hours_data.oh_section_draft.title
+
+
+def test_create_by_instructor_multiple_academic_sections_and_linked_to_academic_section(
+    oh_section_svc: OfficeHoursSectionService, section_svc: SectionService
+):
+    """Test case to validate creation of an office hours section with multiple academic sections
+    and linked to those academic sections by an instructor."""
+    oh_section = oh_section_svc.create(
+        user__comp301_instructor,
+        office_hours_data.oh_section_draft,
+        [comp_301_001_current_term.id, comp_210_001_current_term.id],
+    )
+
+    assert isinstance(oh_section, OfficeHoursSectionDetails)
+    assert oh_section.title == office_hours_data.oh_section_draft.title
+
+    # Check if OH Section Is Linked to Academic Sections
+    comp301 = section_svc.get_by_id(comp_301_001_current_term.id)
+    comp210 = section_svc.get_by_id(comp_210_001_current_term.id)
+
+    assert oh_section.id == comp301.office_hours_section.id
+    assert oh_section.id == comp210.office_hours_section.id
+
+
 def test_create_exception_if_student(oh_section_svc: OfficeHoursSectionService):
     """Test case to validate that creating an office hours section raises a PermissionError if the user is a student."""
-    with pytest.raises(UserPermissionException):
+    with pytest.raises(PermissionError):
         oh_section_svc.create(
             user__comp301_student,
             office_hours_data.oh_section_draft,
@@ -122,7 +188,7 @@ def test_create_exception_if_student(oh_section_svc: OfficeHoursSectionService):
 
 def test_create_exception_if_ta(oh_section_svc: OfficeHoursSectionService):
     """Test case to validate that creating an office hours section raises a PermissionError if the user is a teaching assistant."""
-    with pytest.raises(UserPermissionException):
+    with pytest.raises(PermissionError):
         oh_section_svc.create(
             user__comp301_uta,
             office_hours_data.oh_section_draft,
@@ -133,7 +199,7 @@ def test_create_exception_if_ta(oh_section_svc: OfficeHoursSectionService):
 
 def test_create_exception_if_non_member(oh_section_svc: OfficeHoursSectionService):
     """Test case to validate that creating an office hours section raises a PermissionError if the user is not a member of the section."""
-    with pytest.raises(UserPermissionException):
+    with pytest.raises(PermissionError):
         oh_section_svc.create(
             user__comp110_student_0,
             office_hours_data.oh_section_draft,

--- a/backend/test/services/office_hours/section/create_test.py
+++ b/backend/test/services/office_hours/section/create_test.py
@@ -4,12 +4,13 @@ import pytest
 
 from .....models.office_hours.section_details import OfficeHoursSectionDetails
 from .....services.academics.section import SectionService
-
+from .....services.permission import PermissionService
 from .....services.exceptions import ResourceNotFoundException
 from .....services.office_hours.section import OfficeHoursSectionService
 
 # Imported fixtures provide dependencies injected for the tests as parameters.
-from ..fixtures import permission_svc, oh_section_svc
+from ..fixtures import permission_svc
+from ..fixtures import oh_section_svc
 from ...academics.fixtures import section_svc
 
 # Import the setup_teardown fixture explicitly to load entities in database
@@ -22,6 +23,9 @@ from ..office_hours_data import fake_data_fixture as insert_order_5
 
 # Import the fake model data in a namespace for test assertions
 from .. import office_hours_data
+from ...user_data import root
+from .....services.exceptions import UserPermissionException
+
 from ...academics.section_data import (
     user__comp110_instructor,
     user__comp110_student_0,
@@ -38,12 +42,12 @@ __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
 
-def test_create_by_instructor(
+def test_create_by_root(
     oh_section_svc: OfficeHoursSectionService, section_svc: SectionService
 ):
     """Test case to validate creation of an office hours section by an instructor."""
     oh_section = oh_section_svc.create(
-        user__comp301_instructor,
+        root,
         office_hours_data.oh_section_draft,
         [comp_301_001_current_term.id],
     )
@@ -52,12 +56,12 @@ def test_create_by_instructor(
     assert oh_section.title == office_hours_data.oh_section_draft.title
 
 
-def test_create_by_instructor_and_linked_to_academic_section(
+def test_create_by_root_and_linked_to_academic_section(
     oh_section_svc: OfficeHoursSectionService, section_svc: SectionService
 ):
     """Test case to validate creation of an office hours section linked to an academic section by an instructor."""
     oh_section = oh_section_svc.create(
-        user__comp301_instructor,
+        root,
         office_hours_data.oh_section_draft,
         [comp_301_001_current_term.id],
     )
@@ -69,12 +73,12 @@ def test_create_by_instructor_and_linked_to_academic_section(
     assert oh_section.id == academic_section.office_hours_section.id
 
 
-def test_create_by_instructor_multiple_academic_sections(
+def test_create_by_root_multiple_academic_sections(
     oh_section_svc: OfficeHoursSectionService,
 ):
     """Test case to validate creation of an office hours section with multiple academic sections by an instructor."""
     oh_section = oh_section_svc.create(
-        user__comp301_instructor,
+        root,
         office_hours_data.oh_section_draft,
         [comp_301_001_current_term.id, comp_210_001_current_term.id],
     )
@@ -83,13 +87,13 @@ def test_create_by_instructor_multiple_academic_sections(
     assert oh_section.title == office_hours_data.oh_section_draft.title
 
 
-def test_create_by_instructor_multiple_academic_sections_and_linked_to_academic_section(
+def test_create_by_root_multiple_academic_sections_and_linked_to_academic_section(
     oh_section_svc: OfficeHoursSectionService, section_svc: SectionService
 ):
     """Test case to validate creation of an office hours section with multiple academic sections
     and linked to those academic sections by an instructor."""
     oh_section = oh_section_svc.create(
-        user__comp301_instructor,
+        root,
         office_hours_data.oh_section_draft,
         [comp_301_001_current_term.id, comp_210_001_current_term.id],
     )
@@ -107,7 +111,7 @@ def test_create_by_instructor_multiple_academic_sections_and_linked_to_academic_
 
 def test_create_exception_if_student(oh_section_svc: OfficeHoursSectionService):
     """Test case to validate that creating an office hours section raises a PermissionError if the user is a student."""
-    with pytest.raises(PermissionError):
+    with pytest.raises(UserPermissionException):
         oh_section_svc.create(
             user__comp301_student,
             office_hours_data.oh_section_draft,
@@ -118,7 +122,7 @@ def test_create_exception_if_student(oh_section_svc: OfficeHoursSectionService):
 
 def test_create_exception_if_ta(oh_section_svc: OfficeHoursSectionService):
     """Test case to validate that creating an office hours section raises a PermissionError if the user is a teaching assistant."""
-    with pytest.raises(PermissionError):
+    with pytest.raises(UserPermissionException):
         oh_section_svc.create(
             user__comp301_uta,
             office_hours_data.oh_section_draft,
@@ -129,7 +133,7 @@ def test_create_exception_if_ta(oh_section_svc: OfficeHoursSectionService):
 
 def test_create_exception_if_non_member(oh_section_svc: OfficeHoursSectionService):
     """Test case to validate that creating an office hours section raises a PermissionError if the user is not a member of the section."""
-    with pytest.raises(PermissionError):
+    with pytest.raises(UserPermissionException):
         oh_section_svc.create(
             user__comp110_student_0,
             office_hours_data.oh_section_draft,
@@ -144,7 +148,7 @@ def test_create_exception_if_oh_section_exists(
     """Test case to validate that creating an office hours section raises an Exception if a duplicate section already exists."""
     with pytest.raises(Exception):
         oh_section_svc.create(
-            user__comp110_instructor,
+            root,
             office_hours_data.oh_section_draft,
             [comp_110_001_current_term.id],
         )
@@ -157,7 +161,7 @@ def test_create_exception_if_one_oh_section_exists_and_other_does_not_have_one(
     """Test case to validate that creating an office hours section raises an Exception if one section exists but the other doesn't."""
     with pytest.raises(Exception):
         oh_section_svc.create(
-            user__comp110_instructor,
+            root,
             office_hours_data.oh_section_draft,
             [comp_110_001_current_term.id, comp_301_001_current_term.id],
         )
@@ -170,7 +174,7 @@ def test_create_exception_if_can_not_find_all_academic_sections(
     """Test case to validate that creating an office hours section raises an ResourceNotFoundException if all academic sections are not found."""
     with pytest.raises(ResourceNotFoundException):
         oh_section_svc.create(
-            user__comp110_instructor,
+            root,
             office_hours_data.oh_section_draft,
             [comp_301_001_current_term.id, 99],
         )


### PR DESCRIPTION
This PR allows the root user to create office hour sections so that there is an API endpoint to add an instructor to the OH section.