### PR TITLE
Fix the Organization Creation Form

### DIFF
--- a/frontend/src/app/organization/organization-editor/organization-editor.component.ts
+++ b/frontend/src/app/organization/organization-editor/organization-editor.component.ts
@@ -94,6 +94,7 @@ export class OrganizationEditorComponent {
       let organizationToSubmit = this.organization;
       Object.assign(organizationToSubmit, this.organizationForm.value);
 
+      console.log(this.isNew());
       let submittedOrganization = this.isNew()
         ? this.organizationService.createOrganization(organizationToSubmit)
         : this.organizationService.updateOrganization(organizationToSubmit);
@@ -163,7 +164,7 @@ export class OrganizationEditorComponent {
    * @returns {boolean}
    */
   isNew(): boolean {
-    return this.organization.slug === 'new';
+    return this.route.snapshot.params['slug'] === 'new';
   }
 
   /** Shorthand for determining the action being performed on the organization.


### PR DESCRIPTION
This small PR fixes the broken organization creation form. Previously, the form checked the organization object's slug to determine if the object was new or not. Now, it correctly checks if the route includes `new` as intended.