### PR TITLE
Fix External Registration Capacity Issue

### DIFF
--- a/frontend/src/app/event/event-editor/event-editor.component.ts
+++ b/frontend/src/app/event/event-editor/event-editor.component.ts
@@ -135,7 +135,10 @@ export class EventEditorComponent {
       eventToSubmit.id = id !== 'new' ? id : null;
       eventToSubmit.organization_slug = this.route.snapshot.params['orgid'];
       eventToSubmit.organizers = this.organizers;
-      if (this.eventForm.get('has_limit')?.value === false) {
+      if (
+        this.eventForm.get('has_limit')?.value === false ||
+        this.eventForm.get('internal_registration')?.value === false
+      ) {
         eventToSubmit.registration_limit = 999;
       }
       let submittedEvent = this.isNew()


### PR DESCRIPTION
This small pull request fixes the capacity issue for external registrations, where creating an external registration set the event's capacity to 0, causing the frontend to say the event was filled.