### PR TITLE
Do not cache SPA HTML pages in client

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -110,12 +110,12 @@ app.mount("/", static_files.StaticFileMiddleware(directory=Path("./static")))
 
 # Add application-wide exception handling middleware for commonly encountered API Exceptions
 @app.exception_handler(UserPermissionException)
-def permission_exception_handler(request: Request, e: UserPermissionException):
+def user_permission_exception_handler(request: Request, e: UserPermissionException):
     return JSONResponse(status_code=403, content={"message": str(e)})
 
 
 @app.exception_handler(CoursePermissionException)
-def permission_exception_handler(request: Request, e: UserPermissionException):
+def course_permission_exception_handler(request: Request, e: UserPermissionException):
     return JSONResponse(status_code=403, content={"message": str(e)})
 
 
@@ -132,9 +132,7 @@ def reservation_exception_handler(request: Request, e: ReservationException):
 
 
 @app.exception_handler(CourseDataScrapingException)
-def resource_not_found_exception_handler(
-    request: Request, e: CourseDataScrapingException
-):
+def course_data_scraping_exception(request: Request, e: CourseDataScrapingException):
     return JSONResponse(status_code=500, content={"message": str(e)})
 
 


### PR DESCRIPTION
This commit extends the static files middleware so that browsers will not cache the HTML of the SPA. This helps ensure that when new versions are deployed, clients will always get the latest version rather than the cached version. Cached versions tended to be buggy because bundle names of JS files are autogenerated based on hashes of contents.