### PR TITLE
Section Instructor UI, Section Catalog Load Time, and Other Academics Editor Fixes

### DIFF
--- a/backend/api/academics/section.py
+++ b/backend/api/academics/section.py
@@ -6,7 +6,7 @@ from fastapi import APIRouter, Depends
 from ..authentication import registered_user
 from ...services.academics import SectionService
 from ...models import User
-from ...models.academics import Section, SectionDetails
+from ...models.academics import Section, SectionDetails, CatalogSection
 from ...models.academics.section import EditedSection
 
 __authors__ = ["Ajay Gandecha"]
@@ -17,18 +17,7 @@ __license__ = "MIT"
 api = APIRouter(prefix="/api/academics/section")
 
 
-@api.get("", response_model=list[SectionDetails], tags=["Academics"])
-def get_sections(section_service: SectionService = Depends()) -> list[SectionDetails]:
-    """
-    Get all sections
-
-    Returns:
-        list[SectionDetails]: All `Section`s in the `Section` database table
-    """
-    return section_service.all()
-
-
-@api.get("/update-enrollments", response_model=None, tags=["Academics"])
+@api.get("/update-enrollments", tags=["Academics"])
 def update_enrollments(
     subject: User = Depends(registered_user),
     section_service: SectionService = Depends(),
@@ -39,35 +28,34 @@ def update_enrollments(
     return section_service.update_enrollment_totals(subject)
 
 
-@api.get("/{id}", response_model=SectionDetails, tags=["Academics"])
+@api.get("/{id}", tags=["Academics"])
 def get_section_by_id(
     id: int, section_service: SectionService = Depends()
-) -> SectionDetails:
+) -> CatalogSection:
     """
     Gets one section by its id
 
     Returns:
-        SectionDetails: Section with the given ID
+        CatalogSection: Section with the given ID
     """
     return section_service.get_by_id(id)
 
 
-@api.get("/term/{term_id}", response_model=list[SectionDetails], tags=["Academics"])
+@api.get("/term/{term_id}", tags=["Academics"])
 def get_section_by_term_id(
     term_id: str, section_service: SectionService = Depends()
-) -> list[SectionDetails]:
+) -> list[CatalogSection]:
     """
     Gets list of sections by term ID
 
     Returns:
-        list[SectionDetails]: Sections with the given term
+        list[CatalogSection]: Sections with the given term
     """
     return section_service.get_by_term(term_id)
 
 
 @api.get(
     "/{subject_code}/{course_number}/{section_number}",
-    response_model=SectionDetails,
     tags=["Academics"],
 )
 def get_section_by_subject_code(
@@ -75,12 +63,12 @@ def get_section_by_subject_code(
     course_number: str,
     section_number: str,
     section_service: SectionService = Depends(),
-) -> SectionDetails:
+) -> CatalogSection:
     """
     Gets one section by its properties
 
     Returns:
-        SectionDetails: Course with the given properties
+        CatalogSection: Course with the given properties
     """
     return section_service.get(subject_code, course_number, section_number)
 

--- a/backend/api/academics/section.py
+++ b/backend/api/academics/section.py
@@ -7,6 +7,7 @@ from ..authentication import registered_user
 from ...services.academics import SectionService
 from ...models import User
 from ...models.academics import Section, SectionDetails
+from ...models.academics.section import EditedSection
 
 __authors__ = ["Ajay Gandecha"]
 __copyright__ = "Copyright 2023"
@@ -86,7 +87,7 @@ def get_section_by_subject_code(
 
 @api.post("", response_model=SectionDetails, tags=["Academics"])
 def new_section(
-    section: Section,
+    section: EditedSection,
     subject: User = Depends(registered_user),
     section_service: SectionService = Depends(),
 ) -> SectionDetails:
@@ -101,7 +102,7 @@ def new_section(
 
 @api.put("", response_model=SectionDetails, tags=["Academics"])
 def update_section(
-    section: Section,
+    section: EditedSection,
     subject: User = Depends(registered_user),
     section_service: SectionService = Depends(),
 ) -> SectionDetails:

--- a/backend/api/academics/section.py
+++ b/backend/api/academics/section.py
@@ -29,14 +29,12 @@ def update_enrollments(
 
 
 @api.get("/{id}", tags=["Academics"])
-def get_section_by_id(
-    id: int, section_service: SectionService = Depends()
-) -> CatalogSection:
+def get_section_by_id(id: int, section_service: SectionService = Depends()) -> Section:
     """
     Gets one section by its id
 
     Returns:
-        CatalogSection: Section with the given ID
+        Section: Section with the given ID
     """
     return section_service.get_by_id(id)
 

--- a/backend/api/academics/term.py
+++ b/backend/api/academics/term.py
@@ -17,35 +17,35 @@ __license__ = "MIT"
 api = APIRouter(prefix="/api/academics/term")
 
 
-@api.get("", response_model=list[TermDetails], tags=["Academics"])
-def get_terms(term_service: TermService = Depends()) -> list[TermDetails]:
+@api.get("", tags=["Academics"])
+def get_terms(term_service: TermService = Depends()) -> list[Term]:
     """
     Get all terms
 
     Returns:
-        list[TermDetails]: All `Term`s in the `Term` database table
+        list[Term]: All `Term`s in the `Term` database table
     """
     return term_service.all()
 
 
-@api.get("/current", response_model=TermDetails, tags=["Academics"])
-def get_current_term(term_service: TermService = Depends()) -> TermDetails:
+@api.get("/current", tags=["Academics"])
+def get_current_term(term_service: TermService = Depends()) -> Term:
     """
     Gets the current term based on the current date
 
     Returns:
-        TermDetails: Currently active term
+        Term: Currently active term
     """
     return term_service.get_by_date(datetime.today())
 
 
-@api.get("/{id}", response_model=TermDetails, tags=["Academics"])
-def get_term_by_id(id: str, term_service: TermService = Depends()) -> TermDetails:
+@api.get("/{id}", tags=["Academics"])
+def get_term_by_id(id: str, term_service: TermService = Depends()) -> Term:
     """
     Gets one term by its id
 
     Returns:
-        TermDetails: Term with the given ID
+        Term: Term with the given ID
     """
     return term_service.get_by_id(id)
 

--- a/backend/entities/academics/section_entity.py
+++ b/backend/entities/academics/section_entity.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ..entity_base import EntityBase
 from ..section_application_table import section_application_table
 from ...models.academics import Section
+from ...models.academics.section import EditedSection
 from ...models.academics import SectionDetails
 
 __authors__ = ["Ajay Gandecha"]
@@ -111,6 +112,28 @@ class SectionEntity(EntityBase):
     def from_model(cls, model: Section) -> Self:
         """
         Class method that converts a `Section` model into a `SectionEntity`
+
+        Parameters:
+            - model (Section): Model to convert into an entity
+        Returns:
+            SectionEntity: Entity created from model
+        """
+        return cls(
+            id=model.id,
+            course_id=model.course_id,
+            number=model.number,
+            term_id=model.term_id,
+            meeting_pattern=model.meeting_pattern,
+            override_title=model.override_title,
+            override_description=model.override_description,
+            enrolled=model.enrolled,
+            total_seats=model.total_seats,
+        )
+
+    @classmethod
+    def from_edited_model(cls, model: EditedSection) -> Self:
+        """
+        Class method that converts a `EditedSection` model into a `SectionEntity`
 
         Parameters:
             - model (Section): Model to convert into an entity

--- a/backend/entities/academics/section_entity.py
+++ b/backend/entities/academics/section_entity.py
@@ -7,10 +7,13 @@ from ..entity_base import EntityBase
 from ..section_application_table import section_application_table
 from ...models.academics import Section
 from ...models.academics.section import EditedSection
+from ...models.academics import Section, CatalogSection
 from ...models.academics import SectionDetails
+from ...models.public_user import PublicUser
+from ...models.roster_role import RosterRole
 
 __authors__ = ["Ajay Gandecha"]
-__copyright__ = "Copyright 2023"
+__copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
 
@@ -206,6 +209,44 @@ class SectionEntity(EntityBase):
             course_site=(
                 self.course_site.to_model() if self.course_site is not None else None
             ),
+            enrolled=self.enrolled,
+            total_seats=self.total_seats,
+        )
+
+    def to_catalog_model(self) -> CatalogSection:
+        """
+        Converts a `SectionEntity` object into a `CatalogSection` model object
+
+        Returns:
+            Section: `CatalogSection` object from the entity
+        """
+
+        return CatalogSection(
+            id=self.id,
+            subject_code=self.course.subject_code,
+            course_number=self.course.number,
+            section_number=self.number,
+            title=(
+                self.override_title
+                if len(self.override_title) > 0
+                else self.course.title
+            ),
+            meeting_pattern=self.meeting_pattern,
+            description=(
+                self.override_description
+                if len(self.override_description) > 0
+                else self.course.description
+            ),
+            lecture_room=(
+                self.lecture_rooms[0].room.to_model()
+                if len(self.lecture_rooms) > 0
+                else None
+            ),
+            instructors=[
+                member.user.to_public_model()
+                for member in self.members
+                if member.member_role == RosterRole.INSTRUCTOR
+            ],
             enrolled=self.enrolled,
             total_seats=self.total_seats,
         )

--- a/backend/entities/academics/section_member_entity.py
+++ b/backend/entities/academics/section_member_entity.py
@@ -90,6 +90,7 @@ class SectionMemberEntity(EntityBase):
         """
         return SectionMember(
             id=self.id,
+            user_id=self.user_id,
             first_name=self.user.first_name,
             last_name=self.user.last_name,
             pronouns=self.user.pronouns,

--- a/backend/entities/user_entity.py
+++ b/backend/entities/user_entity.py
@@ -8,7 +8,7 @@ from backend.entities.academics.section_member_entity import SectionMemberEntity
 from backend.models.academics.section_member import SectionMember
 from .entity_base import EntityBase
 from .user_role_table import user_role_table
-from ..models import User
+from ..models import User, PublicUser
 
 __authors__ = ["Kris Jordan", "Matt Vu"]
 __copyright__ = "Copyright 2023 - 2024"
@@ -133,3 +133,13 @@ class UserEntity(EntityBase):
         self.github_id = model.github_id or None
         self.github_avatar = model.github_avatar or ""
         self.accepted_community_agreement = model.accepted_community_agreement
+
+    def to_public_model(self) -> PublicUser:
+        return PublicUser(
+            id=self.id,
+            first_name=self.first_name,
+            last_name=self.last_name,
+            pronouns=self.pronouns,
+            email=self.email,
+            github_avatar=self.github_avatar,
+        )

--- a/backend/models/academics/__init__.py
+++ b/backend/models/academics/__init__.py
@@ -2,7 +2,7 @@ from .term import Term
 from .term_details import TermDetails
 from .course import Course
 from .course_details import CourseDetails
-from .section import Section
+from .section import Section, CatalogSection
 from .section_details import SectionDetails
 
 __all__ = [
@@ -11,5 +11,6 @@ __all__ = [
     "Course",
     "CourseDetails",
     "Section",
+    "CatalogSection",
     "SectionDetails",
 ]

--- a/backend/models/academics/section.py
+++ b/backend/models/academics/section.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 
 from backend.models.academics.section_member import SectionMember
 from backend.models.room import Room
+from ..public_user import PublicUser
 
 __authors__ = ["Ajay Gandecha"]
 __copyright__ = "Copyright 2023"
@@ -28,3 +29,24 @@ class Section(BaseModel):
     override_description: str
     enrolled: int
     total_seats: int
+
+
+class EditedSection(BaseModel):
+    """
+    Pydantic model to represent a `EditedSection`.
+
+    This model is based on the `SectionEntity` model, which defines the shape
+    of the `Section` database in the PostgreSQL database
+    """
+
+    id: int | None = None
+    course_id: str
+    number: str
+    term_id: str
+    meeting_pattern: str
+    lecture_room: Room | None = None
+    override_title: str
+    override_description: str
+    enrolled: int
+    total_seats: int
+    instructors: list[PublicUser]

--- a/backend/models/academics/section.py
+++ b/backend/models/academics/section.py
@@ -50,3 +50,21 @@ class EditedSection(BaseModel):
     enrolled: int
     total_seats: int
     instructors: list[PublicUser]
+
+
+class CatalogSection(BaseModel):
+    """
+    Pydantic model that represents a section for the catalog page.
+    """
+
+    id: int | None = None
+    subject_code: str
+    course_number: str
+    section_number: str
+    title: str
+    meeting_pattern: str
+    description: str
+    lecture_room: Room | None = None
+    instructors: list[PublicUser]
+    enrolled: int
+    total_seats: int

--- a/backend/models/academics/section_member.py
+++ b/backend/models/academics/section_member.py
@@ -17,6 +17,7 @@ class SectionMember(BaseModel):
     """
 
     id: int | None = None
+    user_id: int | None = None
     first_name: str
     last_name: str
     pronouns: str

--- a/backend/services/academics/section.py
+++ b/backend/services/academics/section.py
@@ -68,7 +68,7 @@ class SectionService:
         # Return the model
         return [entity.to_catalog_model() for entity in entities]
 
-    def get_by_id(self, id: int) -> CatalogSection:
+    def get_by_id(self, id: int) -> Section:
         """Gets the section from the table for an id.
 
         Args:
@@ -85,7 +85,7 @@ class SectionService:
             raise ResourceNotFoundException(f"Section with id: {id} does not exist.")
 
         # Return the model
-        return entity.to_catalog_model()
+        return entity.to_model()
 
     def get(
         self, subject_code: str, course_number: str, section_number: str

--- a/backend/services/academics/section.py
+++ b/backend/services/academics/section.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import Session
 from pydantic import BaseModel
 
 from ...database import db_session
-from ...models.academics import Section
+from ...models.academics import Section, CatalogSection
 from ...models.academics import SectionDetails
 from ...models.academics.section import EditedSection
 from ...models.roster_role import RosterRole
@@ -49,30 +49,15 @@ class SectionService:
         self._permission_svc = permission_svc
         self._section_member_svc = section_member_svc
 
-    def all(self) -> list[SectionDetails]:
-        """Retrieves all sections from the table
-
-        Returns:
-            list[SectionDetails]: List of all `SectionDetails`
-        """
-        # Select all entries in `Section` table
-        query = select(SectionEntity).order_by(
-            SectionEntity.course_id, SectionEntity.number
-        )
-        entities = self._session.scalars(query).all()
-
-        # Convert entries to a model and return
-        return [entity.to_details_model() for entity in entities]
-
-    def get_by_term(self, term_id: str) -> list[SectionDetails]:
+    def get_by_term(self, term_id: str) -> list[CatalogSection]:
         """Retrieves all sections from the table by a term.
 
         Args:
             term_id: ID of the term to query by.
         Returns:
-            list[SectionDetails]: List of all `SectionDetails`
+            list[CatalogSection]: List of all `CatalogSection`
         """
-        # Select all entries in the `Section` tabl
+        # Select all entries in the section table
         query = (
             select(SectionEntity)
             .where(SectionEntity.term_id == term_id)
@@ -81,34 +66,15 @@ class SectionService:
         entities = self._session.scalars(query).all()
 
         # Return the model
-        return [entity.to_details_model() for entity in entities]
+        return [entity.to_catalog_model() for entity in entities]
 
-    def get_by_subject(self, subject_code: str) -> list[SectionDetails]:
-        """Retrieves all sections from the table by subject code.
-
-        Args:
-            subject_code: subject to query by.
-        Returns:
-            list[SectionDetails]: List of all `SectionDetails`
-        """
-        # Select all entries in the `Section` table
-        query = (
-            select(SectionEntity)
-            .join(CourseEntity)
-            .where(CourseEntity.subject_code == subject_code)
-        )
-        entities = self._session.scalars(query).all()
-
-        # Return the model
-        return [entity.to_details_model() for entity in entities]
-
-    def get_by_id(self, id: int) -> SectionDetails:
+    def get_by_id(self, id: int) -> CatalogSection:
         """Gets the section from the table for an id.
 
         Args:
             id: ID of the section to retrieve.
         Returns:
-            SectionDetails: Section based on the id.
+            CatalogSection: Section based on the id.
         """
         # Select all entries in the `Section` table and sort by end date
         query = select(SectionEntity).filter(SectionEntity.id == id)
@@ -119,11 +85,11 @@ class SectionService:
             raise ResourceNotFoundException(f"Section with id: {id} does not exist.")
 
         # Return the model
-        return entity.to_details_model()
+        return entity.to_catalog_model()
 
     def get(
         self, subject_code: str, course_number: str, section_number: str
-    ) -> SectionDetails:
+    ) -> CatalogSection:
         """Gets a course based on its subject code, course number, and section number.
 
         Args:
@@ -131,7 +97,7 @@ class SectionService:
             course_number: Course number to query by (ex. 110 in COMP 110)
             section_number: Section number to query by (ex. 003 in COMP 110-003)
         Returns:
-            SectionDetails: Section for the parameters.
+            CatalogSection: Section for the parameters.
         """
         # Select all entries in the `Section` table that contains this date.
         query = (
@@ -152,7 +118,7 @@ class SectionService:
             )
 
         # Return the model
-        return entity.to_details_model()
+        return entity.to_catalog_model()
 
     def create(self, subject: User, section: EditedSection) -> SectionDetails:
         """Creates a new section.

--- a/backend/services/academics/term.py
+++ b/backend/services/academics/term.py
@@ -33,11 +33,11 @@ class TermService:
         self._session = session
         self._permission_svc = permission_svc
 
-    def all(self) -> list[TermDetails]:
+    def all(self) -> list[Term]:
         """Retrieves all terms from the table
 
         Returns:
-            list[TermDetails]: List of all `TermDetails`
+            list[Term]: List of all `TermDetails`
         """
         # Select all entries in `Term` table
         query = select(TermEntity).order_by(TermEntity.start)
@@ -45,15 +45,15 @@ class TermService:
         entities = self._session.scalars(query).all()
 
         # Convert entries to a model and return
-        return [entity.to_details_model() for entity in entities]
+        return [entity.to_model() for entity in entities]
 
-    def get_by_id(self, id: str) -> TermDetails:
+    def get_by_id(self, id: str) -> Term:
         """Gets the term from the table for an id.
 
         Args:
             id: ID of the term to retrieve.
         Returns:
-            TermDetails: Term based on the id.
+            Term: Term based on the id.
         """
         # Select all entries in the `Term` table and sort by end date
         query = select(TermEntity).filter(TermEntity.id == id).limit(1)
@@ -64,15 +64,15 @@ class TermService:
             raise ResourceNotFoundException(f"Term with id: {id} does not exist.")
 
         # Return the model
-        return entity.to_details_model()
+        return entity.to_model()
 
-    def get_by_date(self, date: datetime) -> TermDetails:
+    def get_by_date(self, date: datetime) -> Term:
         """Gets the active term for a given date, if it exists.
 
         Args:
             date: Date to query the active term for.
         Returns:
-            TermDetails: Term based on the provided date.
+            Term: Term based on the provided date.
         """
         # Select all entries in the `Term` table that contains this date.
         # This query either selects the most current term, or the upcoming term if there
@@ -89,7 +89,7 @@ class TermService:
             )
 
         # Return the model
-        return entity.to_details_model()
+        return entity.to_model()
 
     def create(self, subject: User, term: Term) -> TermDetails:
         """Creates a new term.

--- a/backend/test/services/academics/section_data.py
+++ b/backend/test/services/academics/section_data.py
@@ -13,6 +13,7 @@ from ....models.room_details import RoomDetails
 from ....entities.academics import SectionEntity
 from ....entities.academics import SectionMemberEntity
 from ....models.academics import Section
+from ....models.academics.section import EditedSection
 from ....models.roster_role import RosterRole
 
 from ..reset_table_id_seq import reset_table_id_seq
@@ -116,7 +117,7 @@ comp_311_001 = Section(
     total_seats=200,
 )
 
-edited_comp_110 = Section(
+edited_comp_110 = EditedSection(
     id=2,
     course_id=course_data.comp_110.id,
     number="002",
@@ -126,9 +127,10 @@ edited_comp_110 = Section(
     override_description="",
     enrolled=100,
     total_seats=200,
+    instructors=[],
 )
 
-edited_comp_110_with_room = Section(
+edited_comp_110_with_room = EditedSection(
     id=2,
     course_id=course_data.comp_110.id,
     number="002",
@@ -139,9 +141,10 @@ edited_comp_110_with_room = Section(
     lecture_room=virtual_room,
     enrolled=100,
     total_seats=200,
+    instructors=[],
 )
 
-edited_comp_301_with_room = Section(
+edited_comp_301_with_room = EditedSection(
     id=5,
     course_id=course_data.comp_301.id,
     number="001",
@@ -152,9 +155,10 @@ edited_comp_301_with_room = Section(
     lecture_room=virtual_room,
     enrolled=100,
     total_seats=200,
+    instructors=[],
 )
 
-new_section = Section(
+new_section = EditedSection(
     id=7,
     course_id=course_data.comp_110.id,
     number="003",
@@ -164,9 +168,10 @@ new_section = Section(
     override_description="",
     enrolled=100,
     total_seats=200,
+    instructors=[],
 )
 
-new_section_with_lecture_room = Section(
+new_section_with_lecture_room = EditedSection(
     id=8,
     course_id=course_data.comp_110.id,
     number="003",
@@ -177,6 +182,7 @@ new_section_with_lecture_room = Section(
     lecture_room=virtual_room,
     enrolled=100,
     total_seats=200,
+    instructors=[],
 )
 
 

--- a/backend/test/services/academics/section_test.py
+++ b/backend/test/services/academics/section_test.py
@@ -9,7 +9,7 @@ from backend.services.exceptions import (
 )
 from backend.services.permission import PermissionService
 from ....services.academics import SectionService, SectionMemberService
-from ....models.academics import SectionDetails
+from ....models.academics import SectionDetails, CatalogSection
 
 # Imported fixtures provide dependencies injected for the tests as parameters.
 from .fixtures import permission_svc, section_svc, section_member_svc
@@ -30,35 +30,15 @@ __copyright__ = "Copyright 2023"
 __license__ = "MIT"
 
 
-def test_all(section_svc: SectionService):
-    sections = section_svc.all()
-
-    assert len(sections) == len(section_data.sections)
-    assert isinstance(sections[0], SectionDetails)
-
-
 def test_get_by_term(section_svc: SectionService):
     sections = section_svc.get_by_term(term_data.current_term.id)
 
     assert len(sections) == len(section_data.current_term_sections)
-    assert isinstance(sections[0], SectionDetails)
+    assert isinstance(sections[0], CatalogSection)
 
 
 def test_get_by_term_not_found(section_svc: SectionService):
     sections = section_svc.get_by_term(term_data.sp_23.id)
-
-    assert len(sections) == 0
-
-
-def test_get_by_subject(section_svc: SectionService):
-    sections = section_svc.get_by_subject("COMP")
-
-    assert len(sections) == len(section_data.sections)
-    assert isinstance(sections[0], SectionDetails)
-
-
-def test_get_by_subject_not_found(section_svc: SectionService):
-    sections = section_svc.get_by_subject("INLS")
 
     assert len(sections) == 0
 
@@ -69,7 +49,7 @@ def test_get_by_id(section_svc: SectionService):
 
     section = section_svc.get_by_id(section_data.comp_110_001_current_term.id)
 
-    assert isinstance(section, SectionDetails)
+    assert isinstance(section, CatalogSection)
     assert section.id == section_data.comp_110_001_current_term.id
 
 
@@ -82,7 +62,7 @@ def test_get_by_id_not_found(section_svc: SectionService):
 def test_get(section_svc: SectionService):
     section = section_svc.get("COMP", "210", "001")
 
-    assert isinstance(section, SectionDetails)
+    assert isinstance(section, CatalogSection)
     assert section.id == section_data.comp_210_001_current_term.id
 
 
@@ -196,9 +176,6 @@ def test_delete_as_root(section_svc: SectionService):
         "academics.section.delete",
         f"section/{section_data.comp_110_001_current_term.id}",
     )
-
-    sections = section_svc.all()
-    assert len(sections) == len(section_data.sections) - 1
 
 
 def test_delete_as_root_not_found(section_svc: SectionService):

--- a/backend/test/services/academics/term_test.py
+++ b/backend/test/services/academics/term_test.py
@@ -8,7 +8,7 @@ from backend.services.exceptions import (
 )
 from backend.services.permission import PermissionService
 from ....services.academics import TermService
-from ....models.academics import TermDetails
+from ....models.academics import TermDetails, Term
 
 # Imported fixtures provide dependencies injected for the tests as parameters.
 from .fixtures import permission_svc, term_svc
@@ -29,13 +29,13 @@ def test_all(term_svc: TermService):
     terms = term_svc.all()
 
     assert len(terms) == len(term_data.terms)
-    assert isinstance(terms[0], TermDetails)
+    assert isinstance(terms[0], Term)
 
 
 def test_get_by_id(term_svc: TermService):
     term = term_svc.get_by_id(term_data.sp_23.id)
 
-    assert isinstance(term, TermDetails)
+    assert isinstance(term, Term)
     assert term.id == term_data.sp_23.id
 
 
@@ -48,7 +48,7 @@ def test_get_by_id_not_found(term_svc: TermService):
 def test_get_by_date(term_svc: TermService):
     term = term_svc.get_by_date(term_data.today)
 
-    assert isinstance(term, TermDetails)
+    assert isinstance(term, Term)
     assert term.id == term_data.f_23.id
 
 

--- a/frontend/src/app/academics/academics-admin/course/course-editor/course-editor.component.css
+++ b/frontend/src/app/academics/academics-admin/course/course-editor/course-editor.component.css
@@ -3,9 +3,17 @@
     max-width: 640px;
   }
   
-.mat-mdc-form-field {
-  width: stretch;
+mat-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 16px;
 }
+
+mat-form-field {
+  width: 100%;
+}
+  
 
 .mat-mdc-card-actions .mdc-button {
   margin-left: 8px;

--- a/frontend/src/app/academics/academics-admin/course/course-editor/course-editor.component.html
+++ b/frontend/src/app/academics/academics-admin/course/course-editor/course-editor.component.html
@@ -1,7 +1,7 @@
 <!-- Update Course Form -->
 <form [formGroup]="courseForm" (ngSubmit)="onSubmit()">
   <!-- Update Course Card -->
-  <mat-card appearance="outlined">
+  <mat-pane appearance="outlined">
     <mat-card-header>
       <mat-card-title *ngIf="this.courseId === 'new'; else update">
         Create Course
@@ -71,5 +71,5 @@
         Save
       </button>
     </mat-card-actions>
-  </mat-card>
+  </mat-pane>
 </form>

--- a/frontend/src/app/academics/academics-admin/room/room-editor/room-editor.component.css
+++ b/frontend/src/app/academics/academics-admin/room/room-editor/room-editor.component.css
@@ -3,8 +3,19 @@
     max-width: 640px;
   }
   
-.mat-mdc-form-field {
-  width: stretch;
+mat-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 16px;
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+mat-slide-toggle {
+  padding-bottom: 16px;
 }
 
 .mat-mdc-card-actions .mdc-button {

--- a/frontend/src/app/academics/academics-admin/room/room-editor/room-editor.component.html
+++ b/frontend/src/app/academics/academics-admin/room/room-editor/room-editor.component.html
@@ -1,7 +1,7 @@
 <!-- Update Room Form -->
 <form [formGroup]="roomForm" (ngSubmit)="onSubmit()">
   <!-- Update Room Card -->
-  <mat-card appearance="outlined">
+  <mat-pane appearance="outlined">
     <mat-card-header>
       <mat-card-title *ngIf="this.roomId === 'new'; else update">
         Create Room
@@ -66,9 +66,9 @@
           required />
       </mat-form-field>
       <!-- Room Reservable Field -->
-      <p class="checkbox">
-        <mat-checkbox formControlName="reservable">Reservable?</mat-checkbox>
-      </p>
+      <mat-slide-toggle formControlName="reservable">
+        Reservable?
+      </mat-slide-toggle>
     </mat-card-content>
     <mat-card-actions>
       <button mat-stroked-button routerLink="/academics/admin/room">
@@ -78,5 +78,5 @@
         Save
       </button>
     </mat-card-actions>
-  </mat-card>
+  </mat-pane>
 </form>

--- a/frontend/src/app/academics/academics-admin/section/admin-section.component.html
+++ b/frontend/src/app/academics/academics-admin/section/admin-section.component.html
@@ -1,8 +1,6 @@
 <!-- HTML Structure of Admin Terms List -->
-<div
-  class="content"
-  *ngIf="displayTerm.value && displayTerm.value.course_sections; else noTerm">
-  <table mat-table [dataSource]="displayTerm.value.course_sections">
+<div class="content" *ngIf="displayTerm.value && sections(); else noTerm">
+  <table mat-table [dataSource]="sections()">
     <ng-container matColumnDef="name">
       <th mat-header-cell *matHeaderCellDef>
         <div class="header">
@@ -22,14 +20,9 @@
       <td mat-cell *matCellDef="let element">
         <div class="row" (click)="updateSection(element)">
           <p>
-            {{ courseFromId(element.course_id)?.subject_code }}
-            {{ courseFromId(element.course_id)?.number }} -
-            {{ element.number }}:
-            {{
-              element.override_title !== ''
-                ? element.override_title
-                : courseFromId(element.course_id)?.title
-            }}
+            {{ element.subject_code }}
+            {{ element.course_number }} - {{ element.section_number }}:
+            {{ element.title }}
           </p>
           <div clas="modify-buttons">
             <button mat-stroked-button (click)="deleteSection(element, $event)">

--- a/frontend/src/app/academics/academics-admin/section/admin-section.component.html
+++ b/frontend/src/app/academics/academics-admin/section/admin-section.component.html
@@ -7,7 +7,7 @@
       <th mat-header-cell *matHeaderCellDef>
         <div class="header">
           Sections
-          <mat-form-field style="margin-left: auto">
+          <mat-form-field appearance="outline" style="margin-left: auto">
             <mat-label>Select Term</mat-label>
             <mat-select [formControl]="displayTerm">
               <mat-option *ngFor="let term of terms$ | async" [value]="term">{{

--- a/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.css
+++ b/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.css
@@ -3,8 +3,15 @@
     max-width: 640px;
 }
   
-.mat-mdc-form-field {
-  width: stretch;
+mat-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 16px;
+}
+
+mat-form-field {
+  width: 100%;
 }
 
 .mat-mdc-card-actions .mdc-button {
@@ -17,6 +24,6 @@ mat-card-content {
   margin-top: 8px;
 }
 
-.checkbox {
-  margin-top: 0px;
+mat-slide-toggle {
+  padding-bottom: 16px;
 }

--- a/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.html
+++ b/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.html
@@ -1,7 +1,7 @@
 <!-- Update Section Form -->
 <form [formGroup]="sectionForm" (ngSubmit)="onSubmit()">
   <!-- Update Section Card -->
-  <mat-card appearance="outlined">
+  <mat-pane appearance="outlined">
     <mat-card-header>
       <mat-card-title *ngIf="this.sectionIdString === 'new'; else update">
         Create Section
@@ -61,11 +61,9 @@
       </mat-form-field>
 
       <!-- Override Title and Description -->
-      <p class="checkbox">
-        <mat-checkbox [formControl]="override"
-          >Override Course Name and Description?</mat-checkbox
-        >
-      </p>
+      <mat-slide-toggle [formControl]="override">
+        Override Course Name and Description?
+      </mat-slide-toggle>
       <mat-form-field
         appearance="outline"
         color="accent"
@@ -98,5 +96,5 @@
         Save
       </button>
     </mat-card-actions>
-  </mat-card>
+  </mat-pane>
 </form>

--- a/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.html
+++ b/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.html
@@ -60,6 +60,9 @@
         </mat-select>
       </mat-form-field>
 
+      <!-- User Selection / Instructors Form Control -->
+      <user-lookup label="Instructors" [users]="instructors"></user-lookup>
+
       <!-- Override Title and Description -->
       <mat-slide-toggle [formControl]="override">
         Override Course Name and Description?

--- a/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.ts
+++ b/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.ts
@@ -3,7 +3,7 @@
  * sections.
  *
  * @author Ajay Gandecha <agandecha@unc.edu>
- * @copyright 2023
+ * @copyright 2024
  * @license MIT
  */
 

--- a/frontend/src/app/academics/academics-admin/term/term-editor/term-editor.component.css
+++ b/frontend/src/app/academics/academics-admin/term/term-editor/term-editor.component.css
@@ -3,8 +3,15 @@
     max-width: 640px;
   }
   
-.mat-mdc-form-field {
-  width: stretch;
+mat-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-top: 16px;
+}
+
+mat-form-field {
+  width: 100%;
 }
 
 .mat-mdc-card-actions .mdc-button {

--- a/frontend/src/app/academics/academics-admin/term/term-editor/term-editor.component.html
+++ b/frontend/src/app/academics/academics-admin/term/term-editor/term-editor.component.html
@@ -1,7 +1,7 @@
 <!-- Update Term Form -->
 <form [formGroup]="termForm" (ngSubmit)="onSubmit()">
   <!-- Update Term Card -->
-  <mat-card appearance="outlined">
+  <mat-pane appearance="outlined">
     <mat-card-header>
       <mat-card-title *ngIf="this.termId === 'new'; else update">
         Create Term
@@ -63,5 +63,5 @@
         Save
       </button>
     </mat-card-actions>
-  </mat-card>
+  </mat-pane>
 </form>

--- a/frontend/src/app/academics/academics.models.ts
+++ b/frontend/src/app/academics/academics.models.ts
@@ -40,6 +40,20 @@ export interface Section {
   total_seats: number;
 }
 
+export interface CatalogSection {
+  id: number | null;
+  subject_code: string;
+  course_number: string;
+  section_number: string;
+  title: string;
+  meeting_pattern: string;
+  description: string;
+  lecture_room: Room | null;
+  instructors: PublicProfile[];
+  enrolled: number;
+  total_seats: number;
+}
+
 /** Defines a Course Section */
 export interface EditedSection {
   id: number | null;
@@ -59,7 +73,6 @@ export interface EditedSection {
 export interface Term extends TimeRange {
   id: string;
   name: string;
-  course_sections: Section[] | null;
 }
 
 /** Defines a Section Member */

--- a/frontend/src/app/academics/academics.models.ts
+++ b/frontend/src/app/academics/academics.models.ts
@@ -8,6 +8,7 @@
  */
 
 import { Seat } from '../coworking/coworking.models';
+import { PublicProfile } from '../profile/profile.service';
 import { TimeRange } from '../time-range';
 
 /** Defines a Course */
@@ -39,6 +40,21 @@ export interface Section {
   total_seats: number;
 }
 
+/** Defines a Course Section */
+export interface EditedSection {
+  id: number | null;
+  course_id: string;
+  number: string;
+  term_id: string;
+  meeting_pattern: string;
+  lecture_room: Room | null;
+  override_title: string;
+  override_description: string;
+  enrolled: number;
+  total_seats: number;
+  instructors: PublicProfile[];
+}
+
 /** Defines a Term */
 export interface Term extends TimeRange {
   id: string;
@@ -49,6 +65,7 @@ export interface Term extends TimeRange {
 /** Defines a Section Member */
 export interface SectionMember {
   id: number | null;
+  user_id: number | null;
   first_name: string;
   last_name: string;
   pronouns: string;

--- a/frontend/src/app/academics/academics.module.ts
+++ b/frontend/src/app/academics/academics.module.ts
@@ -26,6 +26,7 @@ import { AdminRoomComponent } from './academics-admin/room/admin-room.component'
 import { RoomEditorComponent } from './academics-admin/room/room-editor/room-editor.component';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { SharedModule } from '../shared/shared.module';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 @NgModule({
   declarations: [
@@ -56,6 +57,7 @@ import { SharedModule } from '../shared/shared.module';
     MatTabsModule,
     MatInputModule,
     MatCheckboxModule,
+    MatSlideToggleModule,
     AsyncPipe,
     SharedModule
   ]

--- a/frontend/src/app/academics/academics.service.ts
+++ b/frontend/src/app/academics/academics.service.ts
@@ -13,6 +13,7 @@ import { AuthenticationService } from '../authentication.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Observable } from 'rxjs';
 import {
+  CatalogSection,
   Course,
   EditedSection,
   Room,
@@ -118,19 +119,11 @@ export class AcademicsService {
 
   /** Returns all section entries by a term.
    * @param term Term to get sections by
-   * @returns {Observable<Section[]>}
+   * @returns {Observable<CatalogSection[]>}
    */
-  getSectionsByTerm(term: Term): Observable<Section[]> {
-    return this.http.get<Section[]>(`/api/academics/section/term/${term.id}`);
-  }
-
-  /** Returns all section entries by a term at which an office hours section doesn't exist.
-   * @param term Term to get sections by
-   * @returns {Observable<Section[]>}
-   */
-  getSectionsWithNoOfficeHoursByTerm(term: Term): Observable<Section[]> {
-    return this.http.get<Section[]>(
-      `/api/academics/section/term/${term.id}/no-office-hours`
+  getSectionsByTerm(term: Term): Observable<CatalogSection[]> {
+    return this.http.get<CatalogSection[]>(
+      `/api/academics/section/term/${term.id}`
     );
   }
 
@@ -143,7 +136,7 @@ export class AcademicsService {
 
   /** Returns one section from the backend database.
    * @param id ID of the section to look up
-   * @returns {Observable<Section>}
+   * @returns {Observable<CatalogSection>}
    */
   getSection(id: number): Observable<Section> {
     return this.http.get<Section>(`/api/academics/section/${id}`);

--- a/frontend/src/app/academics/academics.service.ts
+++ b/frontend/src/app/academics/academics.service.ts
@@ -12,7 +12,14 @@ import { HttpClient } from '@angular/common/http';
 import { AuthenticationService } from '../authentication.service';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Observable } from 'rxjs';
-import { Course, Room, Section, SectionMember, Term } from './academics.models';
+import {
+  Course,
+  EditedSection,
+  Room,
+  Section,
+  SectionMember,
+  Term
+} from './academics.models';
 
 @Injectable({
   providedIn: 'root'
@@ -146,7 +153,7 @@ export class AcademicsService {
    * @param section: Section to create
    * @returns {Observable<Section>}
    */
-  createSection(section: Section): Observable<Section> {
+  createSection(section: EditedSection): Observable<Section> {
     return this.http.post<Section>('/api/academics/section', section);
   }
 
@@ -154,7 +161,7 @@ export class AcademicsService {
    * @param section: Section to update
    * @returns {Observable<Section>}
    */
-  updateSection(section: Section): Observable<Section> {
+  updateSection(section: EditedSection): Observable<Section> {
     return this.http.put<Section>('/api/academics/section', section);
   }
 

--- a/frontend/src/app/my-courses/catalog/section-offerings/section-offerings.component.css
+++ b/frontend/src/app/my-courses/catalog/section-offerings/section-offerings.component.css
@@ -16,3 +16,14 @@ tr.example-detail-row {
   overflow: hidden;
   display: flex;
 }
+
+.term-selector {
+  margin-left: auto;
+  width: 260px;
+  margin-bottom: -1.25em;
+
+}
+
+.mat-mdc-card-header {
+  align-items: center;
+}

--- a/frontend/src/app/my-courses/catalog/section-offerings/section-offerings.component.html
+++ b/frontend/src/app/my-courses/catalog/section-offerings/section-offerings.component.html
@@ -1,41 +1,35 @@
 <mat-pane class="content" appearance="outlined">
   <mat-card-header>
-    <div style="display: flex; flex-direction: row; width: 100%">
-      <mat-card-title
-        >{{ displayTerm.value.name }} Course Offerings</mat-card-title
-      >
-      <mat-form-field style="margin-left: auto" appearance="outline">
-        <mat-label>Select Term</mat-label>
-        <mat-select [formControl]="displayTerm">
-          <mat-option *ngFor="let term of terms" [value]="term">{{
-            term.name
-          }}</mat-option>
-        </mat-select>
-      </mat-form-field>
-    </div>
+    <mat-card-title>
+      {{ displayTerm() ? displayTerm()!.name + ' ' : '' }}
+      Course Offerings
+    </mat-card-title>
+    <mat-form-field class="term-selector" appearance="outline">
+      <mat-label>Select Term</mat-label>
+      <mat-select
+        [(ngModel)]="displayTermId"
+        (selectionChange)="resetSections()">
+        @for(term of terms; track term.id) {
+        <mat-option [value]="term.id">{{ term.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
   </mat-card-header>
   <mat-card-content>
     <mat-card-content>
-      <table
-        mat-table
-        [dataSource]="displayTerm.value.course_sections ?? []"
-        multiTemplateDataRows>
+      <table mat-table [dataSource]="sections()" multiTemplateDataRows>
         <ng-container matColumnDef="code">
           <th mat-header-cell *matHeaderCellDef>Code</th>
           <td mat-cell *matCellDef="let element">
-            {{ courseFromId(element.course_id)?.subject_code }}
-            {{ courseFromId(element.course_id)?.number }} -
-            {{ element.number }}
+            {{ element.subject_code }}
+            {{ element.course_number }} -
+            {{ element.section_number }}
           </td>
         </ng-container>
         <ng-container matColumnDef="title">
           <th mat-header-cell *matHeaderCellDef>Title</th>
           <td mat-cell *matCellDef="let element">
-            {{
-              element.override_title !== ''
-                ? element.override_title
-                : courseFromId(element.course_id)?.title
-            }}
+            {{ element.title }}
           </td>
         </ng-container>
         <ng-container matColumnDef="instructor">
@@ -100,11 +94,7 @@
                 element === expandedElement ? 'expanded' : 'collapsed'
               ">
               <p>
-                {{
-                  element.override_description !== ''
-                    ? element.override_description
-                    : courseFromId(element.course_id)?.description
-                }}
+                {{ element.description }}
               </p>
             </div>
           </td>

--- a/frontend/src/app/my-courses/catalog/section-offerings/section-offerings.component.html
+++ b/frontend/src/app/my-courses/catalog/section-offerings/section-offerings.component.html
@@ -33,7 +33,7 @@
           </td>
         </ng-container>
         <ng-container matColumnDef="instructor">
-          <th mat-header-cell *matHeaderCellDef>Instructor</th>
+          <th mat-header-cell *matHeaderCellDef>Instructor(s)</th>
           <td mat-cell *matCellDef="let element">
             {{ instructorNameForSection(element) }}
           </td>

--- a/frontend/src/app/my-courses/catalog/section-offerings/section-offerings.component.ts
+++ b/frontend/src/app/my-courses/catalog/section-offerings/section-offerings.component.ts
@@ -121,7 +121,8 @@ export class SectionOfferingsComponent implements OnInit {
    * @returns Name of the section's instructor, or 'Unknown' if no instructor is set.
    */
   instructorNameForSection(section: CatalogSection): string {
-    if (!section.instructors) return 'Unknown';
+    if (!section.instructors || section.instructors.length == 0)
+      return 'Unknown';
     let instructorText = '';
 
     for (let instructor of section.instructors) {

--- a/frontend/src/app/my-courses/catalog/section-offerings/section-offerings.component.ts
+++ b/frontend/src/app/my-courses/catalog/section-offerings/section-offerings.component.ts
@@ -121,15 +121,14 @@ export class SectionOfferingsComponent implements OnInit {
    * @returns Name of the section's instructor, or 'Unknown' if no instructor is set.
    */
   instructorNameForSection(section: CatalogSection): string {
-    // Find the instructor
-    let instructor =
-      section.instructors?.length ?? 0 > 0 ? section.instructors![0] : null;
-    // Return the name for the instructor
-    // If instructor exists: <First Name> <Last Name>
-    // Otherwise: 'Unknown'
-    return instructor
-      ? instructor.first_name + ' ' + instructor.last_name
-      : 'Unknown';
+    if (!section.instructors) return 'Unknown';
+    let instructorText = '';
+
+    for (let instructor of section.instructors) {
+      instructorText +=
+        instructor.first_name + ' ' + instructor.last_name + ', ';
+    }
+    return instructorText.substring(0, instructorText.length - 2);
   }
 
   selectedTerm() {


### PR DESCRIPTION
This PR adds the ability to set section instructors in the Section Admin form UI.

This PR also reverts the UI changes made in #402 to the academics editors so they are now properly formatted. The admin for this will likely change, but for now, I made some slight M3 styling improvements (including using mat switches and the mat pane widget).

<img width="644" alt="image" src="https://github.com/unc-csxl/csxl.unc.edu/assets/17516747/e3b51e3f-62f5-496a-a3c6-d13f48be3813">
