### PR TITLE
Ensure Students Get Removed from Roster if Not in CSV Import

### DIFF
--- a/backend/test/services/academics/section_data.py
+++ b/backend/test/services/academics/section_data.py
@@ -542,6 +542,12 @@ Points Possible,,,,,(read only),(read only),(read only),(read only),(read only),
 "Student, New",0,345345345,nstudent,COMP301.001.S224,,,,,,,,,,,,,,,,
 "Jordan, Kris",0,89898989,kjordan,COMP301.001.S224,,,,,,,,,,,,,,,,"""
 
+smaller_roster_csv = """Student,ID,SIS User ID,SIS Login ID,Section,Assignments Current Points,Assignments Final Points,Assignments Current Score,Assignments Unposted Current Score,Assignments Final Score,Assignments Unposted Final Score,Current Points,Final Points,Current Score,Unposted Current Score,Final Score,Unposted Final Score,Current Grade,Unposted Current Grade,Final Grade,Unposted Final Grade
+Points Possible,,,,,(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only)
+"Root, Rhonda",0,999999999,rroot,COMP301.001.S224,,,,,,,,,,,,,,,,
+"Jordan, Kris",0,89898989,kjordan,COMP301.001.S224,,,,,,,,,,,,,,,,"""
+
+
 bad_roster_csv = """Student,Assignments Current Points,Assignments Final Points,Assignments Current Score,Assignments Unposted Current Score,Assignments Final Score,Assignments Unposted Final Score,Current Points,Final Points,Current Score,Unposted Current Score,Final Score,Unposted Final Score,Current Grade,Unposted Current Grade,Final Grade,Unposted Final Grade
 Points Possible,,,,,(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only)
 "Root, Rhonda",0,999999999,,,,,,,,,,,,,,,

--- a/backend/test/services/academics/section_member_test.py
+++ b/backend/test/services/academics/section_member_test.py
@@ -58,6 +58,32 @@ def test_create_from_csv(section_member_svc: SectionMemberService):
     )
 
 
+def test_create_from_csv_twice(section_member_svc: SectionMemberService):
+    section_member_svc.import_users_from_csv(
+        user_data.instructor,
+        section_data.comp_301_001_current_term.id,
+        csv_data=section_data.roster_csv,
+    )
+    section_member_svc.import_users_from_csv(
+        user_data.instructor,
+        section_data.comp_301_001_current_term.id,
+        csv_data=section_data.roster_csv,
+    )
+
+
+def test_create_from_csv_remove(section_member_svc: SectionMemberService):
+    section_member_svc.import_users_from_csv(
+        user_data.instructor,
+        section_data.comp_301_001_current_term.id,
+        csv_data=section_data.roster_csv,
+    )
+    section_member_svc.import_users_from_csv(
+        user_data.instructor,
+        section_data.comp_301_001_current_term.id,
+        csv_data=section_data.smaller_roster_csv,
+    )
+
+
 def test_create_from_csv_not_instructor(section_member_svc: SectionMemberService):
     with pytest.raises(CoursePermissionException):
         section_member_svc.import_users_from_csv(


### PR DESCRIPTION
This pull request fixes issues with importing students from a CSV into a course roster after the initial upload. It also adds the ability to remove students from the roster if students are not found on a subsequent CSV import, accounting for students who drop the class.