### PR TITLE
Show Room Capacity and Type on the Room Reservation Page

### DIFF
--- a/backend/models/coworking/reservation.py
+++ b/backend/models/coworking/reservation.py
@@ -46,6 +46,7 @@ class Reservation(ReservationIdentity, TimeRange):
 
 class ReservationMapDetails(BaseModel):
     reserved_date_map: dict[str, list[int]] = {}
+    capacity_map: dict[str, int] = {}
     operating_hours_start: datetime | None = None
     operating_hours_end: datetime | None = None
     number_of_time_slots: int | None = None

--- a/backend/models/coworking/reservation.py
+++ b/backend/models/coworking/reservation.py
@@ -47,6 +47,7 @@ class Reservation(ReservationIdentity, TimeRange):
 class ReservationMapDetails(BaseModel):
     reserved_date_map: dict[str, list[int]] = {}
     capacity_map: dict[str, int] = {}
+    room_type_map: dict[str, str] = {}
     operating_hours_start: datetime | None = None
     operating_hours_end: datetime | None = None
     number_of_time_slots: int | None = None

--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -269,6 +269,7 @@ class ReservationService:
         """
         reserved_date_map: dict[str, list[int]] = {}
         capacity_map: dict[str, int] = {}
+        room_type_map: dict[str, str] = {}
 
         # Query DB to get reservable rooms.
         rooms = self._get_reservable_rooms()
@@ -289,9 +290,11 @@ class ReservationService:
                 if room.id:
                     reserved_date_map[room.id] = [RoomState.UNAVAILABLE.value] * 16
                     capacity_map[room.id] = room.capacity
+                    room_type_map[room.id] = "Pairing Room" if room.capacity == 2 else "Small Group" if room.capacity < 6 else "Large Group"
             return ReservationMapDetails(
                 reserved_date_map=reserved_date_map,
                 capacity_map=capacity_map,
+                room_type_map=room_type_map,
                 operating_hours_start=datetime.now().replace(hour=10, minute=0),
                 operating_hours_end=datetime.now().replace(hour=18, minute=0),
                 number_of_time_slots=16,
@@ -357,6 +360,7 @@ class ReservationService:
                             time_slots_for_room[idx] = RoomState.RESERVED.value
             reserved_date_map[room.id] = time_slots_for_room
             capacity_map[room.id] = room.capacity
+            room_type_map[room.id] = "Pairing Room" if room.capacity == 2 else "Small Group" if room.capacity < 6 else "Large Group"
 
 
         self._transform_date_map_for_unavailable(reserved_date_map)
@@ -369,6 +373,7 @@ class ReservationService:
         return ReservationMapDetails(
             reserved_date_map=reserved_date_map,
             capacity_map=capacity_map,
+            room_type_map=room_type_map,
             operating_hours_start=operating_hours_start,
             operating_hours_end=operating_hours_end,
             number_of_time_slots=operating_hours_duration,

--- a/backend/services/coworking/reservation.py
+++ b/backend/services/coworking/reservation.py
@@ -268,6 +268,7 @@ class ReservationService:
             the implementation. Future reservations are shown up to the current time.
         """
         reserved_date_map: dict[str, list[int]] = {}
+        capacity_map: dict[str, int] = {}
 
         # Query DB to get reservable rooms.
         rooms = self._get_reservable_rooms()
@@ -287,8 +288,10 @@ class ReservationService:
             for room in rooms:
                 if room.id:
                     reserved_date_map[room.id] = [RoomState.UNAVAILABLE.value] * 16
+                    capacity_map[room.id] = room.capacity
             return ReservationMapDetails(
                 reserved_date_map=reserved_date_map,
+                capacity_map=capacity_map,
                 operating_hours_start=datetime.now().replace(hour=10, minute=0),
                 operating_hours_end=datetime.now().replace(hour=18, minute=0),
                 number_of_time_slots=16,
@@ -353,6 +356,8 @@ class ReservationService:
                         if time_slots_for_room[idx] != RoomState.SUBJECT_RESERVED.value:
                             time_slots_for_room[idx] = RoomState.RESERVED.value
             reserved_date_map[room.id] = time_slots_for_room
+            capacity_map[room.id] = room.capacity
+
 
         self._transform_date_map_for_unavailable(reserved_date_map)
         if "SN156" in reserved_date_map:
@@ -363,6 +368,7 @@ class ReservationService:
 
         return ReservationMapDetails(
             reserved_date_map=reserved_date_map,
+            capacity_map=capacity_map,
             operating_hours_start=operating_hours_start,
             operating_hours_end=operating_hours_end,
             number_of_time_slots=operating_hours_duration,

--- a/frontend/src/app/coworking/coworking.models.ts
+++ b/frontend/src/app/coworking/coworking.models.ts
@@ -173,7 +173,6 @@ export interface TablePropertyMap {
 }
 
 export interface ReservationMapDetails {
-  // TODO: add information to contain capacity details
   reserved_date_map: Record<string, number[]>;
   capacity_map: Record<string, number>;
   operating_hours_start: string;

--- a/frontend/src/app/coworking/coworking.models.ts
+++ b/frontend/src/app/coworking/coworking.models.ts
@@ -175,7 +175,7 @@ export interface TablePropertyMap {
 export interface ReservationMapDetails {
   reserved_date_map: Record<string, number[]>;
   capacity_map: Record<string, number>;
-  room_type_map: Record<string, string>
+  room_type_map: Record<string, string>;
   operating_hours_start: string;
   operating_hours_end: string;
   number_of_time_slots: number;

--- a/frontend/src/app/coworking/coworking.models.ts
+++ b/frontend/src/app/coworking/coworking.models.ts
@@ -175,6 +175,7 @@ export interface TablePropertyMap {
 export interface ReservationMapDetails {
   reserved_date_map: Record<string, number[]>;
   capacity_map: Record<string, number>;
+  room_type_map: Record<string, string>
   operating_hours_start: string;
   operating_hours_end: string;
   number_of_time_slots: number;

--- a/frontend/src/app/coworking/coworking.models.ts
+++ b/frontend/src/app/coworking/coworking.models.ts
@@ -173,7 +173,9 @@ export interface TablePropertyMap {
 }
 
 export interface ReservationMapDetails {
+  // TODO: add information to contain capacity details
   reserved_date_map: Record<string, number[]>;
+  capacity_map: Record<string, number>;
   operating_hours_start: string;
   operating_hours_end: string;
   number_of_time_slots: number;

--- a/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.css
+++ b/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.css
@@ -44,3 +44,8 @@ td {
 .divider {
   margin-bottom: 1em;
 }
+
+.room-details {
+  font-size: smaller;
+  font-weight: lighter;
+}

--- a/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.html
+++ b/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.html
@@ -10,8 +10,8 @@
       @for (record of reservationsMap | keyvalue; track record.key) {
       <tr>
         <th>{{ record.key }}
-          <br><span class= "room-details"> {{"# seats: "}}{{ capacityMap[record.key]}}
-          <br>{{ capacityMap[record.key] === 2 ? "Pairing Room" : capacityMap[record.key] < 6 ? "Small Group" : "Large Group"}}</span>
+          <br><span class= "room-details"> {{"# seats: "}}{{capacityMap[record.key]}}
+          <br>{{roomTypeMap[record.key]}}</span>
         </th>
         <td
           *ngFor="let timeSlot of record.value; let j = index"

--- a/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.html
+++ b/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.html
@@ -9,7 +9,7 @@
       </tr>
       @for (record of reservationsMap | keyvalue; track record.key) {
       <tr>
-        <th>{{ record.key }}</th>
+        <th>{{ record.key }}<br>{{"Capacity: "}}{{capacityMap[record.key]}} </th>
         <td
           *ngFor="let timeSlot of record.value; let j = index"
           [style.background]="cellPropertyMap[timeSlot].backgroundColor"

--- a/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.html
+++ b/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.html
@@ -9,7 +9,10 @@
       </tr>
       @for (record of reservationsMap | keyvalue; track record.key) {
       <tr>
-        <th>{{ record.key }}<br>{{"Capacity: "}}{{capacityMap[record.key]}} </th>
+        <th>{{ record.key }}
+          <br>{{"Capacity: "}}{{ capacityMap[record.key]}}
+          <br>{{"Room Type: "}}{{ capacityMap[record.key] === 2 ? "Pairing Room" : capacityMap[record.key] < 6 ? "Small Group" : "Large Group"}}
+        </th>
         <td
           *ngFor="let timeSlot of record.value; let j = index"
           [style.background]="cellPropertyMap[timeSlot].backgroundColor"

--- a/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.html
+++ b/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.html
@@ -10,8 +10,8 @@
       @for (record of reservationsMap | keyvalue; track record.key) {
       <tr>
         <th>{{ record.key }}
-          <br>{{"Capacity: "}}{{ capacityMap[record.key]}}
-          <br>{{"Room Type: "}}{{ capacityMap[record.key] === 2 ? "Pairing Room" : capacityMap[record.key] < 6 ? "Small Group" : "Large Group"}}
+          <br><span class= "room-details"> {{"# seats: "}}{{ capacityMap[record.key]}}
+          <br>{{ capacityMap[record.key] === 2 ? "Pairing Room" : capacityMap[record.key] < 6 ? "Small Group" : "Large Group"}}</span>
         </th>
         <td
           *ngFor="let timeSlot of record.value; let j = index"

--- a/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.ts
+++ b/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.ts
@@ -26,6 +26,9 @@ export class RoomReservationWidgetComponent {
   //- Capcity Map
   capacityMap: Record<string, number> = {};
 
+  //- Room Type Map
+  roomTypeMap: Record<string, string> = {};
+
   //- Select Button enabled
   selectButton: boolean = false;
 
@@ -64,6 +67,7 @@ export class RoomReservationWidgetComponent {
       (result) => {
         this.reservationsMap = result.reserved_date_map;
         this.capacityMap = result.capacity_map;
+        this.roomTypeMap = result.room_type_map;
         let end = new Date(result.operating_hours_end);
         this.operationStart = new Date(result.operating_hours_start);
         let slots = result.number_of_time_slots;

--- a/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.ts
+++ b/frontend/src/app/coworking/widgets/room-reservation-table/room-reservation-table.widget.ts
@@ -23,6 +23,9 @@ export class RoomReservationWidgetComponent {
   //- Reservations Map
   reservationsMap: Record<string, number[]> = {};
 
+  //- Capcity Map
+  capacityMap: Record<string, number> = {};
+
   //- Select Button enabled
   selectButton: boolean = false;
 
@@ -60,6 +63,7 @@ export class RoomReservationWidgetComponent {
     this.reservationTableService.getReservationsForRoomsByDate(date).subscribe(
       (result) => {
         this.reservationsMap = result.reserved_date_map;
+        this.capacityMap = result.capacity_map;
         let end = new Date(result.operating_hours_end);
         this.operationStart = new Date(result.operating_hours_start);
         let slots = result.number_of_time_slots;


### PR DESCRIPTION
- Added the ability to view the capacity and room type when making a room reservation. Currently, rooms are categorized as "Pairing Rooms" (capacity = 2), "Small Group" (2 < capacity < 6), and "Large Group" (capacity > 6). 
- The formatting of the capacity and room type on the room reservation table can be changed in the future to better meet design requirements. 

**Screenshot:**

<img width="1074" alt="Screenshot 2024-09-16 at 1 48 21 PM" src="https://github.com/user-attachments/assets/85acfa41-7e32-4924-8844-dbb0b05d63e5">
