### PR TITLE
Remove hiring details from overview page

### DIFF
--- a/backend/models/academics/hiring/hiring_assignment.py
+++ b/backend/models/academics/hiring/hiring_assignment.py
@@ -89,8 +89,8 @@ class HiringCourseSiteOverview(BaseModel):
     total_cost: float
     coverage: float
     assignments: list[HiringAssignmentOverview]
-    reviews: list[ApplicationReviewOverview]
-    instructor_preferences: list[PublicUser]
+    # reviews: list[ApplicationReviewOverview]
+    # instructor_preferences: list[PublicUser]
 
 
 class HiringAdminOverview(BaseModel):

--- a/backend/services/academics/hiring.py
+++ b/backend/services/academics/hiring.py
@@ -587,13 +587,13 @@ class HiringService:
             .join(CourseSiteEntity.term)
             .where(TermEntity.id == term_id)
             .options(
-                joinedload(CourseSiteEntity.sections)
-                .joinedload(SectionEntity.staff)
-                .joinedload(SectionMemberEntity.user),
-                joinedload(CourseSiteEntity.application_reviews)
-                .joinedload(ApplicationReviewEntity.application)
-                .joinedload(ApplicationEntity.user),
-                joinedload(CourseSiteEntity.hiring_assignments),
+                joinedload(CourseSiteEntity.sections),
+                # # .joinedload(SectionEntity.staff)
+                # # .joinedload(SectionMemberEntity.user),
+                # joinedload(CourseSiteEntity.application_reviews)
+                # .joinedload(ApplicationReviewEntity.application),
+                # # .joinedload(ApplicationEntity.user),
+                # joinedload(CourseSiteEntity.hiring_assignments),
             )
         )
         course_site_entities = self._session.scalars(course_site_query).unique().all()
@@ -615,22 +615,26 @@ class HiringService:
                     if staff.member_role == RosterRole.INSTRUCTOR
                 ]
                 total_enrollment += section_entity.enrolled
-            preferred_review_entities = sorted(
-                [
-                    review
-                    for review in course_site_entity.application_reviews
-                    if review.status == ApplicationReviewStatus.PREFERRED
-                ],
-                key=lambda x: x.preference,
-            )
-            reviews = [
-                application_review.to_overview_model()
-                for application_review in preferred_review_entities
-            ]
-            instructor_preferences = [
-                application_review.application.user.to_public_model()
-                for application_review in preferred_review_entities
-            ]
+
+            # preferred_review_query = (
+            #     select(ApplicationReviewEntity)
+            #     .where(
+            #         ApplicationReviewEntity.course_site_id == course_site_entity.id,
+            #         ApplicationReviewEntity.status == ApplicationReviewStatus.PREFERRED,
+            #     )
+            #     .order_by(ApplicationReviewEntity.preference)
+            # )
+            # preferred_review_entities = self._session.scalars(
+            #     preferred_review_query
+            # ).all()
+            # reviews = [
+            #     application_review.to_overview_model()
+            #     for application_review in preferred_review_entities
+            # ]
+            # instructor_preferences = [
+            #     application_review.application.user.to_public_model()
+            #     for application_review in preferred_review_entities
+            # ]
             assignments = sorted(
                 [
                     assignment.to_overview_model()
@@ -652,8 +656,8 @@ class HiringService:
                 total_cost=total_cost,
                 coverage=coverage,
                 assignments=assignments,
-                reviews=reviews,
-                instructor_preferences=instructor_preferences,
+                # reviews=reviews,
+                # instructor_preferences=instructor_preferences,
             )
 
             # Add overview to the list

--- a/frontend/src/app/hiring/widgets/course-hiring-card/course-hiring-card.widget.html
+++ b/frontend/src/app/hiring/widgets/course-hiring-card/course-hiring-card.widget.html
@@ -8,7 +8,7 @@
   <mat-card-content>
     <mat-card-subtitle class="subtitle-header">Assignments</mat-card-subtitle>
     <div class="table-responsive">
-      <table
+      <!-- <table
         mat-table
         [dataSource]="item().assignments"
         class="surface-container-card">
@@ -85,13 +85,13 @@
         </ng-container>
         <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
         <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
-      </table>
+      </table> -->
     </div>
     <!-- <mat-divider /> -->
     <mat-card-subtitle class="subtitle-header">
       Instructor Preferences
     </mat-card-subtitle>
-    @if(item().instructor_preferences.length === 0) {
+    <!-- @if(item().instructor_preferences.length === 0) {
     <p>The instructor left no preferences.</p>
     }
     <div class="user-chips">
@@ -109,6 +109,6 @@
           [src]="user.github_avatar" />
         {{ user.first_name + ' ' + user.last_name }}
       </mat-chip-option>
-    </div>
+    </div> -->
   </mat-card-content>
 </mat-pane>


### PR DESCRIPTION
This hot fix aims to fix an out of memory (crashing) bug seen in production. This is not the full fix, but a temporary workaround. The full fix will need to fetch individual course details in a separate request.