### PR TITLE
Create Frontend Pagination Abstraction

### DIFF
--- a/frontend/src/app/admin/users/list/admin-users-list.component.ts
+++ b/frontend/src/app/admin/users/list/admin-users-list.component.ts
@@ -4,7 +4,7 @@ import { Profile } from 'src/app/profile/profile.service';
 import { UserAdminService } from 'src/app/admin/users/user-admin.service';
 import { permissionGuard } from 'src/app/permission.guard';
 
-import { Paginated } from 'src/app/pagination';
+import { Paginated, PaginationParams } from 'src/app/pagination';
 import { PageEvent } from '@angular/material/paginator';
 
 @Component({
@@ -13,7 +13,7 @@ import { PageEvent } from '@angular/material/paginator';
   styleUrls: []
 })
 export class AdminUsersListComponent {
-  public page: Paginated<Profile>;
+  public page: Paginated<Profile, PaginationParams>;
 
   public displayedColumns: string[] = [
     'first_name',
@@ -45,7 +45,9 @@ export class AdminUsersListComponent {
     private router: Router,
     route: ActivatedRoute
   ) {
-    let data = route.snapshot.data as { page: Paginated<Profile> };
+    let data = route.snapshot.data as {
+      page: Paginated<Profile, PaginationParams>;
+    };
     this.page = data.page;
   }
 

--- a/frontend/src/app/admin/users/user-admin.service.ts
+++ b/frontend/src/app/admin/users/user-admin.service.ts
@@ -15,7 +15,7 @@ export class UserAdminService {
       filter: params.filter
     };
     let query = new URLSearchParams(paramStrings);
-    return this.http.get<Paginated<Profile>>(
+    return this.http.get<Paginated<Profile, PaginationParams>>(
       '/api/admin/users?' + query.toString()
     );
   }

--- a/frontend/src/app/event/event-page/event-page.component.ts
+++ b/frontend/src/app/event/event-page/event-page.component.ts
@@ -22,7 +22,7 @@ import { DatePipe } from '@angular/common';
 import { EventService } from '../event.service';
 import { NagivationAdminGearService } from 'src/app/navigation/navigation-admin-gear.service';
 
-import { PaginatedEvent } from 'src/app/pagination';
+import { EventPaginationParams, Paginated } from 'src/app/pagination';
 import {
   Subject,
   Subscription,
@@ -38,7 +38,7 @@ import {
   styleUrls: ['./event-page.component.css']
 })
 export class EventPageComponent implements OnInit, OnDestroy {
-  public page: PaginatedEvent<Event>;
+  public page: Paginated<Event, EventPaginationParams>;
   public startDate = new Date();
   public endDate = new Date(new Date().setMonth(new Date().getMonth() + 1));
   public today: boolean = true;
@@ -99,7 +99,7 @@ export class EventPageComponent implements OnInit, OnDestroy {
     // Initialize data from resolvers
     const data = this.route.snapshot.data as {
       profile: Profile;
-      page: PaginatedEvent<Event>;
+      page: Paginated<Event, EventPaginationParams>;
     };
     this.profile = data.profile;
     this.page = data.page;

--- a/frontend/src/app/event/event.service.ts
+++ b/frontend/src/app/event/event.service.ts
@@ -17,7 +17,7 @@ import {
   parseEventJson
 } from './event.model';
 import { DatePipe } from '@angular/common';
-import { EventPaginationParams, PaginatedEvent } from 'src/app/pagination';
+import { EventPaginationParams } from 'src/app/pagination';
 import { Profile, ProfileService } from '../profile/profile.service';
 import { Paginated, PaginationParams } from '../pagination';
 import { RxEvent } from './rx-event';
@@ -53,7 +53,7 @@ export class EventService {
       filter: params.filter
     };
     let query = new URLSearchParams(paramStrings);
-    return this.http.get<Paginated<Profile>>(
+    return this.http.get<Paginated<Profile, PaginationParams>>(
       `/api/events/${event_id}/registrations/users?` + query.toString()
     );
   }
@@ -225,7 +225,7 @@ export class EventService {
     let query = new URLSearchParams(paramStrings);
     if (this.profile) {
       return this.http
-        .get<PaginatedEvent<EventJson>>(
+        .get<Paginated<EventJson, EventPaginationParams>>(
           '/api/events/paginate?' + query.toString()
         )
         .pipe(
@@ -237,7 +237,7 @@ export class EventService {
     } else {
       // if a user isn't logged in, return the normal endpoint without registration statuses
       return this.http
-        .get<PaginatedEvent<EventJson>>(
+        .get<Paginated<EventJson, EventPaginationParams>>(
           '/api/events/paginate/unauthenticated?' + query.toString()
         )
         .pipe(

--- a/frontend/src/app/event/event.service.ts
+++ b/frontend/src/app/event/event.service.ts
@@ -17,9 +17,12 @@ import {
   parseEventJson
 } from './event.model';
 import { DatePipe } from '@angular/common';
-import { EventPaginationParams } from 'src/app/pagination';
 import { Profile, ProfileService } from '../profile/profile.service';
-import { Paginated, PaginationParams } from '../pagination';
+import {
+  Paginated,
+  PaginationParams,
+  TimeRangePaginationParams
+} from '../pagination';
 import { RxEvent } from './rx-event';
 
 @Injectable({
@@ -214,7 +217,7 @@ export class EventService {
     );
   }
 
-  list(params: EventPaginationParams) {
+  list(params: TimeRangePaginationParams) {
     let paramStrings = {
       order_by: params.order_by,
       ascending: params.ascending,
@@ -225,7 +228,7 @@ export class EventService {
     let query = new URLSearchParams(paramStrings);
     if (this.profile) {
       return this.http
-        .get<Paginated<EventJson, EventPaginationParams>>(
+        .get<Paginated<EventJson, TimeRangePaginationParams>>(
           '/api/events/paginate?' + query.toString()
         )
         .pipe(
@@ -237,7 +240,7 @@ export class EventService {
     } else {
       // if a user isn't logged in, return the normal endpoint without registration statuses
       return this.http
-        .get<Paginated<EventJson, EventPaginationParams>>(
+        .get<Paginated<EventJson, TimeRangePaginationParams>>(
           '/api/events/paginate/unauthenticated?' + query.toString()
         )
         .pipe(

--- a/frontend/src/app/event/widgets/event-users-list/event-users-list.widget.ts
+++ b/frontend/src/app/event/widgets/event-users-list/event-users-list.widget.ts
@@ -9,7 +9,7 @@
 
 import { Component, Input, OnInit } from '@angular/core';
 import { PageEvent } from '@angular/material/paginator';
-import { Paginated } from 'src/app/pagination';
+import { Paginated, PaginationParams } from 'src/app/pagination';
 import { Profile } from 'src/app/models.module';
 import { EventService } from '../../event.service';
 import { Event } from '../../event.model';
@@ -21,7 +21,7 @@ import { Event } from '../../event.model';
 })
 export class EventUsersList implements OnInit {
   @Input() event!: Event;
-  page!: Paginated<Profile>;
+  page!: Paginated<Profile, PaginationParams>;
 
   public displayedColumns: string[] = ['name', 'pronouns', 'email'];
 

--- a/frontend/src/app/pagination.ts
+++ b/frontend/src/app/pagination.ts
@@ -99,6 +99,7 @@ abstract class PaginatorAbstraction<T, Params extends URLSearchParams> {
    * @template APIType: (Optional) Response model from the API call, if it is different than `T`.
    * @param paramStrings: Pagination parameters.
    * @param operator: (Optional) Function to convert data from `Paginated<APIType>` to `Paginated<T>`.
+   * @returns {Observable<Paginated<T, Params>>}
    */
   loadPage<APIType = T>(
     paramStrings: Params,

--- a/frontend/src/app/pagination.ts
+++ b/frontend/src/app/pagination.ts
@@ -52,9 +52,6 @@ export interface Paginated<T, ParamType> {
  *
  * @template T: Type of data stored in the paginator's pages.
  * @template Params: Type of the pagination params used by the type of object being paginated.
- *
- * Sample Type:
- * `Paginator<Event, EventPaginationParams>`: Paginates `Event` models using params defined in `EventPaginationParams`.
  */
 abstract class PaginatorAbstraction<T, Params extends URLSearchParams> {
   /** Stores the previously used parameters for reference. */
@@ -84,7 +81,6 @@ abstract class PaginatorAbstraction<T, Params extends URLSearchParams> {
    *
    * Usage:
    * ```
-   * let paginator: Paginator<Organization, OrganizationPaginationParams> = new Paginator<>('api/organization');
    * paginator.loadPage<>(params);
    * paginator.page(); // Returns the loaded page.
    * ```
@@ -96,7 +92,6 @@ abstract class PaginatorAbstraction<T, Params extends URLSearchParams> {
    *
    * Usage:
    * ```
-   * let paginator: Paginator<Event, EventPaginationParams> = new Paginator<>('/api/event');
    * paginator.loadPage<EventJson>(params, parseEventJson);
    * paginator.page(); // Returns the loaded page, in type `Paginated<T>`
    * ```

--- a/frontend/src/app/pagination.ts
+++ b/frontend/src/app/pagination.ts
@@ -139,8 +139,10 @@ abstract class PaginatorAbstraction<T, Params extends URLSearchParams> {
   }
 }
 
+/** Default paginator implementation. */
 export class Paginator<T> extends PaginatorAbstraction<T, PaginationParams> {}
 
+/** Paginator implementation for working with time ranges. */
 export class TimeRangePaginator<T> extends PaginatorAbstraction<
   T,
   TimeRangePaginationParams

--- a/frontend/src/app/pagination.ts
+++ b/frontend/src/app/pagination.ts
@@ -15,15 +15,15 @@ import { WritableSignal, signal } from '@angular/core';
 import { map, tap } from 'rxjs';
 
 /** Defines the general model for the pagination parameters expected by the backend. */
-export interface PaginationParams {
+export interface PaginationParams extends URLSearchParams {
   page: number;
   page_size: number;
   order_by: string;
   filter: string;
 }
 
-/** Defines the model for the pagination parameters expected by the events feature backend. */
-export interface EventPaginationParams {
+/** Defines the general model for the time range pagination parameters expected by the backend. */
+export interface TimeRangePaginationParams extends URLSearchParams {
   order_by: string;
   ascending: string;
   filter: string;
@@ -56,7 +56,7 @@ export interface Paginated<T, ParamType> {
  * Sample Type:
  * `Paginator<Event, EventPaginationParams>`: Paginates `Event` models using params defined in `EventPaginationParams`.
  */
-class Paginator<T, Params extends Record<string, string>> {
+abstract class PaginatorAbstraction<T, Params extends URLSearchParams> {
   /** Stores the previously used parameters for reference. */
   previousParams: Params | null = null;
 
@@ -138,3 +138,10 @@ class Paginator<T, Params extends Record<string, string>> {
     }
   }
 }
+
+export class Paginator<T> extends PaginatorAbstraction<T, PaginationParams> {}
+
+export class TimeRangePaginator<T> extends PaginatorAbstraction<
+  T,
+  TimeRangePaginationParams
+> {}

--- a/frontend/src/app/pagination.ts
+++ b/frontend/src/app/pagination.ts
@@ -1,3 +1,20 @@
+/**
+ * The functionality on this page abstracts out the process of pagination in the frontend so that
+ * working with pagination in services and in components is significantly easier. The abstraction
+ * supports simple pagination, as well as pagination where the HTTP response model does not match
+ * the type of model stored in each page.
+ *
+ * The abstraction makes strong use of generic types so that the feature is flexible to be used
+ * across the site with minimal localization.
+ *
+ * @author Ajay Gandecha <agandecha@unc.edu>
+ */
+
+import { HttpClient } from '@angular/common/http';
+import { WritableSignal, signal } from '@angular/core';
+import { OperatorFunction, tap } from 'rxjs';
+
+/** Defines the general model for the pagination parameters expected by the backend. */
 export interface PaginationParams {
   page: number;
   page_size: number;
@@ -5,6 +22,7 @@ export interface PaginationParams {
   filter: string;
 }
 
+/** Defines the model for the pagination parameters expected by the events feature backend. */
 export interface EventPaginationParams {
   order_by: string;
   ascending: string;
@@ -13,14 +31,123 @@ export interface EventPaginationParams {
   range_end: string;
 }
 
-export interface Paginated<T> {
+/**
+ * Interface that defines a page returned from a paginator.
+ *
+ * @template T: Type of data stored in the page.
+ * @template ParamType: The shape of the parameters used for this page.
+ */
+export interface Paginated<T, ParamType> {
   items: T[];
   length: number;
-  params: PaginationParams;
+  params: ParamType;
 }
 
-export interface PaginatedEvent<T> {
-  items: T[];
-  length: number;
-  params: EventPaginationParams;
+/**
+ * Type alias for a pagination operator function that converts a paginated object of type `APIType`
+ * to a paginated object of type `T`. This is useful when the result of a pagination API call is not
+ * in the same format as the final data type expected.
+ *
+ * For example, the event API calls return objects in the `EventJSON` format, however we use the
+ * `Event` type ultimately (the types for dates in `EventJSON` are strings, but the type for dates
+ * in `Event` are `datetime`s). So, we can define a `PaginationOperatorFunction` to convert from the
+ * `EventJSON` format to the `Event` format in our paginator with the finalized type of
+ * `PaginationOperatorFunction<EventJSON, Event, EventPaginationParams>`.
+ *
+ * @template APIType: The API HTTP Response type.
+ * @template T: The resulting type after the conversion.
+ * @template Params: The type of the pagination params.
+ */
+export type PaginationOperatorFunction<APIType, T, Params> = OperatorFunction<
+  Paginated<APIType, Params>,
+  Paginated<T, Params>
+>;
+
+/**
+ * This class abstracts the functionality of pagination to be significantly easier to work with across the
+ * entire frontend. The paginator works across all different object types and pagination param types with
+ * generics, contains functionality to convert between HTTP response models (such as `EventJson`) to regular
+ * models (such as `Event`). The `page` emitted by the paginator is reactive using a signal, so data automatically
+ * refreshes, simplifying data handlng in frontend components.
+ *
+ * @template T: Type of data stored in the paginator's pages.
+ * @template Params: Type of the pagination params used by the type of object being paginated.
+ *
+ * Sample Type:
+ * `Paginator<Event, EventPaginationParams>`: Paginates `Event` models using params defined in `EventPaginationParams`.
+ */
+class Paginator<T, Params extends Record<string, string>> {
+  /** Stores the previously used parameters for reference. */
+  previousParams: Params | null = null;
+
+  /** Internal writeable signal that updates when a new page is loaded. */
+  private pageSignal: WritableSignal<Paginated<T, Params> | undefined> =
+    signal(undefined);
+  /** Signal that exposes the currently active pagination page to frontend services and components. */
+  public page = this.pageSignal.asReadonly();
+
+  /**
+   * Constructs a paginator object.
+   *
+   * @param api: The string of the API endpoint to be called when a new page is loaded.
+   */
+  constructor(
+    protected api: string,
+    protected http: HttpClient
+  ) {
+    this.api = api;
+  }
+
+  /**
+   * Loads a new pagination page based on the API endpoint provided in the constructor and provided
+   * pagination parameters.
+   *
+   * Usage:
+   * ```
+   * Paginator<Organization, OrganizationPaginationParams> paginator = new Paginator<>('api/organization');
+   * paginator.loadPage<>(params);
+   * paginator.page(); // Returns the loaded page.
+   * ```
+   *
+   * This method also supports a pagination operator function in the case that the API endpoint returns
+   * a model that is different than the provided type `T` for the paginator. This is to be most commonly
+   * used with converting `Json` repsonse models to the regular typed response models. To support this,
+   * the .loadPage method supports a optional generic type for the API response type.
+   *
+   * Usage:
+   * ```
+   * Paginator<Event, EventPaginationParams> paginator = new Paginator<>('/api/event');
+   * paginator.loadPage<EventJson>(params, eventJsonToEventOperatorFunction);
+   * paginator.page(); // Returns the loaded page, in type `Paginated<T>`
+   * ```
+   *
+   * @template APIType: (Optional) Response model from the API call, if it is different than `T`.
+   * @param paramStrings: Pagination parameters.
+   * @param operator: (Optional) Operator to convert data from `Paginated<APIType>` to `Paginated<T>`.
+   */
+  loadPage<APIType = T>(
+    paramStrings: Params,
+    operator?: PaginationOperatorFunction<APIType, T, Params> | null
+  ) {
+    // Stpres the previous pagination parameters used
+    this.previousParams = paramStrings;
+
+    // Determines the query for the URL based on the new paramateres.
+    let query = new URLSearchParams(paramStrings);
+    let route = this.api + '?' + query.toString();
+
+    // Determine if an operator function is necessary
+    if (operator) {
+      // If so, call the API, pipe it through the operator, and update the signal.
+      this.http.get<Paginated<APIType, Params>>(route).pipe(
+        operator,
+        tap((pageData) => this.pageSignal.set(pageData))
+      );
+    } else {
+      // Otherwise, just call the API and update the signal.
+      this.http
+        .get<Paginated<T, Params>>(route)
+        .pipe(tap((pageData) => this.pageSignal.set(pageData)));
+    }
+  }
 }

--- a/frontend/src/app/pagination.ts
+++ b/frontend/src/app/pagination.ts
@@ -82,7 +82,6 @@ abstract class PaginatorAbstraction<T, Params extends URLSearchParams> {
    * Usage:
    * ```
    * paginator.loadPage<>(params);
-   * paginator.page(); // Returns the loaded page.
    * ```
    *
    * This method also supports a  operator function in the case that the API endpoint returns
@@ -93,7 +92,6 @@ abstract class PaginatorAbstraction<T, Params extends URLSearchParams> {
    * Usage:
    * ```
    * paginator.loadPage<EventJson>(params, parseEventJson);
-   * paginator.page(); // Returns the loaded page, in type `Paginated<T>`
    * ```
    *
    * @template APIType: (Optional) Response model from the API call, if it is different than `T`.

--- a/frontend/src/app/pagination.ts
+++ b/frontend/src/app/pagination.ts
@@ -104,7 +104,7 @@ class Paginator<T, Params extends Record<string, string>> {
    *
    * Usage:
    * ```
-   * Paginator<Organization, OrganizationPaginationParams> paginator = new Paginator<>('api/organization');
+   * let paginator: Paginator<Organization, OrganizationPaginationParams> = new Paginator<>('api/organization');
    * paginator.loadPage<>(params);
    * paginator.page(); // Returns the loaded page.
    * ```
@@ -116,7 +116,7 @@ class Paginator<T, Params extends Record<string, string>> {
    *
    * Usage:
    * ```
-   * Paginator<Event, EventPaginationParams> paginator = new Paginator<>('/api/event');
+   * let paginator: Paginator<Event, EventPaginationParams> = new Paginator<>('/api/event');
    * paginator.loadPage<EventJson>(params, eventJsonToEventOperatorFunction);
    * paginator.page(); // Returns the loaded page, in type `Paginated<T>`
    * ```


### PR DESCRIPTION
This pull request creates a new frontend abstraction for pagination. The abstraction supports simple pagination, as well as pagination where the HTTP response model does not match the type of model stored in each page. The abstraction makes strong use of generic types so that the feature is flexible to be used across the site with minimal localization.

This pull request does not implement the abstraction in any features. I was planning on utilizing this in the events feature refactor.

*Again, I am adding @jadekeegan and @atoneyd to this PR, since we have all been working on pagination for quite a while. No need to complete CRs here! You all should not be bothered with notifications after this PR and the events refactor PR come in!*

## Usage

This PR adds the `Paginator<T, Params>` class, which is the main "service" tool responsible for pagination. This paginator object has two generic types, where `T` is for the type of object being paginated, and `Params` specifies the specific type of parameters used for pagination. This is useful for certain features such as the events feature, where `EventPaginationParams` has a different shape than `PaginationParams` to account for date ranges. The object's constructor takes in an API endpoint as a string, which is the API endpoint to be called every time a new page loads. 

This is an example usage for a hypothetical organization paginator:

```ts
let paginator: Paginator<Organization, PaginationParams> = new Paginator<>('api/organizations');
```

Pages are loaded with the `.loadPage(params)` function, which takes in a params object corresponding with the generic type `Params` provided in the paginator's construction. This is an example usage of loading the next page for the paginator defined above:

```ts
paginator.loadPage(params);
```

When a page is loaded, a *signal* (Angular v17 feature, analogous to `RxObject`) called `page` is updated inside the paginator object. We can easily access the data like so:

```ts
paginator.page(); // Loads the current page.
```

The `loadPage()` function is more powerful. There are many cases in the CSXL site where the *response model* from the API is **not** the same as the model of data we are trying to store in pages. This is most notable in the events feature. The API endpoint for events return data in the `EventJson` format, where dates are codified as strings. Then, in the frontend, this is converted to standard `Event` format. This convention is used so that dates are converted properly.

The `loadPage()` function can account for this. The function has an optional generic type parameter called `APIType`, which by default is just `T`. This generic type signals the type of the response rather than the type of data stored in the page. This can be different from `T` in cases where they are not the same.

In addition, this defines a type alias called `PaginationOperatorFunction<APIType, T, Params>`, which is just an operator function that helps to convert `Paginated<APIType, Params>` objects to `Paginated<T, Params`>. This alias just helps the code to be a bit more readable, and is defined as follows:

```ts
type PaginationOperatorFunction<APIType, T, Params> = OperatorFunction<Paginated<APIType, Params>, Paginated<T, Params>>;
```

So, `.loadPage<APIType>(params, operator) can take in an operator function of type `PaginationOperatorFunction` which processes the conversion.

Here is the example usage for events:
```ts
let paginator: Paginator<Event, EventPaginationParams> = new Paginator<>('/api/event');
paginator.loadPage<EventJson>(params, eventJsonToEventOperatorFunction);
paginator.page(); // Returns the loaded page, in type `Paginated<T>`
```
