### PR TITLE
Redesign Organization Details Pane and Card

### DIFF
--- a/frontend/src/app/organization/organization-details/organization-details.component.html
+++ b/frontend/src/app/organization/organization-details/organization-details.component.html
@@ -5,10 +5,7 @@
 } @else {
 <organization-details-info-card
   [organization]="organization"
-  [profile]="profile" />
+  [profile]="profile"
+  [eventCreationPermissions]="eventCreationPermission$ | async"
+/>
 }
-
-<admin-fab
-  primaryIcon="edit"
-  primaryText="Edit"
-  secondaryIcon="calendar_add_on" />

--- a/frontend/src/app/organization/organization-details/organization-details.component.ts
+++ b/frontend/src/app/organization/organization-details/organization-details.component.ts
@@ -97,8 +97,7 @@ export class OrganizationDetailsComponent implements OnInit {
       'organization.*',
       `organization/${this.organization?.slug}`,
       '',
-      `/organizations/${this.organization?.slug}/edit`,
-      `/events/${this.organization?.slug}/new/edit`
+      `/organizations/${this.organization?.slug}/edit`
     );
   }
 }

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.css
@@ -1,165 +1,55 @@
-/** Profile Card CSS */
-.mdc-list-item--with-two-lines .mdc-list-item__primary-text,
-.mdc-list-item--with-three-lines .mdc-list-item__primary-text {
-    margin-bottom: 0;
-}
 
-
-.organization-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    padding-bottom: 16px;
-}
-
-.left-header-info {
-    padding-top: 0.5rem;
-    width: 10%;
-}
-
-.right-header-info {
-    display: flex;
+mat-card-header {
     flex-direction: column;
-    width: 90%;
+    width: 100%;
 }
 
-.organization-top-header-group {
-    display: flex;
-    flex-direction: row;
-    align-items: flex-start;
-    justify-content: left;
-}
-
-.organization-name-section {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-content: center;
-    height: 48px;
-}
-
-/* .organization-icons-section {
-    display: flex;
-    flex-direction: row-reverse;
-    width: 50%;
-    height: 5vh;
-} */
-.link-icons {
-    display: flex;
-    flex-direction: row;
-    gap: 12px;
-}
-/*TODO(mdc-migration): The following rule targets internal classes of card that may no longer apply for the MDC version. */
-mat-card-footer {
-    margin: 0 1rem 1.25rem 1rem;
-}
-
-.edit-organization-button {
-    margin-left: 6rem;
-}
-
-.user-avatar {
-    margin-right: 1rem;
+p {
     margin-bottom: 0;
-    background-color: #4786C6;
-    text-align: center;
-    vertical-align: middle;
-    justify-content: center;
-    width: 40px;
-    height: 40px;
-    line-height: 40px;
-    border-radius: 100%;
-    font-size: 1.15em;
-}
-
-.user-name {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: -webkit-box;
-    -webkit-line-clamp: 1;
-    /* number of lines to show */
-    line-clamp: 1;
-    -webkit-box-orient: vertical;
 }
 
 .mat-mdc-card-avatar {
     margin-bottom: 0 !important;
 }
 
-.mdc-list-group__subheader {
-    margin: 0;
+.header-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
 }
 
-.user-info-label {
-    font-weight: 500;
-    margin-bottom: 0;
-    font-size: 1.15em;
+.row {
+    display: flex;
+    flex-direction: row;
+    gap: 4px;
+    align-items: center;
 }
 
-.organization-description {
-    font-size: 1rem;
-    margin-top: 0;
+.links-row {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    margin-top: 4px;
+    align-items: center;
+    margin-bottom: 12px;
+    margin-left: 48px;
+    margin-right: 32px;
+    gap: 12px;
+  }
+  
+  .link-icons {
+    width: 22px;
+    height: 22px;
+  }
+
+mat-divider {
+    margin-top: 12px;
+    padding-bottom: 4px;
 }
 
-.logo {
-    width: 85%;
-    border-radius: 50% !important;
-}
-
-a {
-    text-decoration: none !important;
-}
-
-/** Make cards display in one column, with the event card appearing last */
-@media only screen and (max-width: 1180px) {
-
-    .right-header-info {
-        width: 100%;
-    }
-
-    .organization-card {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-around;
-    }
-
-    .logo {
-        width: 40px;
-        height: 40px;
-        border-radius: 50% !important;
-        margin-right: 0.5rem;
-    }
-
-    .organization-header {
-        flex-direction: column;
-        justify-content: left;
-        align-items: flex-start !important;
-    }
-
-    .organization-name-section {
-        width: 100%;
-    }
-
-    .organization-icons-section {
-        width: 100%;
-        height: 100% !important;
-    }
-
-    button {
-        width: max-content;
-    }
-
-    .mat-mdc-card {
-        margin: 1rem !important;
-    }
-
-    .edit-organization-button {
-        margin-left: 0;
-    }
-}
-
-@media only screen and (max-width: 1280px) {
-    .right-header-info {
-        width: 100%;
-    }
+mat-card-actions {
+    padding-bottom: 12px;
+    justify-content: flex-end;
+    gap: 8px;
 }

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.html
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.html
@@ -1,71 +1,99 @@
-<mat-pane
-  class="organization-card"
-  *ngIf="organization !== undefined"
-  appearance="outlined">
-  <!-- Organization Card Header (Image, Name, Description) -->
-  <mat-card-header class="organization-header">
-    @if (!isTablet && !isHandset) {
-    <div class="left-header-info">
-      <!-- Organization Logo (Laptops/Monitors) -->
-      <img mat-card-image src="{{ organization.logo }}" class="logo" />
+@if (organization) {
+<mat-pane>
+  <mat-card-header>
+    <div class="header-row">
+      <img mat-card-avatar src="{{ organization.logo }}" />
+      <mat-card-title>{{ organization.name }}</mat-card-title>
     </div>
-    }
-    <div class="right-header-info">
-      <!-- Organization Name, Logo, and Social Media -->
-      <div class="organization-top-header-group">
-        <!-- Organization Logo (Tablets/Phones) -->
-        @if (isTablet || isHandset) {
-        <img
-          mat-card-image
-          src="{{ organization.logo }}"
-          class="logo"
-          [ngStyle]="{
-            width: '32px',
-            height: '32px',
-            'margin-right': '16px'
-          }" />
-        }
-        <!-- Organization Name -->
-        <div class="organization-name-section">
-          <mat-card-title class="user-name">
-            {{ organization.name }}
-          </mat-card-title>
-        </div>
+    <div class="links-row">
+      @if (organization.website !== '') {
+      <div class="row">
+        <mat-icon class="link-icons secondary-icon">link</mat-icon>
+        <p>
+          <a
+            class="font-secondary"
+            [href]="organization.website"
+            target="_blank"
+            >Website</a
+          >
+        </p>
       </div>
-
-      <!-- Organization Description -->
-      <p class="organization-description">
-        {{ organization.long_description || organization.short_description }}
-      </p>
-
-      <!-- Organization Icons (Phones)-->
-      <div
-        class="organization-icons-section"
-        [ngStyle]="{ 'flex-direction': 'row' }">
-        <div class="link-icons">
-          @if(organization) { @if (organization.website !== '') {
-          <social-media-icon
-            [fontIcon]="'link'"
-            [href]="organization!.website" />
-          } @if (organization.email !== '') {
-          <social-media-icon
-            [fontIcon]="'mail'"
-            [href]="'mailto:' + organization.email" />
-          } @if(organization.instagram !== '') {
-          <social-media-icon
-            [svgIcon]="'instagram'"
-            [href]="organization!.instagram" />
-          } @if(organization.linked_in !== '') {
-          <social-media-icon
-            [svgIcon]="'linkedin'"
-            [href]="organization!.linked_in" />
-          } @if(organization.youtube !== '') {
-          <social-media-icon
-            [svgIcon]="'youtube'"
-            [href]="organization!.youtube" />
-          } }
-        </div>
+      } @if (organization.email !== '') {
+      <div class="row">
+        <mat-icon class="secondary-icon">mail</mat-icon>
+        <p>
+          <a
+            class="font-secondary"
+            href="mailto:{{ organization.email }}"
+            target="_blank"
+            >Email</a
+          >
+        </p>
       </div>
+      } @if (organization.instagram !== '') {
+      <div class="row">
+        <mat-icon class="link-icons secondary-icon" svgIcon="instagram" />
+        <p>
+          <a
+            class="font-secondary"
+            [href]="organization.instagram"
+            target="_blank"
+            >Instagram</a
+          >
+        </p>
+      </div>
+      } @if (organization.linked_in !== '') {
+      <div class="row">
+        <mat-icon
+          class="link-icons secondary-icon"
+          id="linkedin-icon"
+          svgIcon="linkedin" />
+        <p>
+          <a
+            class="font-secondary"
+            [href]="organization.linked_in"
+            target="_blank"
+            >LinkedIn</a
+          >
+        </p>
+      </div>
+      } @if (organization.youtube !== '') {
+      <div class="row">
+        <mat-icon class="link-icons secondary-icon" svgIcon="youtube" />
+        <p>
+          <a
+            class="font-secondary"
+            [href]="organization.youtube"
+            target="_blank"
+            >YouTube</a
+          >
+        </p>
+      </div>
+      }
     </div>
   </mat-card-header>
+  <mat-card-content>
+    <p>{{ organization.long_description || organization.short_description }}</p>
+    @if(eventCreationPermissions) {
+    <mat-divider />
+    }
+  </mat-card-content>
+  <mat-card-actions>
+    @if(eventCreationPermissions) {
+    <button
+      mat-stroked-button
+      class="primary-button"
+      [routerLink]="'/events/' + this.organization.slug + '/new/edit'">
+      <mat-icon class="font-primary">calendar_add_on</mat-icon>
+      Create Event
+    </button>
+    <button
+      mat-flat-button
+      class="primary-button"
+      [routerLink]="'/organizations/' + this.organization.slug + '/edit'">
+      Edit
+    </button>
+    }
+  </mat-card-actions>
 </mat-pane>
+}

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.ts
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.ts
@@ -3,68 +3,28 @@
  * individual organization detail card from the whole organization detail page.
  *
  * @author Ajay Gandecha, Jade Keegan, Brianna Ta, Audrey Toney
- * @copyright 2023
+ * @copyright 2024
  * @license MIT
  */
 
-import { Component, Input, OnDestroy, OnInit, input } from '@angular/core';
-import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
-import { Subscription } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { Component, Input } from '@angular/core';
 import { Organization } from '../../organization.model';
 import { Profile } from '../../../profile/profile.service';
-import { NagivationAdminGearService } from '../../../navigation/navigation-admin-gear.service';
+import { SocialMediaIconWidgetService } from 'src/app/shared/social-media-icon/social-media-icon.widget.service';
 
 @Component({
   selector: 'organization-details-info-card',
   templateUrl: './organization-details-info-card.widget.html',
   styleUrls: ['./organization-details-info-card.widget.css']
 })
-export class OrganizationDetailsInfoCard implements OnInit, OnDestroy {
+export class OrganizationDetailsInfoCard {
   /** The organization to show */
   @Input() organization: Organization | undefined;
   /** The currently logged in user */
   @Input() profile?: Profile;
-
-  /** Holds data on whether or not the user is on a mobile device */
-  public isHandset: boolean = false;
-  private isHandsetSubscription!: Subscription;
-
-  /** Holds data on whether or not the user is on a tablet */
-  public isTablet: boolean = false;
-  private isTabletSubscription!: Subscription;
+  /** Whether or not the user has permission to create events */
+  @Input() eventCreationPermissions!: boolean | null;
 
   /** Constructs the organization detail info card widget */
-  constructor(
-    private breakpointObserver: BreakpointObserver,
-    private gearService: NagivationAdminGearService
-  ) {}
-
-  /** Runs whenever the view is rendered initally on the screen */
-  ngOnInit(): void {
-    this.isHandsetSubscription = this.initHandset();
-    this.isTabletSubscription = this.initTablet();
-  }
-
-  /** Unsubscribe from subscribers when the page is destroyed */
-  ngOnDestroy(): void {
-    this.isHandsetSubscription.unsubscribe();
-    this.isTabletSubscription.unsubscribe();
-  }
-
-  /** Determines whether the page is being used on a mobile device */
-  private initHandset() {
-    return this.breakpointObserver
-      .observe([Breakpoints.Handset, Breakpoints.TabletPortrait])
-      .pipe(map((result) => result.matches))
-      .subscribe((isHandset) => (this.isHandset = isHandset));
-  }
-
-  /** Determines whether the page is being used on a tablet */
-  private initTablet() {
-    return this.breakpointObserver
-      .observe(Breakpoints.TabletLandscape)
-      .pipe(map((result) => result.matches))
-      .subscribe((isTablet) => (this.isTablet = isTablet));
-  }
+  constructor(private icons: SocialMediaIconWidgetService) {}
 }


### PR DESCRIPTION
This small PR redesigns the organization detail page and card to better match standards used in the rest of the site. The FAB icons  have also been removed in favor of traditional buttons on the card.

## Before:
<img width="1259" alt="Screenshot 2024-07-25 at 11 24 05 PM" src="https://github.com/user-attachments/assets/8a9540e4-394a-4f1f-a4ae-20518e47613b">

## After
<img width="1259" alt="Screenshot 2024-07-25 at 11 24 18 PM" src="https://github.com/user-attachments/assets/ba615dbc-6bb2-425f-a700-f6f04f3a07a4">
