### PR TITLE
Add Profile Images and Location Descriptions to Office Hour Tickets

### DIFF
--- a/backend/models/academics/my_courses.py
+++ b/backend/models/academics/my_courses.py
@@ -84,8 +84,8 @@ class OfficeHourTicketOverview(BaseModel):
     state: str
     type: str
     description: str
-    creators: list[str]
-    caller: str | None
+    creators: list[PublicUser]
+    caller: PublicUser | None
 
 
 class OfficeHourQueueOverview(BaseModel):
@@ -107,5 +107,7 @@ class OfficeHourGetHelpOverview(BaseModel):
     event_mode: str
     event_start_time: datetime
     event_end_time: datetime
+    event_location: str
+    event_location_description: str
     ticket: OfficeHourTicketOverview | None
     queue_position: int

--- a/backend/services/office_hours/office_hours.py
+++ b/backend/services/office_hours/office_hours.py
@@ -175,6 +175,8 @@ class OfficeHoursService:
             event_mode=queue_entity.mode.to_string(),
             event_start_time=queue_entity.start_time,
             event_end_time=queue_entity.end_time,
+            event_location=queue_entity.room.nickname,
+            event_location_description=queue_entity.location_description,
             ticket=(
                 self._to_oh_ticket_overview(active_ticket) if active_ticket else None
             ),
@@ -254,15 +256,8 @@ class OfficeHoursService:
             state=ticket.state.to_string(),
             type=ticket.type.to_string(),
             description=ticket.description,
-            creators=[
-                f"{creator.user.first_name} {creator.user.last_name}"
-                for creator in ticket.creators
-            ],
-            caller=(
-                f"{ticket.caller.user.first_name} {ticket.caller.user.last_name}"
-                if ticket.caller
-                else None
-            ),
+            creators=[creator.user.to_public_model() for creator in ticket.creators],
+            caller=(ticket.caller.user.to_public_model() if ticket.caller else None),
         )
 
     def create(self, user: User, site_id: int, event: NewOfficeHours) -> OfficeHours:

--- a/backend/services/office_hours/ticket.py
+++ b/backend/services/office_hours/ticket.py
@@ -54,15 +54,8 @@ class OfficeHourTicketService:
             state=ticket.state.to_string(),
             type=ticket.type.to_string(),
             description=ticket.description,
-            creators=[
-                f"{creator.user.first_name} {creator.user.last_name}"
-                for creator in ticket.creators
-            ],
-            caller=(
-                f"{ticket.caller.user.first_name} {ticket.caller.user.last_name}"
-                if ticket.caller
-                else None
-            ),
+            creators=[creator.user.to_public_model() for creator in ticket.creators],
+            caller=(ticket.caller.user.to_public_model() if ticket.caller else None),
         )
 
     def call_ticket(self, user: User, ticket_id: int) -> OfficeHourTicketOverview:

--- a/backend/test/services/office_hours/ticket_test.py
+++ b/backend/test/services/office_hours/ticket_test.py
@@ -38,8 +38,7 @@ def test_call_ticket(oh_ticket_svc: OfficeHourTicketService):
         user_data.instructor, office_hours_data.comp_110_queued_ticket.id
     )
     assert called.state == TicketState.CALLED.to_string()
-    name = user_data.instructor.first_name + " " + user_data.instructor.last_name
-    assert called.caller == name
+    assert called.caller.id == user_data.instructor.id
 
 
 def test_call_ticket_already_called(oh_ticket_svc: OfficeHourTicketService):

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-get-help/office-hours-get-help.component.css
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-get-help/office-hours-get-help.component.css
@@ -39,3 +39,10 @@ mat-form-field {
 .mat-mdc-card-actions {
     justify-content: end;
 }
+
+.row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+}

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-get-help/office-hours-get-help.component.html
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-get-help/office-hours-get-help.component.html
@@ -40,9 +40,15 @@
       {{ data()!.event_end_time | date: 'shortTime' }}
     </p>
     <div class="queue-text-container">
+      <div class="row">
+        <p class="secondary-color">
+          <span class="bold-text">Your ticket has been called by: </span>
+        </p>
+        <user-chip-list [users]="[data()!.ticket!.caller!]" [clickable]="false" />
+      </div>
       <p class="secondary-color">
-        <span class="bold-text">Your ticket has been called by: </span
-        >{{ data()!.ticket!.caller }}
+        <span class="bold-text">Meeting Location: <span class="font-primary">{{ data()!.event_location }}</span></span><br/>
+        {{ data()!.event_location_description }}
       </p>
     </div>
   </mat-card-header>

--- a/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.css
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.css
@@ -43,3 +43,19 @@ p {
     margin-top: 12px;
     margin-bottom: 12px;
 }
+
+.spacing-divider-bottom {
+    margin-top: 4px;
+    margin-bottom: 12px;
+}
+
+.row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 8px;
+
+    p {
+        margin-bottom: 8px;
+    }
+}

--- a/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.html
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.html
@@ -25,8 +25,11 @@
   @if(expanded()) {
   <mat-card-content>
     <mat-divider class="spacing-divider" />
-    <p><span class="semibold-text">Helping:</span> {{ ticket.creators }}</p>
-    <mat-divider class="spacing-divider" />
+    <div class="row">
+      <p><span class="semibold-text">Helping:</span></p>
+      <user-chip-list [users]="ticket.creators" [clickable]="false" />
+    </div>
+    <mat-divider class="spacing-divider-bottom" />
 
     <!-- <p><span class="semibold-text">Description:</span></p> -->
     <p markdown>{{ ticket.description }}</p>

--- a/frontend/src/app/my-courses/my-courses.model.ts
+++ b/frontend/src/app/my-courses/my-courses.model.ts
@@ -119,8 +119,8 @@ export interface OfficeHourTicketOverviewJson {
   state: string;
   type: number;
   description: string;
-  creators: string[];
-  caller: string | undefined;
+  creators: PublicProfile[];
+  caller: PublicProfile | undefined;
 }
 
 export interface OfficeHourTicketOverview {
@@ -130,8 +130,8 @@ export interface OfficeHourTicketOverview {
   state: string;
   type: number;
   description: string;
-  creators: string[];
-  caller: string | undefined;
+  creators: PublicProfile[];
+  caller: PublicProfile | undefined;
 }
 
 export interface OfficeHourQueueOverviewJson {
@@ -163,6 +163,8 @@ export interface OfficeHourGetHelpOverviewJson {
   event_mode: string;
   event_start_time: string;
   event_end_time: string;
+  event_location: string;
+  event_location_description: string;
   ticket: OfficeHourTicketOverviewJson | undefined;
   queue_position: number;
 }
@@ -172,6 +174,8 @@ export interface OfficeHourGetHelpOverview {
   event_mode: string;
   event_start_time: Date;
   event_end_time: Date;
+  event_location: string;
+  event_location_description: string;
   ticket: OfficeHourTicketOverview | undefined;
   queue_position: number;
 }

--- a/frontend/src/app/shared/user-chip-list/user-chip-list.widget.html
+++ b/frontend/src/app/shared/user-chip-list/user-chip-list.widget.html
@@ -33,7 +33,7 @@
   </mat-chip-row>
   } } @else {
   <div class="no-hover-chipset">
-    <mat-chip-row class="user-chip" *ngFor="let user of users" disableRipple>
+    <mat-chip class="user-chip" *ngFor="let user of users" disableRipple>
       <img
         class="user-image"
         *ngIf="user.github_avatar"
@@ -48,7 +48,7 @@
       <ng-template #disableMailTo>
         {{ user.first_name + ' ' + user.last_name }}
       </ng-template>
-    </mat-chip-row>
+    </mat-chip>
   </div>
   }
 </div>


### PR DESCRIPTION
This small PR adds profile images on the office hour ticket cards so that students can have a visual aid to find their TA, and TAs can have a visual aid to find their students.

In addition, the room location and location description now show for students whose tickets have been called.