### PR TITLE
Add Settings Page to My Courses, Enable UTA and GTA Selections

### DIFF
--- a/backend/api/academics/my_courses.py
+++ b/backend/api/academics/my_courses.py
@@ -52,7 +52,7 @@ def get_course_site(
     course_site_id: int,
     subject: User = Depends(registered_user),
     course_site_svc: CourseSiteService = Depends(),
-) -> CourseSiteOverview:
+) -> UpdatedCourseSite:
     """
     Gets the current office hour event overviews for a given class.
 

--- a/backend/api/academics/my_courses.py
+++ b/backend/api/academics/my_courses.py
@@ -12,8 +12,13 @@ from ...models.academics.my_courses import (
     TermOverview,
     CourseMemberOverview,
     OfficeHoursOverview,
+    CourseSiteOverview,
 )
-from ...models.office_hours.course_site import NewCourseSite, CourseSite
+from ...models.office_hours.course_site import (
+    NewCourseSite,
+    CourseSite,
+    UpdatedCourseSite,
+)
 from ...models.office_hours.course_site_details import CourseSiteDetails
 from ...models.pagination import PaginationParams, Paginated
 
@@ -40,6 +45,21 @@ def get_user_courses(
         list[TermOverview]
     """
     return course_site_svc.get_user_course_sites(subject)
+
+
+@api.get("/{course_site_id}", tags=["My Courses"])
+def get_course_site(
+    course_site_id: int,
+    subject: User = Depends(registered_user),
+    course_site_svc: CourseSiteService = Depends(),
+) -> CourseSiteOverview:
+    """
+    Gets the current office hour event overviews for a given class.
+
+    Returns:
+        list[OfficeHoursOverview]
+    """
+    return course_site_svc.get(subject, course_site_id)
 
 
 @api.get("/{course_site_id}/roster", tags=["My Courses"])
@@ -142,3 +162,18 @@ def create_course_site(
         CourseSiteDetails: Course created
     """
     return course_site_svc.create(subject, course_site)
+
+
+@api.put("", tags=["My Courses"])
+def update_course_site(
+    course_site: UpdatedCourseSite,
+    subject: User = Depends(registered_user),
+    course_site_svc: CourseSiteService = Depends(),
+) -> CourseSite:
+    """
+    Updates a course site to the database
+
+    Returns:
+        CourseSite: Course updated
+    """
+    return course_site_svc.update(subject, course_site)

--- a/backend/models/academics/my_courses.py
+++ b/backend/models/academics/my_courses.py
@@ -19,6 +19,9 @@ class SectionOverview(BaseModel):
     number: str
     meeting_pattern: str
     course_site_id: int | None
+    subject_code: str
+    course_number: str
+    section_number: str
 
 
 class CourseOverview(BaseModel):
@@ -32,6 +35,7 @@ class CourseOverview(BaseModel):
 
 class CourseSiteOverview(BaseModel):
     id: int
+    term_id: str
     subject_code: str
     number: str
     title: str

--- a/backend/models/academics/my_courses.py
+++ b/backend/models/academics/my_courses.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from ...models import Paginated
 from ...models.office_hours.ticket_state import TicketState
 from ...models.office_hours.ticket_type import TicketType
+from ...models.public_user import PublicUser
 
 
 class TeachingSectionOverview(BaseModel):
@@ -36,6 +37,8 @@ class CourseSiteOverview(BaseModel):
     title: str
     role: str
     sections: list[SectionOverview]
+    gtas: list[PublicUser]
+    utas: list[PublicUser]
 
 
 class TermOverview(BaseModel):

--- a/backend/models/office_hours/course_site.py
+++ b/backend/models/office_hours/course_site.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel
+from ..public_user import PublicUser
 
 __authors__ = [
     "Ajay Gandecha",
@@ -30,6 +31,8 @@ class UpdatedCourseSite(BaseModel):
     title: str
     term_id: str
     section_ids: list[int]
+    gtas: list[PublicUser]
+    utas: list[PublicUser]
 
 
 class CourseSite(BaseModel):

--- a/backend/test/services/academics/course_site_test.py
+++ b/backend/test/services/academics/course_site_test.py
@@ -250,6 +250,8 @@ def test_update_term_noninstructor(course_site_svc: CourseSiteService):
         title="Anything",
         term_id=term_data.current_term.id,
         section_ids=[],
+        gtas=[],
+        utas=[],
     )
     with pytest.raises(CoursePermissionException):
         course_site_svc.update(

--- a/backend/test/services/office_hours/office_hours_data.py
+++ b/backend/test/services/office_hours/office_hours_data.py
@@ -311,6 +311,8 @@ updated_comp_110_site = UpdatedCourseSite(
     title="New Course Site",
     term_id=term_data.current_term.id,
     section_ids=[section_data.comp_110_001_current_term.id],
+    utas=[],
+    gtas=[],
 )
 
 updated_comp_110_site_term_mismatch = UpdatedCourseSite(
@@ -321,6 +323,8 @@ updated_comp_110_site_term_mismatch = UpdatedCourseSite(
         section_data.comp_110_001_current_term.id,
         section_data.comp_101_001.id,
     ],
+    utas=[],
+    gtas=[],
 )
 
 updated_course_site_term_nonmember = UpdatedCourseSite(
@@ -331,6 +335,8 @@ updated_course_site_term_nonmember = UpdatedCourseSite(
         section_data.comp_110_001_current_term.id,
         section_data.comp_311_001_current_term.id,
     ],
+    utas=[],
+    gtas=[],
 )
 
 updated_course_does_not_exist = UpdatedCourseSite(
@@ -341,6 +347,8 @@ updated_course_does_not_exist = UpdatedCourseSite(
         section_data.comp_110_001_current_term.id,
         section_data.comp_311_002_current_term.id,
     ],
+    utas=[],
+    gtas=[],
 )
 
 updated_course_site_term_noninstructor = UpdatedCourseSite(
@@ -351,6 +359,8 @@ updated_course_site_term_noninstructor = UpdatedCourseSite(
         section_data.comp_311_001_current_term.id,
         section_data.comp_311_002_current_term.id,
     ],
+    utas=[],
+    gtas=[],
 )
 
 updated_course_site_term_already_in_site = UpdatedCourseSite(
@@ -361,6 +371,8 @@ updated_course_site_term_already_in_site = UpdatedCourseSite(
         section_data.comp_301_001_current_term.id,
         section_data.comp_110_001_current_term.id,
     ],
+    utas=[],
+    gtas=[],
 )
 
 new_site_other_user = NewCourseSite(

--- a/frontend/src/app/my-courses/course/course.component.html
+++ b/frontend/src/app/my-courses/course/course.component.html
@@ -1,1 +1,1 @@
-<tab-container [links]="links" />
+<tab-container [links]="links()" />

--- a/frontend/src/app/my-courses/course/course.component.ts
+++ b/frontend/src/app/my-courses/course/course.component.ts
@@ -6,8 +6,21 @@
  * @license MIT
  */
 
-import { Component } from '@angular/core';
+import {
+  Component,
+  computed,
+  OnInit,
+  signal,
+  WritableSignal
+} from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+import { MyCoursesService } from '../my-courses.service';
+import {
+  parseTermOverviewJsonList,
+  TermOverviewJson
+} from '../my-courses.model';
+import { map } from 'rxjs';
+import { HttpClient } from '@angular/common/http';
 
 @Component({
   selector: 'app-course',
@@ -16,23 +29,59 @@ import { ActivatedRoute } from '@angular/router';
 })
 export class CourseComponent {
   /** Links for the tab bar */
-  public links = [
-    {
-      label: 'Office Hours',
-      path: `/course/${this.route.snapshot.params['course_site_id']}/office-hours`,
-      icon: 'person_raised_hand'
-    },
-    {
-      label: 'Roster',
-      path: `/course/${this.route.snapshot.params['course_site_id']}/roster`,
-      icon: 'groups'
-    },
-    {
-      label: 'Settings',
-      path: `/course/${this.route.snapshot.params['course_site_id']}/settings`,
-      icon: 'settings'
-    }
-  ];
+  isInstructor: WritableSignal<boolean> = signal(false);
 
-  constructor(private route: ActivatedRoute) {}
+  links = computed(() => {
+    if (this.isInstructor()) {
+      return [
+        {
+          label: 'Office Hours',
+          path: `/course/${this.route.snapshot.params['course_site_id']}/office-hours`,
+          icon: 'person_raised_hand'
+        },
+        {
+          label: 'Roster',
+          path: `/course/${this.route.snapshot.params['course_site_id']}/roster`,
+          icon: 'groups'
+        },
+        {
+          label: 'Settings',
+          path: `/course/${this.route.snapshot.params['course_site_id']}/settings`,
+          icon: 'settings'
+        }
+      ];
+    } else {
+      return [
+        {
+          label: 'Office Hours',
+          path: `/course/${this.route.snapshot.params['course_site_id']}/office-hours`,
+          icon: 'person_raised_hand'
+        },
+        {
+          label: 'Roster',
+          path: `/course/${this.route.snapshot.params['course_site_id']}/roster`,
+          icon: 'groups'
+        }
+      ];
+    }
+  });
+
+  constructor(
+    private route: ActivatedRoute,
+    protected myCoursesService: MyCoursesService,
+    protected http: HttpClient
+  ) {
+    let id = +this.route.snapshot.params['course_site_id'];
+    this.http
+      .get<TermOverviewJson[]>('/api/my-courses')
+      .pipe(map(parseTermOverviewJsonList))
+      .subscribe((terms) => {
+        console.log(terms);
+        let isInstructor =
+          terms.flatMap((term) => term.sites).find((site) => site.id === id)
+            ?.role == 'Instructor';
+
+        this.isInstructor.set(isInstructor);
+      });
+  }
 }

--- a/frontend/src/app/my-courses/course/settings/settings.component.css
+++ b/frontend/src/app/my-courses/course/settings/settings.component.css
@@ -1,0 +1,18 @@
+::ng-deep .mat-mdc-card-outlined {
+    max-width: 100% !important;
+    margin-right: 32px !important;
+}
+
+mat-form-field {
+    width: 100%;
+}
+
+.mat-mdc-card-actions {
+    padding-bottom: 16px;
+    justify-content: end;
+    gap: 12px;
+}
+
+mat-card-content {
+    padding-top: 16px;
+}

--- a/frontend/src/app/my-courses/course/settings/settings.component.html
+++ b/frontend/src/app/my-courses/course/settings/settings.component.html
@@ -40,9 +40,8 @@
         <mat-autocomplete
           #auto="matAutocomplete"
           (optionSelected)="selected($event)">
-          @if(selectedTerm.value) { @for (section of
-          selectedTerm.value!.teaching_no_site; track section.id) { @if
-          (!selectedSections().includes(section.id)) {
+          @if(selectedTerm.value) { @for (section of allSections(); track
+          section.id) { @if (!selectedSections().includes(section.id)) {
           <mat-option [value]="section.id"
             >{{ section.subject_code }} {{ section.course_number }}-{{
               section.section_number

--- a/frontend/src/app/my-courses/course/settings/settings.component.html
+++ b/frontend/src/app/my-courses/course/settings/settings.component.html
@@ -61,16 +61,10 @@
         [users]="utas"></user-lookup>
     </mat-card-content>
     <mat-card-actions>
-      <button
-        mat-stroked-button
-        type="button"
-        [disabled]="noChanges()"
-        (click)="resetForm()">
+      <button mat-stroked-button type="button" (click)="resetForm()">
         Reset
       </button>
-      <button mat-flat-button type="submit" [disabled]="!formIsValid()" (click)="submit()">
-        Save
-      </button>
+      <button mat-flat-button type="submit" (click)="submit()">Save</button>
     </mat-card-actions>
   </form>
 </mat-pane>

--- a/frontend/src/app/my-courses/course/settings/settings.component.html
+++ b/frontend/src/app/my-courses/course/settings/settings.component.html
@@ -43,7 +43,7 @@
           @if(selectedTerm.value) { @for (section of
           selectedTerm.value!.teaching_no_site; track section.id) { @if
           (!selectedSections().includes(section.id)) {
-          <mat-option [value]="section"
+          <mat-option [value]="section.id"
             >{{ section.subject_code }} {{ section.course_number }}-{{
               section.section_number
             }}</mat-option

--- a/frontend/src/app/my-courses/course/settings/settings.component.html
+++ b/frontend/src/app/my-courses/course/settings/settings.component.html
@@ -1,8 +1,76 @@
 <mat-pane>
-  <mat-card-header>
-    <mat-card-title>Settings</mat-card-title>
-  </mat-card-header>
-  <mat-card-content>
-    <p>Settings here.</p>
-  </mat-card-content>
+  <form>
+    <mat-card-header>
+      <mat-card-title>Settings</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <!-- Title Field -->
+      <mat-form-field appearance="outline">
+        <mat-label>Title</mat-label>
+        <input
+          matInput
+          placeholder="Enter the title for the course site."
+          [formControl]="title"
+          required />
+      </mat-form-field>
+      <!-- Section Selection Field -->
+      <mat-form-field appearance="outline">
+        <mat-label>Select Course Sections</mat-label>
+        <mat-chip-grid #chipGrid>
+          @for (sectionId of selectedSections(); track sectionId) { @if
+          (sectionForId(sectionId)) {
+          <mat-chip-row (removed)="remove(sectionForId(sectionId)!)">
+            {{ sectionForId(sectionId)!.subject_code }}
+            {{ sectionForId(sectionId)!.course_number }}-{{
+              sectionForId(sectionId)!.section_number
+            }}
+            <button matChipRemove>
+              <mat-icon>cancel</mat-icon>
+            </button>
+          </mat-chip-row>
+          } }
+        </mat-chip-grid>
+        <input
+          name="currentSection"
+          placeholder="Add Sections..."
+          #sectionInput
+          [(ngModel)]="currentSectionInput"
+          [matChipInputFor]="chipGrid"
+          [matAutocomplete]="auto" />
+        <mat-autocomplete
+          #auto="matAutocomplete"
+          (optionSelected)="selected($event)">
+          @if(selectedTerm.value) { @for (section of
+          selectedTerm.value!.teaching_no_site; track section.id) { @if
+          (!selectedSections().includes(section.id)) {
+          <mat-option [value]="section"
+            >{{ section.subject_code }} {{ section.course_number }}-{{
+              section.section_number
+            }}</mat-option
+          >
+          } } }
+        </mat-autocomplete>
+      </mat-form-field>
+      <!-- GTA Field -->
+      <user-lookup
+        label="Graduate Teaching Assistants"
+        [users]="gtas"></user-lookup>
+      <!-- GTA Field -->
+      <user-lookup
+        label="Undergraduate Teaching Assistants"
+        [users]="utas"></user-lookup>
+    </mat-card-content>
+    <mat-card-actions>
+      <button
+        mat-stroked-button
+        type="button"
+        [disabled]="noChanges()"
+        (click)="resetForm()">
+        Reset
+      </button>
+      <button mat-flat-button type="submit" [disabled]="!formIsValid()" (click)="submit()">
+        Save
+      </button>
+    </mat-card-actions>
+  </form>
 </mat-pane>

--- a/frontend/src/app/my-courses/course/settings/settings.component.ts
+++ b/frontend/src/app/my-courses/course/settings/settings.component.ts
@@ -108,26 +108,8 @@ export class SettingsComponent {
     return (
       this.title.value !== null &&
       this.title.value !== '' &&
-      this.selectedSections().length > 0 &&
-      !this.noChanges()
+      this.selectedSections().length > 0
     );
-  }
-
-  /** Determines if there are no current edits. */
-  noChanges(): boolean {
-    const titleCheck = this.title.value === this.courseSite?.title;
-    // JSON.stringify() and sorts are used to compare lists independent of order.
-    const sectionsCheck =
-      JSON.stringify(this.selectedSections().sort()) ===
-      JSON.stringify(this.courseSite?.section_ids.sort());
-    const gtasCheck =
-      JSON.stringify(this.gtas.map((user) => user.id).sort()) ===
-      JSON.stringify(this.courseSite?.gtas.map((user) => user.id).sort());
-    const utasCheck =
-      JSON.stringify(this.utas.map((user) => user.id).sort()) ===
-      JSON.stringify(this.courseSite?.utas.map((user) => user.id).sort());
-
-    return titleCheck && sectionsCheck && gtasCheck && utasCheck;
   }
 
   /**

--- a/frontend/src/app/my-courses/course/settings/settings.component.ts
+++ b/frontend/src/app/my-courses/course/settings/settings.component.ts
@@ -4,6 +4,7 @@ import {
   CourseSite,
   CourseSiteOverview,
   SectionOverview,
+  sectionOverviewToTeachingSectionOverview,
   TeachingSectionOverview,
   TermOverview,
   UpdatedCourseSite
@@ -146,15 +147,29 @@ export class SettingsComponent {
 
   /** Retrieve a section for a given ID */
   sectionForId(id: number) {
-    console.log(id);
     let term = this.myCoursesService
       .allTerms()
       .find((term) => term.id == this.courseSite!.term_id)!;
+    console.log(term);
     return (
       term.teaching_no_site.find((section) => section.id === id) ||
       term.sites
         .flatMap((site) => site.sections)
         .find((section) => section.id === id)
     );
+  }
+
+  /** Retrieves a list of all sections for the dropwdown */
+  allSections() {
+    let term = this.myCoursesService
+      .allTerms()
+      .find((term) => term.id == this.courseSite!.term_id)!;
+    return term.teaching_no_site
+      .concat(
+        term.sites
+          .flatMap((site) => site.sections)
+          .map(sectionOverviewToTeachingSectionOverview)
+      )
+      .sort((a, b) => +a.course_number - +b.course_number);
   }
 }

--- a/frontend/src/app/my-courses/course/settings/settings.component.ts
+++ b/frontend/src/app/my-courses/course/settings/settings.component.ts
@@ -146,6 +146,7 @@ export class SettingsComponent {
 
   /** Retrieve a section for a given ID */
   sectionForId(id: number) {
+    console.log(id);
     let term = this.myCoursesService
       .allTerms()
       .find((term) => term.id == this.courseSite!.term_id)!;

--- a/frontend/src/app/my-courses/course/settings/settings.component.ts
+++ b/frontend/src/app/my-courses/course/settings/settings.component.ts
@@ -1,4 +1,18 @@
-import { Component } from '@angular/core';
+import { Component, signal, WritableSignal } from '@angular/core';
+import { MyCoursesService } from '../../my-courses.service';
+import {
+  CourseSite,
+  CourseSiteOverview,
+  SectionOverview,
+  TeachingSectionOverview,
+  TermOverview,
+  UpdatedCourseSite
+} from '../../my-courses.model';
+import { ActivatedRoute } from '@angular/router';
+import { FormControl } from '@angular/forms';
+import { PublicProfile } from 'src/app/profile/profile.service';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { MatSnackBar } from '@angular/material/snack-bar';
 
 @Component({
   selector: 'app-settings',
@@ -6,10 +20,158 @@ import { Component } from '@angular/core';
   styleUrl: './settings.component.css'
 })
 export class SettingsComponent {
+  [x: string]: any;
   /** Route information to be used in the routing module */
   public static Route = {
     path: 'settings',
     title: 'Course',
     component: SettingsComponent
   };
+
+  /** Stores the course site.  */
+  public courseSite: UpdatedCourseSite | null = null;
+
+  /** Section selector */
+  title = new FormControl('');
+  selectedTerm: FormControl<TermOverview | null> = new FormControl(null);
+  selectedSections: WritableSignal<number[]> = signal([]);
+  currentSectionInput = signal('');
+
+  /** GTA and UTA selectors */
+  public gtas: PublicProfile[] = [];
+  public utas: PublicProfile[] = [];
+
+  constructor(
+    private route: ActivatedRoute,
+    protected myCoursesService: MyCoursesService,
+    private snackBar: MatSnackBar
+  ) {
+    this.resetForm();
+  }
+
+  /**
+   * Handles the selection of items from the autocomplete dropdown for sections.
+   *
+   * Logic from the dialog example on the Angular Material docs:
+   * https://material.angular.io/components/chips/examples#chips-autocomplete
+   */
+  selected(event: MatAutocompleteSelectedEvent): void {
+    let section = event.option.value as number;
+    this.selectedSections.update((sections) => [...sections, section]);
+    this.currentSectionInput.set('');
+    event.option.deselect();
+  }
+
+  /**
+   * Handles the removal of items from the autocomplete dropdown for sections.
+   *
+   * Logic from the dialog example on the Angular Material docs:
+   * https://material.angular.io/components/chips/examples#chips-autocomplete
+   */
+  remove(section: SectionOverview | TeachingSectionOverview): void {
+    this.selectedSections.update((sections) => {
+      let index = sections.indexOf(section.id);
+      if (index < 0) {
+        return sections;
+      }
+
+      sections.splice(index, 1);
+      return [...sections];
+    });
+  }
+
+  /** Resets the sections back to an empty list. */
+  resetSections(): void {
+    this.selectedSections.set([]);
+  }
+
+  /** Resets the form */
+  resetForm() {
+    let courseSiteId = this.route.parent!.snapshot.params['course_site_id'];
+    this.myCoursesService
+      .getCourseSite(courseSiteId)
+      .subscribe((courseSite) => {
+        this.courseSite = courseSite;
+        this.title.setValue(courseSite.title);
+        let term = this.myCoursesService
+          .allTerms()
+          .find((term) => term.id == this.courseSite!.term_id)!;
+        this.selectedTerm.setValue(term);
+        this.selectedSections.set(this.courseSite.section_ids);
+        this.gtas = this.courseSite.gtas;
+        this.utas = this.courseSite.utas;
+      });
+  }
+
+  /** Determines if the form is valid and can be submitted. */
+  formIsValid(): boolean {
+    return (
+      this.title.value !== null &&
+      this.title.value !== '' &&
+      this.selectedSections().length > 0 &&
+      !this.noChanges()
+    );
+  }
+
+  /** Determines if there are no current edits. */
+  noChanges(): boolean {
+    const titleCheck = this.title.value === this.courseSite?.title;
+    // JSON.stringify() and sorts are used to compare lists independent of order.
+    const sectionsCheck =
+      JSON.stringify(this.selectedSections().sort()) ===
+      JSON.stringify(this.courseSite?.section_ids.sort());
+    const gtasCheck =
+      JSON.stringify(this.gtas.map((user) => user.id).sort()) ===
+      JSON.stringify(this.courseSite?.gtas.map((user) => user.id).sort());
+    const utasCheck =
+      JSON.stringify(this.utas.map((user) => user.id).sort()) ===
+      JSON.stringify(this.courseSite?.utas.map((user) => user.id).sort());
+
+    return titleCheck && sectionsCheck && gtasCheck && utasCheck;
+  }
+
+  /**
+   * Submits the form and creates a new course site.
+   */
+  submit(): void {
+    if (this.courseSite && this.formIsValid()) {
+      // Create object
+      let updatedCourseSite: UpdatedCourseSite = {
+        id: this.courseSite.id,
+        title: this.title.value ?? '',
+        term_id: this.courseSite.term_id,
+        section_ids: this.selectedSections(),
+        gtas: this.gtas,
+        utas: this.utas
+      };
+
+      // Attempt to update
+      this.myCoursesService.updateCourseSite(updatedCourseSite).subscribe({
+        next: () => {
+          this.resetForm();
+          this.snackBar.open('Successfully updated the course site.', '', {
+            duration: 2000
+          });
+        },
+        error: (err) => {
+          this.snackBar.open('Could not save the course site.', '', {
+            duration: 2000
+          });
+        }
+      });
+    }
+  }
+
+  /** Retrieve a section for a given ID */
+  sectionForId(id: number) {
+    let term = this.myCoursesService
+      .allTerms()
+      .find((term) => term.id == this.courseSite!.term_id)!;
+    return (
+      term.teaching_no_site.find((section) => section.id === id) ||
+      term.sites
+        .flatMap((site) => site.sections)
+        .find((section) => section.id === id)
+    );
+  }
 }

--- a/frontend/src/app/my-courses/course/settings/settings.component.ts
+++ b/frontend/src/app/my-courses/course/settings/settings.component.ts
@@ -14,6 +14,7 @@ import { FormControl } from '@angular/forms';
 import { PublicProfile } from 'src/app/profile/profile.service';
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { myCoursesInstructorGuard } from '../../my-courses.guard';
 
 @Component({
   selector: 'app-settings',
@@ -26,7 +27,8 @@ export class SettingsComponent {
   public static Route = {
     path: 'settings',
     title: 'Course',
-    component: SettingsComponent
+    component: SettingsComponent,
+    canActivate: [myCoursesInstructorGuard]
   };
 
   /** Stores the course site.  */

--- a/frontend/src/app/my-courses/my-courses.guard.ts
+++ b/frontend/src/app/my-courses/my-courses.guard.ts
@@ -1,0 +1,33 @@
+/**
+ * The Instructor Editor Guard ensures that the page can open if the user
+ * is an instructor.
+ *
+ * @author Ajay Gandecha
+ * @copyright 2024
+ * @license MIT
+ */
+
+import { HttpClient } from '@angular/common/http';
+import { inject } from '@angular/core';
+import { CanActivateFn } from '@angular/router';
+import { PermissionService } from 'src/app/permission.service';
+import {
+  parseTermOverviewJsonList,
+  TermOverviewJson
+} from './my-courses.model';
+import { map } from 'rxjs';
+
+export const myCoursesInstructorGuard: CanActivateFn = (route, _) => {
+  /** Determine if page is viewable by user based on permissions */
+  let id = +route.parent!.params['course_site_id'];
+  return inject(HttpClient)
+    .get<TermOverviewJson[]>('/api/my-courses')
+    .pipe(map(parseTermOverviewJsonList))
+    .pipe(
+      map(
+        (terms) =>
+          terms.flatMap((term) => term.sites).find((site) => site.id === id)
+            ?.role == 'Instructor'
+      )
+    );
+};

--- a/frontend/src/app/my-courses/my-courses.model.ts
+++ b/frontend/src/app/my-courses/my-courses.model.ts
@@ -21,6 +21,18 @@ export interface SectionOverview {
   section_number: string;
 }
 
+export const sectionOverviewToTeachingSectionOverview = (
+  sectionOverview: SectionOverview
+): TeachingSectionOverview => {
+  return {
+    id: sectionOverview.id,
+    subject_code: sectionOverview.subject_code,
+    course_number: sectionOverview.course_number,
+    section_number: sectionOverview.section_number,
+    title: ''
+  };
+};
+
 export interface CourseOverview {
   id: string;
   subject_code: string;

--- a/frontend/src/app/my-courses/my-courses.model.ts
+++ b/frontend/src/app/my-courses/my-courses.model.ts
@@ -9,12 +9,16 @@
 
 import { Section } from '../academics/academics.models';
 import { Paginated, PaginationParams } from '../pagination';
+import { PublicProfile } from '../profile/profile.service';
 
 export interface SectionOverview {
   id: number;
   number: string;
   meeting_pattern: string;
   course_site_id: number | null;
+  subject_code: string;
+  course_number: string;
+  section_number: string;
 }
 
 export interface CourseOverview {
@@ -168,17 +172,29 @@ export interface TicketDraft {
 
 export interface CourseSiteOverview {
   id: number;
+  term_id: string;
   subject_code: string;
   number: string;
   title: string;
   role: string;
   sections: SectionOverview[];
+  gtas: PublicProfile[];
+  utas: PublicProfile[];
 }
 
 export interface NewCourseSite {
   title: string;
   term_id: string;
   section_ids: number[];
+}
+
+export interface UpdatedCourseSite {
+  id: number;
+  title: string;
+  term_id: string;
+  section_ids: number[];
+  gtas: PublicProfile[];
+  utas: PublicProfile[];
 }
 
 export interface CourseSite {

--- a/frontend/src/app/my-courses/my-courses.service.ts
+++ b/frontend/src/app/my-courses/my-courses.service.ts
@@ -35,7 +35,9 @@ import {
   OfficeHours,
   OfficeHoursJson,
   parseOfficeHoursJson,
-  NewOfficeHours
+  NewOfficeHours,
+  UpdatedCourseSite,
+  CourseSiteOverview
 } from './my-courses.model';
 import { Observable, map, tap } from 'rxjs';
 import { Paginator } from '../pagination';
@@ -213,12 +215,30 @@ export class MyCoursesService {
   }
 
   /**
+   * Gets a new course site for a given ID.
+   * @param courseSiteID: ID of the course site to get
+   * @returns {Observable<CourseSite>}
+   */
+  getCourseSite(courseSiteId: number): Observable<UpdatedCourseSite> {
+    return this.http.get<UpdatedCourseSite>(`/api/my-courses/${courseSiteId}`);
+  }
+
+  /**∂
    * Creates a new course site.
    * @param newCourseSite New course site to create
    * @returns {Observable<CourseSite>}
    */
   createCourseSite(newCourseSite: NewCourseSite): Observable<CourseSite> {
     return this.http.post<CourseSite>(`/api/my-courses/new`, newCourseSite);
+  }
+
+  /**
+   * Updates a course site.
+   * @param courseSite: Site to update
+   * @returns {Observable<CourseSite>}
+   */
+  updateCourseSite(courseSite: UpdatedCourseSite): Observable<CourseSite> {
+    return this.http.put<CourseSite>(`/api/my-courses`, courseSite);
   }
 
   /**


### PR DESCRIPTION
This pull request completes the settings page for instructors on the My Courses page. Instructors are now able to add / remove sections, as well as add or remove GTAs and UTAs. Adding a UTA will give them access to the course site. If a user is an existing UTA or GTA, their role will be upgraded.

### Settings Page

<img width="1410" alt="image" src="https://github.com/user-attachments/assets/c8ad3c60-12ba-4534-b7a6-a536a1180123">

The settings page is not accessible or visible for students or UTA/GTAs.