### PR TITLE
Index Academics join table columns that back common queries

### DIFF
--- a/backend/entities/academics/section_entity.py
+++ b/backend/entities/academics/section_entity.py
@@ -1,7 +1,7 @@
 """Definition of SQLAlchemy table-backed object mapping entity for Course Sections."""
 
 from typing import Self
-from sqlalchemy import Integer, String, ForeignKey
+from sqlalchemy import Integer, String, ForeignKey, Index
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..entity_base import EntityBase
 from ..section_application_table import section_application_table
@@ -18,6 +18,22 @@ class SectionEntity(EntityBase):
 
     # Name for the course section table in the PostgreSQL database
     __tablename__ = "academics__section"
+
+    # Add indexes to the database for fast, common lookup queries
+    __table_args__ = (
+        Index(
+            "ix_academics__section__by_term",
+            "term_id",
+            "course_id",
+            unique=False,
+        ),
+        Index(
+            "ix_academics__section__by_course",
+            "course_id",
+            "term_id",
+            unique=False,
+        ),
+    )
 
     # Section properties (columns in the database table)
 

--- a/backend/entities/academics/section_member_entity.py
+++ b/backend/entities/academics/section_member_entity.py
@@ -48,8 +48,8 @@ class SectionMemberEntity(EntityBase):
         Index(
             "ix_academics__user_section__by_section",
             "section_id",
-            "user_id",
-            unique=True,
+            "member_role",
+            unique=False,
         ),
     )
 

--- a/backend/entities/academics/section_member_entity.py
+++ b/backend/entities/academics/section_member_entity.py
@@ -1,12 +1,12 @@
 """Definition of SQLAlchemy table-backed object mapping entity for the user - section association table."""
 
 from typing import Self
-from sqlalchemy import ForeignKey, Integer
+from sqlalchemy import ForeignKey, Integer, Index
 from sqlalchemy import Enum as SQLAlchemyEnum
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from backend.entities.office_hours import user_created_tickets_table
-from backend.models.academics.section_member_details import SectionMemberDetails
+from ..office_hours import user_created_tickets_table
+from ...models.academics.section_member_details import SectionMemberDetails
 
 from ...models.roster_role import RosterRole
 from ...models.academics.section_member import SectionMember, SectionMemberDraft
@@ -37,6 +37,22 @@ class SectionMemberEntity(EntityBase):
     # Name for the user section table in the PostgreSQL database
     __tablename__ = "academics__user_section"
 
+    # Add indexes to the database for fast, common lookup queries
+    __table_args__ = (
+        Index(
+            "ix_academics__user_section__by_user",
+            "user_id",
+            "section_id",
+            unique=True,
+        ),
+        Index(
+            "ix_academics__user_section__by_section",
+            "section_id",
+            "user_id",
+            unique=True,
+        ),
+    )
+
     # User Section properties (columns in the database table)
 
     # Unique ID for a user's membership in an academic section
@@ -63,10 +79,6 @@ class SectionMemberEntity(EntityBase):
     # Tickets that have been called by the user
     called_oh_tickets: Mapped[list["OfficeHoursTicketEntity"]] = relationship(
         back_populates="caller", cascade="all, delete"
-    )
-
-    application_id: Mapped[int] = mapped_column(
-        ForeignKey("application.id"), nullable=True
     )
 
     def to_flat_model(self) -> SectionMember:

--- a/backend/migrations/versions/87dd1109e7b2_migration_for_academics_indexes.py
+++ b/backend/migrations/versions/87dd1109e7b2_migration_for_academics_indexes.py
@@ -35,8 +35,8 @@ def upgrade() -> None:
     op.create_index(
         "ix_academics__user_section__by_section",
         "academics__user_section",
-        ["section_id", "user_id"],
-        unique=True,
+        ["section_id", "member_role"],
+        unique=False,
     )
     op.create_index(
         "ix_academics__user_section__by_user",

--- a/backend/migrations/versions/87dd1109e7b2_migration_for_academics_indexes.py
+++ b/backend/migrations/versions/87dd1109e7b2_migration_for_academics_indexes.py
@@ -1,0 +1,76 @@
+"""Adds Indexes to Academics for common query patterns.
+
+Revision ID: 87dd1109e7b2
+Revises: eb379629af4f
+Create Date: 2024-06-08 07:17:36.113064
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "87dd1109e7b2"
+down_revision = "eb379629af4f"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add indices to the academics__section and academics__user_section tables for common query patterns.
+    op.create_index(
+        "ix_academics__section__by_course",
+        "academics__section",
+        ["course_id", "term_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_academics__section__by_term",
+        "academics__section",
+        ["term_id", "course_id"],
+        unique=False,
+    )
+
+    op.create_index(
+        "ix_academics__user_section__by_section",
+        "academics__user_section",
+        ["section_id", "user_id"],
+        unique=True,
+    )
+    op.create_index(
+        "ix_academics__user_section__by_user",
+        "academics__user_section",
+        ["user_id", "section_id"],
+        unique=True,
+    )
+
+    # Remove the foreign key to a TA application from UserSection. It will go somewhere else eventually.
+    op.drop_constraint(
+        "academics__user_section_application_id_fkey",
+        "academics__user_section",
+        type_="foreignkey",
+    )
+    op.drop_column("academics__user_section", "application_id")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "academics__user_section",
+        sa.Column("application_id", sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.create_foreign_key(
+        "academics__user_section_application_id_fkey",
+        "academics__user_section",
+        "application",
+        ["application_id"],
+        ["id"],
+    )
+    op.drop_index(
+        "ix_academics__user_section__by_user", table_name="academics__user_section"
+    )
+    op.drop_index(
+        "ix_academics__user_section__by_section", table_name="academics__user_section"
+    )
+    op.drop_index("ix_academics__section__by_term", table_name="academics__section")
+    op.drop_index("ix_academics__section__by_course", table_name="academics__section")


### PR DESCRIPTION
By adding Indexes to Academics' SectionMemberEntity (by user and by section), and SectionEntity (by term and by course), we should see an automatic performance increase for some common queries (e.g. look up all members of a section or all sections for a user).

This PR also drops the `application_id` column from `SectionMemberEntity` as a cleanup while we're running a migration on the table. When the time comes, this information (linking a section member to their TA application) can be held in a different entity, for example a `TAAssignmentEntity` which can join an application to a member (with additional information such as hiring level, and so on).

Migration created and validated per the `backend/migrations/README` validation steps.