### PR TITLE
Office Hours Queue Redesign and Bug Fixes

### DIFF
--- a/backend/models/academics/my_courses.py
+++ b/backend/models/academics/my_courses.py
@@ -96,6 +96,10 @@ class OfficeHourQueueOverview(BaseModel):
     active: OfficeHourTicketOverview | None
     other_called: list[OfficeHourTicketOverview]
     queue: list[OfficeHourTicketOverview]
+    personal_tickets_called: int
+    average_minutes: int
+    total_tickets_called: int
+    history: list[OfficeHourTicketOverview]
 
 
 class OfficeHourEventRoleOverview(BaseModel):

--- a/backend/services/office_hours/office_hours.py
+++ b/backend/services/office_hours/office_hours.py
@@ -2,6 +2,7 @@
 Service for office hour events.
 """
 
+import math
 from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
@@ -198,6 +199,21 @@ class OfficeHoursService:
             and ticket.caller
             and ticket.caller.user_id != user.id
         ]
+        completed_tickets = [
+            ticket for ticket in oh_event.tickets if ticket.state == TicketState.CLOSED
+        ]
+        personal_completed_tickets = [
+            ticket for ticket in completed_tickets if ticket.caller.user_id == user.id
+        ]
+        personal_minutes = [
+            (ticket.closed_at - ticket.called_at).total_seconds() / 60.0
+            for ticket in personal_completed_tickets
+        ]
+        personal_average_minutes = (
+            math.floor(sum(personal_minutes) / len(personal_minutes))
+            if len(personal_minutes) > 0
+            else 0
+        )
         queued_tickets = [
             ticket for ticket in oh_event.tickets if ticket.state == TicketState.QUEUED
         ]
@@ -215,6 +231,12 @@ class OfficeHoursService:
                 self._to_oh_ticket_overview(ticket) for ticket in called_tickets
             ],
             queue=[self._to_oh_ticket_overview(ticket) for ticket in queued_tickets],
+            personal_tickets_called=len(personal_completed_tickets),
+            average_minutes=personal_average_minutes,
+            total_tickets_called=len(completed_tickets),
+            history=[
+                self._to_oh_ticket_overview(ticket) for ticket in completed_tickets
+            ],
         )
 
     def get_oh_event_role(

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-queue/office-hours-queue.component.css
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-queue/office-hours-queue.component.css
@@ -70,6 +70,11 @@
     border-color: transparent !important;
 }
 
+.facts-pane-content {
+    overflow-y: auto;
+    height: 100%;
+}
+
 .mdc-list-item--with-leading-icon .mdc-list-item__start {
     font-size: 24px;
     background: #4786c6;
@@ -97,11 +102,12 @@ strong {
 
 .history-card {
     margin: 0 !important;
+    margin-bottom: 12px !important;
 }
 
 @media only screen and (max-width: 1000px) {
     .container {
-        flex-direction: column-reverse;
+        flex-direction: column;
     }
 
     .left-column {

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-queue/office-hours-queue.component.css
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-queue/office-hours-queue.component.css
@@ -20,3 +20,114 @@
     height: 24px;
     margin-top: 0px;
 }
+
+.container {
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+  }
+
+
+.left-column {
+    display: flex;
+    flex-direction: column;
+    width: 70%;
+    height: 85vh;
+}
+
+.right-column {
+    display: flex;
+    flex-direction: column;
+    width: 30%;
+    height: 85vh;
+    padding-right: 16px;
+}
+
+.queue-pane {
+    flex: 1 1 auto; /* Only take up needed space */
+  
+    /* This CSS is absolute wizardry, which allows the pane to not
+      overflow on the bottom while also enabling scrolling... */
+    min-height: 0;
+    max-height: 100%;
+    max-width: 100%;
+    border-color: transparent !important;
+  }
+
+.ta-facts-pane {
+    max-width: 100%;
+    border-color: transparent !important;
+}
+
+.facts-pane {
+    flex: 1 1 auto; /* Only take up needed space */
+
+    /* This CSS is absolute wizardry, which allows the pane to not
+        overflow on the bottom while also enabling scrolling... */
+    min-height: 0;
+    max-height: 100%;
+    max-width: 100%;
+    border-color: transparent !important;
+}
+
+.mdc-list-item--with-leading-icon .mdc-list-item__start {
+    font-size: 24px;
+    background: #4786c6;
+    width: 36px;
+    height: 36px;
+    text-align: center;
+    margin-top: auto;
+    margin-bottom: auto;
+    margin-left: 8px;
+    margin-right: 8px;
+    padding-bottom: 0;
+    line-height: 36px;
+    border-radius: 100%;
+    color: white;
+  }
+
+.pane-subtitle {
+    margin-top: 16px;
+    margin-bottom: 12px;
+}
+
+strong {
+    font-weight: 500 !important;
+}
+
+.history-card {
+    margin: 0 !important;
+}
+
+@media only screen and (max-width: 1000px) {
+    .container {
+        flex-direction: column-reverse;
+    }
+
+    .left-column {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        height: auto;
+    }
+
+    .right-column {
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        height: auto;
+    }
+
+    .queue-pane {
+        flex: auto;
+
+        ::ng-deep .mat-mdc-card-outlined {
+            height: auto !important;
+        }
+
+        .mat-mdc-card-content {
+            height: auto !important;
+            overflow-y: auto !important;
+        }
+    }
+}

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-queue/office-hours-queue.component.html
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-queue/office-hours-queue.component.html
@@ -1,40 +1,88 @@
 @if (queue()) {
-<mat-pane>
-  <mat-card-header class="pane-header">
-    <mat-card-title>{{ queue()!.type }} Event</mat-card-title>
-    <p>
-      {{ queue()!.start_time | date: 'shortTime' }} -
-      {{ queue()!.end_time | date: 'shortTime' }}
-    </p>
-    <mat-chip-set>
-      <mat-chip>{{ queue()!.queue.length }} waiting</mat-chip>
-    </mat-chip-set>
-    <mat-divider id="pane-divider" />
-  </mat-card-header>
-  <mat-card-content class="pane-content">
-    <mat-card-subtitle>Called Tickets</mat-card-subtitle>
-    @if (!queue()!.active && queue()!.other_called.length === 0) {
-    <p>Nobody is being helped right now.</p>
-    } @if(queue()!.active) {
-    <called-ticket-card
-      [ticket]="queue()!.active!"
-      [calledByUser]="true"
-      (closeButtonPressed)="closeTicket($event)" />
-    } @for(ticket of queue()!.other_called; track ticket.id) {
-    <called-ticket-card
-      [ticket]="ticket"
-      (closeButtonPressed)="closeTicket($event)" />
-    }
-    <mat-card-subtitle>Queue</mat-card-subtitle>
-    @if (queue()!.queue.length === 0) {
-    <p>There are no tickets in the queue.</p>
-    } @for(ticket of queue()!.queue; track ticket.id) {
-    <queued-ticket-card
-      [ticket]="ticket"
-      [disableCallTicketButton]="queue()!.active !== undefined"
-      (callButtonPressed)="callTicket($event)"
-      (cancelButtonPressed)="cancelTicket($event)" />
-    }
-  </mat-card-content>
-</mat-pane>
+  <div class="container">
+    <div class="left-column">
+      <mat-card appearance="outlined" class="queue-pane">
+        <mat-card-header class="pane-header">
+          <mat-card-title>{{ queue()!.type }} Event</mat-card-title>
+          <p>
+            {{ queue()!.start_time | date: 'shortTime' }} -
+            {{ queue()!.end_time | date: 'shortTime' }}
+          </p>
+          <mat-chip-set>
+            <mat-chip>{{ queue()!.queue.length }} waiting</mat-chip>
+          </mat-chip-set>
+          <mat-divider id="pane-divider" />
+        </mat-card-header>
+        <mat-card-content class="pane-content">
+          <mat-card-subtitle>Called Tickets</mat-card-subtitle>
+          @if (!queue()!.active && queue()!.other_called.length === 0) {
+          <p>Nobody is being helped right now.</p>
+          } @if(queue()!.active) {
+          <called-ticket-card
+            [ticket]="queue()!.active!"
+            [calledByUser]="true"
+            (closeButtonPressed)="closeTicket($event)" />
+          } @for(ticket of queue()!.other_called; track ticket.id) {
+          <called-ticket-card
+            [ticket]="ticket"
+            (closeButtonPressed)="closeTicket($event)" />
+          }
+          <mat-card-subtitle>Queue</mat-card-subtitle>
+          @if (queue()!.queue.length === 0) {
+          <p>There are no tickets in the queue.</p>
+          } @for(ticket of queue()!.queue; track ticket.id) {
+          <queued-ticket-card
+            [ticket]="ticket"
+            [disableCallTicketButton]="queue()!.active !== undefined"
+            (callButtonPressed)="callTicket($event)"
+            (cancelButtonPressed)="cancelTicket($event)" />
+          }
+        </mat-card-content>
+      </mat-card>
+    </div>
+    <div class="right-column">
+      <mat-card appearance="outlined" class="ta-facts-pane">
+        <mat-card-header class="pane-header">
+          <mat-card-title>Your Facts</mat-card-title>
+          <mat-divider id="pane-divider" />
+        </mat-card-header>
+        <mat-card-content class="pane-content">
+          <p><strong>Number of Tickets: </strong>{{ queue()!.personal_tickets_called }}</p>
+          <p><strong>Average Time per Ticket: </strong>{{ queue()!.average_minutes }} min</p>
+        </mat-card-content>
+      </mat-card>
+      <mat-card appearance="outlined" class="facts-pane">
+        <mat-card-header class="pane-header">
+          <mat-card-title>Office Hours Data</mat-card-title>
+          <mat-divider id="pane-divider" />
+        </mat-card-header>
+        <mat-card-content class="pane-content">
+          <mat-action-list>
+            <mat-list-item>
+              <span matListItemTitle>ticket{{ queue()!.total_tickets_called !== 1 ? "s" : "" }} called since opening!</span>
+              <span matListItemIcon class="primary-background">
+                {{ queue()!.total_tickets_called }}
+              </span>
+            </mat-list-item>
+          </mat-action-list>
+          <mat-divider id="pane-divider" />
+          <mat-card-subtitle class="pane-subtitle">History</mat-card-subtitle>
+          @for(ticket of queue()!.history; track ticket.id) {
+            <mat-card appearance="outlined" class="history-card">
+              <mat-card-header>
+                <mat-card-subtitle>{{ ticket.type }}</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <div>
+                  <p>Opened by <strong>{{ ticket.creators[0].first_name }} {{ ticket.creators[0].last_name }}</strong> and called by <strong>{{ ticket.caller!.first_name }} {{ ticket.caller!.last_name }}</strong> at <strong>{{ ticket.called_at | date: 'shortTime' }}</strong></p>
+                </div>
+              </mat-card-content>
+            </mat-card>
+          } @empty {
+            <p>No tickets called yet.</p>
+          }
+        </mat-card-content>
+      </mat-card>
+    </div>
+  </div>
 }

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-queue/office-hours-queue.component.html
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-queue/office-hours-queue.component.html
@@ -56,7 +56,7 @@
           <mat-card-title>Office Hours Data</mat-card-title>
           <mat-divider id="pane-divider" />
         </mat-card-header>
-        <mat-card-content class="pane-content">
+        <mat-card-content class="pane-content facts-pane-content">
           <mat-action-list>
             <mat-list-item>
               <span matListItemTitle>ticket{{ queue()!.total_tickets_called !== 1 ? "s" : "" }} called since opening!</span>

--- a/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.html
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.html
@@ -9,7 +9,7 @@
       </p>
       } @else {
       <p>
-        Called by <span class="semibold-text">{{ ticket.caller }}</span> at
+        Called by <span class="semibold-text">{{ ticket.caller!.first_name }} {{ ticket.caller!.last_name }}</span> at
         {{ ticket.called_at | date: 'shortTime' }}
       </p>
       }

--- a/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.html
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/called-ticket-card/called-ticket-card.widget.html
@@ -1,7 +1,7 @@
 <mat-card appearance="outlined">
   <mat-card-header>
     <div class="column-view">
-      <mat-card-subtitle>Ticket - {{ ticket.type }}</mat-card-subtitle>
+      <mat-card-subtitle>{{ ticket.type }}</mat-card-subtitle>
       @if (calledByUser) {
       <p>
         <span class="semibold-text">You</span> called this ticket at

--- a/frontend/src/app/my-courses/course/office-hours/widgets/queued-ticket-card/queued-ticket-card.widget.html
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/queued-ticket-card/queued-ticket-card.widget.html
@@ -1,7 +1,7 @@
 <mat-card appearance="outlined">
   <mat-card-header>
     <div class="column-view">
-      <mat-card-subtitle>Ticket - {{ ticket.type }}</mat-card-subtitle>
+      <mat-card-subtitle>{{ ticket.type }}</mat-card-subtitle>
       <p>Created at {{ ticket.created_at | date: 'shortTime' }}</p>
     </div>
   </mat-card-header>

--- a/frontend/src/app/my-courses/my-courses.model.ts
+++ b/frontend/src/app/my-courses/my-courses.model.ts
@@ -142,6 +142,10 @@ export interface OfficeHourQueueOverviewJson {
   active: OfficeHourTicketOverviewJson | undefined;
   other_called: OfficeHourTicketOverviewJson[];
   queue: OfficeHourTicketOverviewJson[];
+  personal_tickets_called: number;
+  average_minutes: number;
+  total_tickets_called: number;
+  history: OfficeHourTicketOverviewJson[];
 }
 
 export interface OfficeHourQueueOverview {
@@ -152,6 +156,10 @@ export interface OfficeHourQueueOverview {
   active: OfficeHourTicketOverview | undefined;
   other_called: OfficeHourTicketOverview[];
   queue: OfficeHourTicketOverview[];
+  personal_tickets_called: number;
+  average_minutes: number;
+  total_tickets_called: number;
+  history: OfficeHourTicketOverview[];
 }
 
 export interface OfficeHourEventRoleOverview {
@@ -326,7 +334,8 @@ export const parseOfficeHourQueueOverview = (
     other_called: responseModel.other_called.map(
       parseOfficeHourTicketOverviewJson
     ),
-    queue: responseModel.queue.map(parseOfficeHourTicketOverviewJson)
+    queue: responseModel.queue.map(parseOfficeHourTicketOverviewJson),
+    history: responseModel.history.map(parseOfficeHourTicketOverviewJson)
   });
 };
 

--- a/frontend/src/app/my-courses/my-courses.module.ts
+++ b/frontend/src/app/my-courses/my-courses.module.ts
@@ -46,6 +46,7 @@ import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { SettingsComponent } from './course/settings/settings.component';
 import { ImportRosterDialog } from './dialogs/import-roster/import-roster.dialog';
 import { OfficeHoursEditorComponent } from './course/office-hours/office-hours-editor/office-hours-editor.component';
+import { MatListModule } from '@angular/material/list';
 
 @NgModule({
   declarations: [
@@ -87,7 +88,8 @@ import { OfficeHoursEditorComponent } from './course/office-hours/office-hours-e
     MatButtonToggleModule,
     MatChipsModule,
     MatInputModule,
-    MatAutocompleteModule
+    MatAutocompleteModule,
+    MatListModule
   ]
 })
 export class MyCoursesModule {}


### PR DESCRIPTION
This pull request redesigns the office hour queue for TAs. The new page is full-width and displays TA facts and office hour event history. This page is also responsive, showing the queue first, then the facts below.

This PR also fixes the bug found by Will and Chloe relating to `[Object object]` showing up on called tickets.

### Screenshot

<img width="1961" alt="Screenshot 2024-08-27 at 9 58 07 PM" src="https://github.com/user-attachments/assets/5c87b627-91c8-497f-bf02-d8646fc07edc">
