### PR TITLE
Disable SQL Query logging in production

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -19,7 +19,12 @@ def _engine_str(database: str = getenv("POSTGRES_DATABASE")) -> str:
     return f"{dialect}://{user}:{password}@{host}:{port}/{database}"
 
 
-engine = sqlalchemy.create_engine(_engine_str(), echo=True)
+def _in_production() -> bool:
+    """Helper function for reading settings from environment variables to determine verbosity of SQL output."""
+    return getenv("MODE") == "production"
+
+
+engine = sqlalchemy.create_engine(_engine_str(), echo=not _in_production())
 """Application-level SQLAlchemy database engine."""
 
 


### PR DESCRIPTION
This PR disables query logging in production. Thanks to new use cases, were overflowing ITS CloudApps logs :)

Verified by changing the `env` variable `MODE` to `production` and seeing logs stop, `development` and logs returned.