### PR TITLE
Replace login icon, show "Sign In" text on mobile over icon

### DIFF
--- a/frontend/src/app/navigation/navigation.component.css
+++ b/frontend/src/app/navigation/navigation.component.css
@@ -94,6 +94,18 @@
   display: flex;
   flex-direction: row;
   align-items: center;
+  justify-content: space-between
+}
+
+.toolbar-left {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+#toolbar-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 /* NOTE: This is temporary until the admin pages are refactored. */
@@ -117,12 +129,9 @@ a {
 
 .profile-chip-container {
   display: flex;
-  margin-left: auto;
-  margin-top: auto;
-  margin-bottom: auto;
-  margin-right: 16px;
   align-items: center;
 }
+
 /* Round the border for the profile image chip */
 .mat-mdc-standard-chip {
   --mdc-chip-container-shape-radius: 16px;
@@ -141,7 +150,7 @@ a {
   height: 22px !important;
 }
 
-@media only screen and (max-width: 640px) {
+@media only screen and (max-width: 768px) {
   .desktop-profile-chips {
     display: none;
   }
@@ -163,5 +172,13 @@ a {
     border-radius: 50% !important;
     margin-left: 3px;
     margin-top: 3px;
+  }
+
+  ::ng-deep .mat-mdc-standard-chip .mdc-evolution-chip__graphic {
+    display: none !important;
+  }
+
+  ::ng-deep .mat-mdc-standard-chip .mdc-evolution-chip__text-label:not(:only-child) {
+    padding-left: 12px;
   }
 }

--- a/frontend/src/app/navigation/navigation.component.html
+++ b/frontend/src/app/navigation/navigation.component.html
@@ -121,18 +121,18 @@
   <mat-sidenav-content>
     <mat-toolbar color="primary">
       <div class="toolbar">
-        <button
-          type="button"
-          aria-label="Toggle sidenav"
-          mat-icon-button
-          (click)="drawer.toggle()"
-          *ngIf="isHandset">
+        <div class="toolbar-left">
+          <button
+           type="button"
+           aria-label="Toggle sidenav"
+           mat-icon-button
+           (click)="drawer.toggle()"
+           *ngIf="isHandset">
           <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
-        </button>
-        <span [class]="isHandset ? 'title-medium' : ''">{{ navigationService.title$ | async }}</span>
+          </button>
+          <span id="toolbar-title" [class]="isHandset ? 'title-medium' : ''">{{ navigationService.title$ | async }}</span>
+        </div>
 
-
-        
         <div class="profile-chip-container">
           @if(navigationAdminGearService.adminSettingsData()) {
             <button
@@ -144,7 +144,7 @@
               <mat-icon aria-label="Admin icon" color="secondary">settings</mat-icon>
             </button>
           }
-          
+
             @if(profile$ | async; as profile) {
               <mat-chip-set class="desktop-profile-chips">
               <mat-chip class="profile-chip" routerLink="/profile">
@@ -168,23 +168,13 @@
                 }
               </button>
             } @else {
-              <a class="desktop-profile-chips" href="/auth?continue_to={{ router.url }}">
+              <a class="profile-chip-container" href="/auth?continue_to={{ router.url }}">
                 <mat-chip class="profile-chip">
-                  <mat-icon matChipAvatar>login</mat-icon>
+                  <mat-icon matChipAvatar>account_circle</mat-icon>
                   Sign In
                 </mat-chip>
               </a>
-              <a class="mobile-icon-chips" href="/auth?continue_to={{ router.url }}">
-                <button
-                class="mat-csxl-stroked-icon-button profile-circle-icon"
-                  type="button"
-                  mat-icon-button>
-                  <mat-icon class="login-circle-icon" matChipAvatar>login</mat-icon>
-                </button>   
-              </a>
-                       
             }
-         
         </div>
       </div>
     </mat-toolbar>


### PR DESCRIPTION
# Summary
Replaces the "login" icon with "account_circle" on all devices, and hides the icon on mobile/thin screens (width < 768px). Also includes multiple toolbar changes to account for the width. Resolves #623.

# Details
I felt the "login" icon felt too ambiguous, so I replaced it with "account_circle". Icons like this are seen in other sites and apps as a placeholder for a profile picture when there is none (this site does that as well).
On mobile, only the icon was displayed. However, I felt that an icon by itself did not convey enough--so to completely eliminate ambiguity, the chip reads "Sign In", without the icon, when the user is signed out.
This probably shouldn't cause overflow except on significantly older or smaller devices. To account for this, I modified the toolbar:
- The left side of the toolbar is now wrapped in a div with the class "toolbar-left", which allows me to:
- Use `justify-content: space-between;` on the toolbar, also allowing me to remove the margins on `.profile-class-container`
  - The chip is now flush with the margins of the page
- In the event the screen is not wide enough, the title is clipped with ellipsis.
	- The max-width for the swap between mobile/desktop chips was increased to 768px to reduce cases of the toolbar's title being cut off.

Video (signed out):

https://github.com/user-attachments/assets/3ef25bbf-8d7f-48fb-ad93-dad8533802f3

Video (signed in):

https://github.com/user-attachments/assets/4a2154fc-8dc3-416d-8601-12446cd652c0

Additional comments: 
- Is there a formatter for this project? I would run Prettier, but `navigation.component.html` appears to have Prettier disabled, and I didn't want to mess too much with the file.
- This is my first time working with Angular; please let me know if I did something that goes against the "Angular way"! 😅