### PR TITLE
Fix Roster Import from Canvas after Grades Added

### DIFF
--- a/backend/services/academics/section_member.py
+++ b/backend/services/academics/section_member.py
@@ -186,7 +186,11 @@ class SectionMemberService:
 
         try:
             for row in reader:
-                if reader.line_num != 2 and row["Student"] != "Student, Test":
+                if (
+                    reader.line_num != 2
+                    and row["Student"] != "Student, Test"
+                    and len(row["Student"]) > 0
+                ):
 
                     # Ensure that the uploaded CSV only contains one section
                     unique_sections.add(row["Section"])

--- a/backend/test/services/academics/section_data.py
+++ b/backend/test/services/academics/section_data.py
@@ -554,3 +554,11 @@ Points Possible,,,,,(read only),(read only),(read only),(read only),(read only),
 "Student, Sally",0,sstudent,COMP301.001.S224,,,,,,,,,,,,,,,,
 "Student, New",0,345345345,nstudent,COMP301.001.S224,,,,,,,,,,,,,,,,
 "Jordan, Kris",0,89898989,kjordan,COMP301.001.S224,,,,,,,,,,,,,,,,"""
+
+extra_row_roster_csv = """Student,ID,SIS User ID,SIS Login ID,Section,Assignments Current Points,Assignments Final Points,Assignments Current Score,Assignments Unposted Current Score,Assignments Final Score,Assignments Unposted Final Score,Current Points,Final Points,Current Score,Unposted Current Score,Final Score,Unposted Final Score,Current Grade,Unposted Current Grade,Final Grade,Unposted Final Grade
+Points Possible,,,,,(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only)
+,,,,,,,,,,,,,,,,,,,
+"Root, Rhonda",0,999999999,rroot,COMP301.001.S224,,,,,,,,,,,,,,,,
+"Student, Sally",0,111111111,sstudent,COMP301.001.S224,,,,,,,,,,,,,,,,
+"Student, New",0,345345345,nstudent,COMP301.001.S224,,,,,,,,,,,,,,,,
+"Jordan, Kris",0,89898989,kjordan,COMP301.001.S224,,,,,,,,,,,,,,,,"""

--- a/backend/test/services/academics/section_member_test.py
+++ b/backend/test/services/academics/section_member_test.py
@@ -82,6 +82,11 @@ def test_create_from_csv_remove(section_member_svc: SectionMemberService):
         section_data.comp_301_001_current_term.id,
         csv_data=section_data.smaller_roster_csv,
     )
+    section_member_svc.import_users_from_csv(
+        user_data.instructor,
+        section_data.comp_301_001_current_term.id,
+        csv_data=section_data.extra_row_roster_csv,
+    )
 
 
 def test_create_from_csv_not_instructor(section_member_svc: SectionMemberService):


### PR DESCRIPTION
This small PR adds an extra check to filter out empty rows in canvas import CSVs as recommended in #624.

*Resolves #624*