### PR TITLE
Show Applicant Course Preferences on Hiring Page

### DIFF
--- a/backend/entities/academics/hiring/application_review_entity.py
+++ b/backend/entities/academics/hiring/application_review_entity.py
@@ -129,5 +129,6 @@ class ApplicationReviewEntity(EntityBase):
             preference=self.preference,
             notes=self.notes,
             application=self.application.to_overview_model(),
-            applicant_course_ranking=applicant_preference_for_course,
+            applicant_course_ranking=applicant_preference_for_course
+            + 1,  # Increment since starting index is 0.
         )

--- a/backend/entities/academics/hiring/application_review_entity.py
+++ b/backend/entities/academics/hiring/application_review_entity.py
@@ -4,6 +4,7 @@ from sqlalchemy import Integer, String, ForeignKey, Index
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 from typing import Self
 from sqlalchemy import Enum as SQLAlchemyEnum
+from itertools import groupby
 
 from ...entity_base import EntityBase
 from ....models.academics.hiring.application_review import (
@@ -83,6 +84,43 @@ class ApplicationReviewEntity(EntityBase):
         Returns:
             ApplicationReviewOverview: `ApplicationReviewOverview` object from the entity
         """
+        # Determine the ranking of the applicant for a given course
+        # 1. Find all of the applicant's preferred sections
+        applicant_section_preferences = self.application.preferred_sections
+        # 2. Find the course sites that the applicant's preferred sections are attached to.
+        preferences_course_site_ids = [
+            section.course_site_id for section in applicant_section_preferences
+        ]
+        # 3. Remove duplicates in the list above while preserving an ordering.
+        #    (i.e., keep only the first occurrence of each ID)
+        #    Note: Cannot just use a set since sets are unordered.
+        found_course_site_ids = set()
+        preferences_course_site_ids_no_duplicates = []
+        for course_site_id in preferences_course_site_ids:
+            if course_site_id not in found_course_site_ids:
+                preferences_course_site_ids_no_duplicates.append(course_site_id)
+                found_course_site_ids.add(course_site_id)
+
+        # 3. Find the applicant's preference for the sections included in the course site by
+        #    determining the first index where the course site ID occurs in the list above.
+        #    Example:
+        #    Assume a student applied to 110-001 --> 110-002 --> 210-001 --> 210-002 --> 301-001 --> 110-003
+        #    Assume that the all COMP 110 sections are in course site ID #8, 210 in #7, and 301 in #6.
+        #    Then, preferences_course_site_ids = [8, 8, 8, 7, 7, 6, 8]
+        #    So, preferences_course_site_ids_no_duplicates = [8, 7, 6]
+        #    Therefore, this is the user's preference order:
+        #    1. Sections in course site 8 (COMP 110s)
+        #    2. Sections in course site 7 (COMP 210s)
+        #    3. Sections in course site 6 (COMP 301)
+        applicant_preference_for_course = (
+            preferences_course_site_ids_no_duplicates.index(
+                self.course_site_id
+            )  # Find the min index.
+            # This case should never be reached, but it prevents an error if so.
+            if self.course_site_id in preferences_course_site_ids_no_duplicates
+            else -1
+        )
+
         return ApplicationReviewOverview(
             id=self.id,
             application_id=self.application_id,
@@ -91,4 +129,5 @@ class ApplicationReviewEntity(EntityBase):
             preference=self.preference,
             notes=self.notes,
             application=self.application.to_overview_model(),
+            applicant_course_ranking=applicant_preference_for_course,
         )

--- a/backend/entities/application_entity.py
+++ b/backend/entities/application_entity.py
@@ -189,6 +189,7 @@ class UTAApplicationEntity(ApplicationEntity):
         "SectionEntity",
         secondary=section_application_table,
         back_populates="preferred_applicants",
+        order_by=section_application_table.c.preference,
     )
 
     # Any row in the main Application table that is an instance of UTAApplicationEntity will override

--- a/backend/models/academics/hiring/application_review.py
+++ b/backend/models/academics/hiring/application_review.py
@@ -60,6 +60,7 @@ class ApplicationReviewOverview(ApplicationReview):
     status: ApplicationReviewStatus = ApplicationReviewStatus.NOT_PROCESSED
     preference: int
     notes: str
+    applicant_course_ranking: int
 
 
 class HiringStatus(BaseModel):

--- a/backend/services/academics/hiring.py
+++ b/backend/services/academics/hiring.py
@@ -74,7 +74,10 @@ class HiringService:
 
         for application in applications:
             # Check if the application is missing reviews
-            if len(application.reviews) == 0:
+            reviews_course_site_ids = [
+                review.course_site_id for review in application.reviews
+            ]
+            if course_site_id not in reviews_course_site_ids:
                 applications_missing_review.append(application)
 
         # Step 4: Create reviews for applications missing reviews, if any.

--- a/backend/test/services/academics/course_site_test.py
+++ b/backend/test/services/academics/course_site_test.py
@@ -41,7 +41,7 @@ def test_get_user_course_sites(course_site_svc: CourseSiteService):
     assert isinstance(term_overview[0], TermOverview)
     assert len(term_overview) == 2
     assert term_overview[-1].id == term_data.current_term.id
-    assert len(term_overview[-1].sites) == 1
+    assert len(term_overview[-1].sites) == 2
 
 
 def test_get_course_site_roster(course_site_svc: CourseSiteService):

--- a/backend/test/services/academics/hiring/hiring_data.py
+++ b/backend/test/services/academics/hiring/hiring_data.py
@@ -103,12 +103,12 @@ application_four = NewUTAApplicationDetails(
 applications = [application_one, application_two, application_three, application_four]
 
 application_associations = [
-    (application_one, section_data.comp_110_001_current_term, 0),
+    (application_one, section_data.comp_301_001_current_term, 0),
+    (application_one, section_data.comp_110_001_current_term, 1),
+    (application_one, section_data.comp_110_002_current_term, 2),
     (application_two, section_data.comp_110_001_current_term, 0),
     (application_three, section_data.comp_110_001_current_term, 0),
     (application_four, section_data.comp_110_001_current_term, 0),
-    (application_one, section_data.comp_110_002_current_term, 1),
-    (application_one, section_data.comp_301_001_current_term, 2),
 ]
 
 review_one = ApplicationReview(

--- a/backend/test/services/academics/hiring/hiring_data.py
+++ b/backend/test/services/academics/hiring/hiring_data.py
@@ -107,6 +107,7 @@ application_associations = [
     (application_two, section_data.comp_110_001_current_term, 0),
     (application_three, section_data.comp_110_001_current_term, 0),
     (application_four, section_data.comp_110_001_current_term, 0),
+    (application_one, section_data.comp_301_001_current_term, 1),
 ]
 
 review_one = ApplicationReview(

--- a/backend/test/services/academics/hiring/hiring_data.py
+++ b/backend/test/services/academics/hiring/hiring_data.py
@@ -107,7 +107,8 @@ application_associations = [
     (application_two, section_data.comp_110_001_current_term, 0),
     (application_three, section_data.comp_110_001_current_term, 0),
     (application_four, section_data.comp_110_001_current_term, 0),
-    (application_one, section_data.comp_301_001_current_term, 1),
+    (application_one, section_data.comp_110_002_current_term, 1),
+    (application_one, section_data.comp_301_001_current_term, 2),
 ]
 
 review_one = ApplicationReview(
@@ -161,7 +162,7 @@ def insert_fake_data(session: Session):
                 }
             )
         )
-    session.commit()
+        session.commit()
 
     for review in reviews:
         entity = ApplicationReviewEntity.from_model(review)

--- a/backend/test/services/academics/hiring/hiring_test.py
+++ b/backend/test/services/academics/hiring/hiring_test.py
@@ -47,7 +47,7 @@ __license__ = "MIT"
 def test_get_status(hiring_svc: HiringService):
     """Test that an instructor can get status on hiring."""
     hiring_status = hiring_svc.get_status(
-        user_data.instructor, office_hours_data.comp_301_site.id
+        user_data.instructor, office_hours_data.comp_110_site.id
     )
     assert isinstance(hiring_status, HiringStatus)
     assert len(hiring_status.not_preferred) == 1

--- a/backend/test/services/academics/hiring/hiring_test.py
+++ b/backend/test/services/academics/hiring/hiring_test.py
@@ -47,7 +47,7 @@ __license__ = "MIT"
 def test_get_status(hiring_svc: HiringService):
     """Test that an instructor can get status on hiring."""
     hiring_status = hiring_svc.get_status(
-        user_data.instructor, office_hours_data.comp_110_site.id
+        user_data.instructor, office_hours_data.comp_301_site.id
     )
     assert isinstance(hiring_status, HiringStatus)
     assert len(hiring_status.not_preferred) == 1

--- a/backend/test/services/fixtures.py
+++ b/backend/test/services/fixtures.py
@@ -10,8 +10,8 @@ from ...services import (
     OrganizationService,
     EventService,
     RoomService,
-    HiringService,
 )
+from ...services.academics import HiringService
 
 __authors__ = ["Kris Jordan", "Ajay Gandecha"]
 __copyright__ = "Copyright 2023"

--- a/backend/test/services/office_hours/office_hours_data.py
+++ b/backend/test/services/office_hours/office_hours_data.py
@@ -266,7 +266,6 @@ new_course_site = NewCourseSite(
     title="Ina's COMP 301",
     term_id=term_data.current_term.id,
     section_ids=[
-        section_data.comp_301_001_current_term.id,
         section_data.comp_301_002_current_term.id,
     ],
 )
@@ -275,7 +274,6 @@ new_course_site_term_mismatch = NewCourseSite(
     title="Ina's COMP 301",
     term_id=term_data.f_23.id,
     section_ids=[
-        section_data.comp_301_001_current_term.id,
         section_data.comp_301_002_current_term.id,
     ],
 )
@@ -285,7 +283,7 @@ new_course_site_term_nonmember = NewCourseSite(
     title="Ina's COMP 3x1",
     term_id=term_data.current_term.id,
     section_ids=[
-        section_data.comp_301_001_current_term.id,
+        section_data.comp_301_002_current_term.id,
         section_data.comp_311_001_current_term.id,
     ],
 )
@@ -293,7 +291,7 @@ new_course_site_term_noninstructor = NewCourseSite(
     title="Ina's COMP 3x1",
     term_id=term_data.current_term.id,
     section_ids=[
-        section_data.comp_301_001_current_term.id,
+        section_data.comp_301_002_current_term.id,
         section_data.comp_311_002_current_term.id,
     ],
 )
@@ -303,7 +301,7 @@ new_course_site_term_already_in_site = NewCourseSite(
     title="Ina's COMP courses",
     term_id=term_data.current_term.id,
     section_ids=[
-        section_data.comp_301_001_current_term.id,
+        section_data.comp_301_002_current_term.id,
         section_data.comp_110_001_current_term.id,
     ],
 )

--- a/backend/test/services/office_hours/office_hours_data.py
+++ b/backend/test/services/office_hours/office_hours_data.py
@@ -46,6 +46,7 @@ __license__ = "MIT"
 
 # Site
 comp_110_site = CourseSite(id=1, title="COMP 110", term_id=term_data.current_term.id)
+comp_301_site = CourseSite(id=2, title="COMP 301", term_id=term_data.current_term.id)
 
 # Sections
 comp_110_sections = (
@@ -55,6 +56,11 @@ comp_110_sections = (
     ],
     comp_110_site.id,
 )
+comp_301_sections = (
+    [section_data.comp_301_001_current_term],
+    comp_301_site.id,
+)
+
 
 # Office Hours
 comp_110_current_office_hours = OfficeHours(
@@ -152,8 +158,8 @@ comp_110_ticket_creators = [
 ]
 
 # All
-sites = [comp_110_site]
-section_pairings = [comp_110_sections]
+sites = [comp_110_site, comp_301_site]
+section_pairings = [comp_110_sections, comp_301_sections]
 
 office_hours = [
     comp_110_current_office_hours,

--- a/frontend/src/app/hiring/dialogs/application-dialog/application-dialog.dialog.css
+++ b/frontend/src/app/hiring/dialogs/application-dialog/application-dialog.dialog.css
@@ -26,3 +26,17 @@ mat-form-field {
 .end-align {
   margin-left: auto;
 }
+
+.text-badge {
+  font-size: 10px;
+  height: 22px;
+  width: 32px;
+  text-align: center;
+  padding-left: 6px;
+  padding-right: 6px;
+  padding-top: 2px;
+  padding-bottom: 2px;
+  border-radius: 11px;
+  line-height: 22px;
+  color: white;
+}

--- a/frontend/src/app/hiring/dialogs/application-dialog/application-dialog.dialog.html
+++ b/frontend/src/app/hiring/dialogs/application-dialog/application-dialog.dialog.html
@@ -69,6 +69,18 @@
 
   <mat-divider />
 
+  <p mat-card-subtitle>Applicant Preferences</p>
+
+  <p>
+    {{ data.review.application.applicant_name }} ranked this course as their
+    <span class="text-badge primary-background"
+      >#{{ data.review.applicant_course_ranking }}</span
+    >
+    choice.
+  </p>
+
+  <mat-divider />
+
   <div class="row">
     <p mat-card-subtitle>Your Notes</p>
     <!-- <p class="end-align"><em>Changes saved.</em></p> -->

--- a/frontend/src/app/hiring/hiring.models.ts
+++ b/frontend/src/app/hiring/hiring.models.ts
@@ -30,6 +30,7 @@ export interface ApplicationReviewOverview {
   status: ApplicationReviewStatus;
   preference: number;
   notes: string;
+  applicant_course_ranking: number;
 }
 
 export interface HiringStatus {

--- a/frontend/src/app/hiring/widgets/application-card/application-card.widget.css
+++ b/frontend/src/app/hiring/widgets/application-card/application-card.widget.css
@@ -71,3 +71,20 @@
 .semibold {
   font-weight: 500;
 }
+
+.mat-mdc-card-subtitle {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 96%;
+}
+
+.accessories {
+  margin-left: auto;
+
+  p {
+    margin-bottom: 0;
+    text-align: center;
+    font-size: 10px;
+  }
+}

--- a/frontend/src/app/hiring/widgets/application-card/application-card.widget.html
+++ b/frontend/src/app/hiring/widgets/application-card/application-card.widget.html
@@ -6,17 +6,24 @@
   <mat-card-header>
     <mat-card-subtitle>
       <span class="preference">{{ item.preference + 1 }}. </span>
-      <span>{{ item.application.applicant_name }}</span>
+      <span> {{ item.application.applicant_name }}</span>
       @if (item.notes.length > 0) {
       <mat-icon class="notes" matListItemIcon>tooltip</mat-icon>
       }
+      <div class="accessories">
+        <p class="font-variant">
+          Course rank:
+          <span
+            [class]="
+              'text-badge ' +
+              (item.applicant_course_ranking === 1
+                ? 'primary-background'
+                : 'secondary-background')
+            "
+            >#{{ item.applicant_course_ranking }}</span
+          >
+        </p>
+      </div>
     </mat-card-subtitle>
-    <p>
-      Ranked this course as their
-      <span class="text-badge primary-background"
-        >#{{ item.applicant_course_ranking }}</span
-      >
-      choice.
-    </p>
   </mat-card-header>
 </mat-card>

--- a/frontend/src/app/hiring/widgets/application-card/application-card.widget.html
+++ b/frontend/src/app/hiring/widgets/application-card/application-card.widget.html
@@ -11,5 +11,12 @@
       <mat-icon class="notes" matListItemIcon>tooltip</mat-icon>
       }
     </mat-card-subtitle>
+    <p>
+      Ranked this course as their
+      <span class="text-badge primary-background"
+        >#{{ item.applicant_course_ranking }}</span
+      >
+      choice.
+    </p>
   </mat-card-header>
 </mat-card>

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -266,6 +266,9 @@ html, body {
     .font-secondary {
         color: mat.get-theme-color($theme, secondary) !important;
     }
+    .font-variant {
+        color: mat.get-theme-color($theme, on-surface-variant) !important;
+    }
 }
 
 /// Defines a mixin that applies custom widgets to material text field components


### PR DESCRIPTION
This pull request adds applicant's course preferences on the the hiring page so that instructors know how each applicant ranks their course.

This PR also fixes a bug which prevented applicants from showing up on other course sites once one course site has been loaded.

### Frontend - Hiring Column Card

<img width="451" alt="image" src="https://github.com/user-attachments/assets/4f9c8137-a4da-462e-a288-4fc879b62f88">

### Frontend - Hiring Dialog

<img width="409" alt="Screenshot 2024-07-16 at 7 04 36 PM" src="https://github.com/user-attachments/assets/9c2bf333-85da-4617-81ef-f6dd8dd3c701">
