### PR TITLE
Change 'red' color to match M3 styling

### DIFF
--- a/frontend/src/app/coworking/room-reservation/new-reservation-page/new-reservation-page.component.html
+++ b/frontend/src/app/coworking/room-reservation/new-reservation-page/new-reservation-page.component.html
@@ -1,10 +1,3 @@
-<banner-card
-  type="info"
-  [wide]="true"
-  icon="construction"
-  title="Page Under Construction"
-  body="This page's styling has not yet been updated to conform to Material 3." />
-
 <mat-pane>
   <mat-card-header>
     <mat-card-title>Reserve a Room</mat-card-title>

--- a/frontend/src/app/coworking/room-reservation/new-reservation-page/new-reservation-page.component.html
+++ b/frontend/src/app/coworking/room-reservation/new-reservation-page/new-reservation-page.component.html
@@ -26,7 +26,7 @@
         <span class="legend-text">Available</span>
       </div>
       <div class="legend-item">
-        <div class="legend-color" style="background-color: red"></div>
+        <div class="legend-color" style="background-color: #B3261E"></div>
         <span class="legend-text">Reserved</span>
       </div>
       <div class="legend-item">

--- a/frontend/src/app/coworking/room-reservation/reservation-table.service.ts
+++ b/frontend/src/app/coworking/room-reservation/reservation-table.service.ts
@@ -46,7 +46,7 @@ export class ReservationTableService {
       isDisabled: false
     },
     [ReservationTableService.CellEnum.BOOKED]: {
-      backgroundColor: 'red',
+      backgroundColor: '#B3261E',
       isDisabled: true
     },
     [ReservationTableService.CellEnum.RESERVING]: {


### PR DESCRIPTION
In this PR, I switch the red shade from the default 'red' color to the M3 error40 shade (hex code: #B3261E) for the Room Reservation Table.
<img width="1428" alt="Screenshot 2024-10-06 at 5 20 17 PM" src="https://github.com/user-attachments/assets/27c1da6c-4fd9-4609-84a8-a5c864e8ba36">
The above image depicts the new shade of red implemented in this PR for both the legend and the cells in the room reservation cell property map.