### PR TITLE
Fix Course Preferences Not Displaying on Frontend Application After Edit

### DIFF
--- a/frontend/src/app/applications/applications.model.ts
+++ b/frontend/src/app/applications/applications.model.ts
@@ -43,5 +43,5 @@ export interface Application {
   best_moment: string | null;
   desired_improvement: string | null;
   advisor: string | null;
-  preferred_sections: CatalogSectionIdentity[];
+  preferred_sections: ApplicationSectionChoice[];
 }

--- a/frontend/src/app/applications/form/application-form.component.ts
+++ b/frontend/src/app/applications/form/application-form.component.ts
@@ -83,6 +83,7 @@ export class ApplicationFormComponent {
       if (application) {
         this.application = application;
         this.formGroup.patchValue(application!);
+        this.selectedSections.set(application!.preferred_sections);
       }
     });
   }


### PR DESCRIPTION
This small PR ensures that the selected sections on an application form are populated when editing an application.