### PR TITLE
Fix Critical Issue - Applications Data Leaking with Section Data

### DIFF
--- a/backend/entities/academics/section_entity.py
+++ b/backend/entities/academics/section_entity.py
@@ -162,7 +162,4 @@ class SectionEntity(EntityBase):
                 if self.office_hours_section is not None
                 else None
             ),
-            preferred_applicants=[
-                applicant.to_model() for applicant in self.preferred_applicants
-            ],
         )

--- a/backend/models/academics/section_details.py
+++ b/backend/models/academics/section_details.py
@@ -3,9 +3,6 @@ from pydantic import BaseModel
 from ...models.academics.section_member import SectionMember
 from ...models.office_hours.section import OfficeHoursSection
 
-from ..room import Room
-from backend.models.application import UTAApplication
-
 from .course import Course
 from .term import Term
 from .section import Section
@@ -28,4 +25,3 @@ class SectionDetails(Section):
     term: Term
     office_hours_section: OfficeHoursSection | None
     members: list[SectionMember]
-    preferred_applicants: list[UTAApplication]


### PR DESCRIPTION
This pull request removes the `preferred_applicants` field from the backend section model. This field leaks users' application data via the public GET section data API. In addition, this data caused pages relying on sections data to load extremely slowly.

After further analysis, it does not appear that this extra field had any functionality in the backend, so I think it can be safely removed.