### PR TITLE
Office Hours Feature Fixes

### DIFF
--- a/frontend/src/app/my-courses/course/office-hours/office-hours-editor/office-hours-editor.component.html
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-editor/office-hours-editor.component.html
@@ -62,6 +62,7 @@
 
       <!-- Start Time -->
       <mat-form-field appearance="outline" color="accent">
+        <mat-label>Office Hours Event Start Time</mat-label>
         <input
           matInput
           type="datetime-local"
@@ -73,6 +74,7 @@
 
       <!-- End Time -->
       <mat-form-field appearance="outline" color="accent">
+        <mat-label>Office Hours Event End Time</mat-label>
         <input
           matInput
           type="datetime-local"

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-get-help/office-hours-get-help.component.html
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-get-help/office-hours-get-help.component.html
@@ -68,7 +68,7 @@
           <mat-option [value]="1">Conceptual Help</mat-option>
         </mat-select>
       </mat-form-field>
-      @if (ticketForm.controls['type'].value === 'Assignment Help') {
+      @if (+ticketForm.controls['type'].value! === 0) {
       <mat-form-field appearance="outline">
         <mat-label>
           What section of the assignment do you need help with?

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-get-help/office-hours-get-help.component.ts
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-get-help/office-hours-get-help.component.ts
@@ -51,7 +51,7 @@ export class OfficeHoursGetHelpComponent implements OnInit, OnDestroy {
 
   /** Office Hour Ticket Editor Form */
   public ticketForm = this.formBuilder.group({
-    type: new FormControl('Assignment Help', [Validators.required]),
+    type: new FormControl(0, [Validators.required]),
     assignmentSection: new FormControl('', [Validators.required]),
     codeSection: new FormControl('', [Validators.required]),
     conceptsSection: new FormControl('', [Validators.required]),
@@ -93,7 +93,7 @@ export class OfficeHoursGetHelpComponent implements OnInit, OnDestroy {
 
   isFormValid(): boolean {
     let contentFieldsValid =
-      this.ticketForm.controls['type'].value === 'Assignment Help'
+      this.ticketForm.controls['type'].value === 0
         ? this.ticketForm.controls['assignmentSection'].value !== '' &&
           this.ticketForm.controls['codeSection'].value !== '' &&
           this.ticketForm.controls['conceptsSection'].value !== '' &&
@@ -120,24 +120,26 @@ export class OfficeHoursGetHelpComponent implements OnInit, OnDestroy {
 
   submitTicketForm() {
     let form_description: string = '';
-    let form_type: string = this.ticketForm.controls['type'].value!;
+    let form_type: number = this.ticketForm.controls['type'].value!;
 
     /* Below is logic for checking form values and assigning the correct
       TicketType and ticket description accordingly
     */
-    if (this.ticketForm.controls['type'].value === 'Conceptual Help') {
+    if (this.ticketForm.controls['type'].value === 1) {
       form_description =
-        'Conceptual: ' + (this.ticketForm.controls['description'].value ?? '');
+        '**Conceptual Question**:  \n' +
+        (this.ticketForm.controls['description'].value ?? '');
     } else {
       // Concatenates form description together and adds in new line characters
+      // NOTE: Two spaces in front of \n is required.
       form_description =
-        'Assignment Part: ' +
+        '**Assignment Part**:  \n' +
         (this.ticketForm.controls['assignmentSection'].value ?? '') +
-        ' \nGoal: ' +
+        '  \n  \n**Goal**:  \n' +
         (this.ticketForm.controls['codeSection'].value ?? '') +
-        ' \nConcepts: ' +
+        '  \n  \n**Concepts**:  \n' +
         (this.ticketForm.controls['conceptsSection'].value ?? '') +
-        ' \nTried: ' +
+        '  \n  \n**Tried**:  \n' +
         (this.ticketForm.controls['attemptSection'].value ?? '');
     }
 

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.html
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.html
@@ -30,7 +30,7 @@
   </mat-card-header>
   @if (viewState === ViewState.Scheduled) {
   <mat-card-content class="pane-content">
-    <mat-card-subtitle>Current Events</mat-card-subtitle>
+    <mat-card-subtitle>Happening Now</mat-card-subtitle>
     <div class="card-container">
       @if (currentOfficeHourEvents().length === 0) {
       <p>Office hours are currently closed.</p>

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.html
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.html
@@ -65,17 +65,17 @@
                 {{ element.location }}
               </td>
             </ng-container>
-            <ng-container matColumnDef="actions">
-              <th mat-header-cell *matHeaderCellDef>Actions</th>
-              <td mat-cell *matCellDef="let element">
-                <button mat-icon-button [routerLink]="element.id + '/edit'">
-                  <mat-icon>edit</mat-icon>
-                </button>
-                <button mat-icon-button (click)="deleteOfficeHours(element)">
-                  <mat-icon>delete</mat-icon>
-                </button>
-              </td>
-            </ng-container>
+              <ng-container matColumnDef="actions">
+                <th mat-header-cell *matHeaderCellDef>Actions</th>
+                <td mat-cell *matCellDef="let element">
+                  <button mat-icon-button [routerLink]="element.id + '/edit'">
+                    <mat-icon>edit</mat-icon>
+                  </button>
+                  <button mat-icon-button (click)="deleteOfficeHours(element)">
+                    <mat-icon>delete</mat-icon>
+                  </button>
+                </td>
+              </ng-container>  
             <tr mat-header-row *matHeaderRowDef="futureOhDisplayedColumns"></tr>
             <tr
               mat-row

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.html
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.html
@@ -23,7 +23,7 @@
         <mat-button-toggle [value]="ViewState.History">
           History
         </mat-button-toggle>
-        <mat-button-toggle [value]="ViewState.Data">Data</mat-button-toggle>
+        <!-- <mat-button-toggle [value]="ViewState.Data">Data</mat-button-toggle> -->
       </mat-button-toggle-group>
     </div>
     <mat-divider />

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.ts
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.ts
@@ -54,7 +54,7 @@ export class OfficeHoursPageComponent {
   private previousFutureOfficeHourEventParams: PaginationParams =
     DEFAULT_PAGINATION_PARAMS;
 
-  public futureOhDisplayedColumns: string[] = ['date', 'type', 'actions'];
+  public futureOhDisplayedColumns: string[] = ['date', 'type'];
 
   /** Encapsulated past events paginator and params */
   private pastOfficeHourEventsPaginator: Paginator<OfficeHourEventOverview>;
@@ -119,8 +119,8 @@ export class OfficeHoursPageComponent {
       const courseSite = terms
         .flatMap((term) => term.sites)
         .find((site) => site.id == +this.courseSiteId);
-      if (courseSite?.role === 'Student') {
-        this.futureOhDisplayedColumns.pop();
+      if (courseSite?.role !== 'Student') {
+        this.futureOhDisplayedColumns = ['date', 'type', 'actions'];
       }
     });
   }

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.ts
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.ts
@@ -6,7 +6,7 @@
  * @license MIT
  */
 
-import { Component, WritableSignal, signal } from '@angular/core';
+import { Component, OnInit, WritableSignal, signal } from '@angular/core';
 import { PageEvent } from '@angular/material/paginator';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ActivatedRoute } from '@angular/router';
@@ -111,6 +111,18 @@ export class OfficeHoursPageComponent {
       .subscribe((page) => {
         this.pastOfficeHourEventsPage.set(page);
       });
+
+    // This subscription loads whether or not the user is a student in the course, and
+    // hides the Actions columns if so. This is a hack to get around requirements for
+    // Angular tables, and should be revisited in the future.
+    this.myCoursesService.getTermOverviews().subscribe((terms) => {
+      const courseSite = terms
+        .flatMap((term) => term.sites)
+        .find((site) => site.id == +this.courseSiteId);
+      if (courseSite?.role === 'Student') {
+        this.futureOhDisplayedColumns.pop();
+      }
+    });
   }
 
   /** Handles a pagination event for the future office hours table */

--- a/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.css
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.css
@@ -34,3 +34,12 @@ p {
     padding-top: 12px;
     justify-content: end;
 }
+
+::ng-deep strong, b {
+    font-weight: 500 !important;
+}
+
+.spacing-divider {
+    margin-top: 12px;
+    margin-bottom: 12px;
+}

--- a/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.html
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.html
@@ -24,9 +24,12 @@
   </mat-card-header>
   @if(expanded()) {
   <mat-card-content>
+    <mat-divider class="spacing-divider" />
     <p><span class="semibold-text">Helping:</span> {{ ticket.creators }}</p>
-    <p><span class="semibold-text">Description:</span></p>
-    <p>{{ ticket.description }}</p>
+    <mat-divider class="spacing-divider" />
+
+    <!-- <p><span class="semibold-text">Description:</span></p> -->
+    <p markdown>{{ ticket.description }}</p>
   </mat-card-content>
   <mat-card-actions>
     <button

--- a/frontend/src/app/my-courses/course/office-hours/widgets/queued-ticket-card/queued-ticket-card.widget.css
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/queued-ticket-card/queued-ticket-card.widget.css
@@ -37,3 +37,7 @@ p {
     gap: 8px;
     justify-content: end;
 }
+
+::ng-deep strong, b {
+    font-weight: 500 !important;
+}

--- a/frontend/src/app/my-courses/course/office-hours/widgets/queued-ticket-card/queued-ticket-card.widget.html
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/queued-ticket-card/queued-ticket-card.widget.html
@@ -6,8 +6,8 @@
     </div>
   </mat-card-header>
   <mat-card-content>
-    <p><span class="semibold-text">Description:</span></p>
-    <p>{{ ticket.description }}</p>
+    <!-- <p><span class="semibold-text">Description:</span></p> -->
+    <p markdown>{{ ticket.description }}</p>
   </mat-card-content>
   <mat-card-actions>
     <button

--- a/frontend/src/app/my-courses/course/roster/roster.component.html
+++ b/frontend/src/app/my-courses/course/roster/roster.component.html
@@ -9,9 +9,11 @@
     <mat-card-header id="pane-header">
       <mat-card-title>Course Roster</mat-card-title>
       <div class="header-buttons">
-        <button mat-stroked-button color="primary" (click)="importFromCanvas()">
-          Import From Canvas
-        </button>
+        @if(myCoursesService.courseOverview(+courseSiteId)?.role !== 'Student') {
+          <button mat-stroked-button color="primary" (click)="importFromCanvas()">
+            Import From Canvas
+          </button>
+        }
       </div>
     </mat-card-header>
     <mat-card-content>

--- a/frontend/src/app/my-courses/course/roster/roster.component.ts
+++ b/frontend/src/app/my-courses/course/roster/roster.component.ts
@@ -83,6 +83,18 @@ export class RosterComponent {
     this.rosterPaginator.loadPage(this.previousParams).subscribe((page) => {
       this.rosterPage.set(page);
     });
+
+    // This subscription loads whether or not the user is a student in the course, and
+    // hides some detail columns if so. This is a hack to get around requirements for
+    // Angular tables, and should be revisited in the future.
+    this.myCoursesService.getTermOverviews().subscribe((terms) => {
+      const courseSite = terms
+        .flatMap((term) => term.sites)
+        .find((site) => site.id == +this.courseSiteId);
+      if (courseSite?.role === 'Student') {
+        this.displayedColumns = ['section', 'name'];
+      }
+    });
   }
 
   handlePageEvent(e: PageEvent) {

--- a/frontend/src/app/my-courses/course/roster/roster.component.ts
+++ b/frontend/src/app/my-courses/course/roster/roster.component.ts
@@ -46,7 +46,7 @@ export class RosterComponent {
   > = signal(undefined);
   private previousParams: PaginationParams = DEFAULT_PAGINATION_PARAMS;
 
-  public displayedColumns: string[] = ['section', 'name', 'pid', 'email'];
+  public displayedColumns: string[] = ['section', 'name'];
 
   /** Current search bar query */
   public searchBarQuery: WritableSignal<string> = signal('');
@@ -91,8 +91,8 @@ export class RosterComponent {
       const courseSite = terms
         .flatMap((term) => term.sites)
         .find((site) => site.id == +this.courseSiteId);
-      if (courseSite?.role === 'Student') {
-        this.displayedColumns = ['section', 'name'];
+      if (courseSite?.role !== 'Student') {
+        this.displayedColumns = ['section', 'name', 'pid', 'email'];
       }
     });
   }

--- a/frontend/src/app/my-courses/course/roster/roster.component.ts
+++ b/frontend/src/app/my-courses/course/roster/roster.component.ts
@@ -67,15 +67,17 @@ export class RosterComponent {
     });
   });
 
+  courseSiteId: string;
+
   constructor(
     private route: ActivatedRoute,
     protected dialog: MatDialog,
     protected myCoursesService: MyCoursesService
   ) {
-    let courseSiteId = this.route.parent!.snapshot.params['course_site_id'];
+    this.courseSiteId = this.route.parent!.snapshot.params['course_site_id'];
 
     this.rosterPaginator = new Paginator<CourseMemberOverview>(
-      `/api/my-courses/${courseSiteId}/roster`
+      `/api/my-courses/${this.courseSiteId}/roster`
     );
 
     this.rosterPaginator.loadPage(this.previousParams).subscribe((page) => {

--- a/frontend/src/app/my-courses/my-courses.model.ts
+++ b/frontend/src/app/my-courses/my-courses.model.ts
@@ -117,7 +117,7 @@ export interface OfficeHourTicketOverviewJson {
   created_at: string;
   called_at: string | undefined;
   state: string;
-  type: string;
+  type: number;
   description: string;
   creators: string[];
   caller: string | undefined;
@@ -128,7 +128,7 @@ export interface OfficeHourTicketOverview {
   created_at: Date;
   called_at: Date | undefined;
   state: string;
-  type: string;
+  type: number;
   description: string;
   creators: string[];
   caller: string | undefined;
@@ -179,7 +179,7 @@ export interface OfficeHourGetHelpOverview {
 export interface TicketDraft {
   office_hours_id: number;
   description: string;
-  type: string;
+  type: number;
 }
 
 export interface CourseSiteOverview {

--- a/frontend/src/app/my-courses/my-courses.service.ts
+++ b/frontend/src/app/my-courses/my-courses.service.ts
@@ -90,12 +90,15 @@ export class MyCoursesService {
 
   /** Refreshes the my courses data emitted by the signals. */
   getTermOverviews() {
-    this.http
+    const terms$ = this.http
       .get<TermOverviewJson[]>('/api/my-courses')
-      .pipe(map(parseTermOverviewJsonList))
-      .subscribe((terms) => {
-        this.termsSignal.set(terms);
-      });
+      .pipe(map(parseTermOverviewJsonList));
+
+    terms$.subscribe((terms) => {
+      this.termsSignal.set(terms);
+    });
+
+    return terms$;
   }
 
   /**

--- a/frontend/src/app/my-courses/widgets/course-card/course-card.widget.html
+++ b/frontend/src/app/my-courses/widgets/course-card/course-card.widget.html
@@ -27,7 +27,7 @@
       mat-flat-button
       color="primary"
       type="submit"
-      [routerLink]="'/course/' + course.id">
+      [routerLink]="'/course/' + course.id + '/office-hours'">
       Get Help
     </button>
     } @else { @if (course.role === 'Instructor') {


### PR DESCRIPTION
This pull request cleans up the office hours feature for pilot use by both TAs and students.

### Changes:
* Hide the actions columns in office hours events for students so they do not see dummy "edit" and "delete" icons. Also, hide the "Import from Canvas" button on the roster, which was viewable by students (but did not function).
* Hide the currently unused office hours data tab from view.
* Hide PIDs and emails of other students on the roster from the student view. Instructors can still access this data.
* Added labels on the date-time fields on the office hours form.
* Fixed many issues with the office hours description texts. Now, they are properly formatted and work as expected.
* Made some improvements to styling throughout.