### PR TITLE
Add Button to Pass on Applicants Preferring Other Courses 

### DIFF
--- a/frontend/src/app/hiring/hiring-page/hiring-page.component.css
+++ b/frontend/src/app/hiring/hiring-page/hiring-page.component.css
@@ -22,6 +22,7 @@
   display: flex;
   flex-direction: column;
   overflow-y: scroll;
+  height: 100%;
 }
 
 .row {

--- a/frontend/src/app/hiring/hiring-page/hiring-page.component.html
+++ b/frontend/src/app/hiring/hiring-page/hiring-page.component.html
@@ -56,17 +56,20 @@
         }
       </div>
     </mat-card-content>
-    <!-- NOTE: Feature disabled while rank is inaccurate. -->
-    <!-- <mat-card-actions>
+    <mat-card-actions>
       <div class="actions-container">
         <mat-divider />
         <div class="actions-button-container">
-          <button mat-flat-button class="tertiary-button">
-            Pass on 1st Choice Applicants
+          <button
+            mat-flat-button
+            class="tertiary-button"
+            (click)="passOnNonFirstChoiceApplicants()">
+            <mat-icon>steps</mat-icon>
+            Pass on Applicants Preferring Other Courses
           </button>
         </div>
       </div>
-    </mat-card-actions> -->
+    </mat-card-actions>
   </mat-pane>
   <mat-pane>
     <mat-card-header>

--- a/frontend/src/app/hiring/hiring-page/hiring-page.component.ts
+++ b/frontend/src/app/hiring/hiring-page/hiring-page.component.ts
@@ -136,4 +136,19 @@ export class HiringPageComponent {
         });
     });
   }
+
+  /**
+   * Moves non-first choice applicants from not processed to the
+   * not preferred column.
+   */
+  passOnNonFirstChoiceApplicants() {
+    let notFirstChoice = this.notProcessed.filter(
+      (a) => a.applicant_course_ranking > 1
+    );
+    this.notProcessed = this.notProcessed.filter(
+      (a) => a.applicant_course_ranking === 1
+    );
+    this.notPreferred = this.notPreferred.concat(notFirstChoice);
+    this.updateHiringStatus();
+  }
 }

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -71,6 +71,7 @@ html, body {
 /// 
 /// @param {theme} $theme: Angular Material theme to apply styles with.
 @mixin mat-button-styles($theme) {
+
     .mat-mdc-fab {
         .mat-icon {
             color: mat.get-theme-color($theme, on-primary);
@@ -78,6 +79,9 @@ html, body {
     }
 
     .tertiary-button {
+        .mat-icon {
+            color: white !important;
+        }
         @include mat.button-color($theme, $color-variant: tertiary);
     }
 


### PR DESCRIPTION
This PR adds a button to the hiring page that passes on applicants preferring other courses. The button has been thoughtfully designed to include an ***elegant*** and ***expressive*** icon that conveys the button's purpose to the user.


<img width="479" alt="Screenshot 2024-07-16 at 9 02 26 PM" src="https://github.com/user-attachments/assets/45268f83-365b-41f9-84ab-92536c11cd41">

This button will be used as a case study to showcase best design practices in COMP 423 in the fall and all that Material has to offer, and how the smallest of changes to a UI can have the largest of impact.