### PR TITLE
[Intermediate] Signage API

### DIFF
--- a/backend/api/signage.py
+++ b/backend/api/signage.py
@@ -4,11 +4,9 @@ from fastapi import APIRouter, Depends
 
 from ..api.authentication import registered_user
 
-from ..services.article import ArticleService
+from ..services import SignageService
 
-from ..models import User
-from ..models.articles import WelcomeOverview, ArticleOverview, ArticleDraft
-from ..models.pagination import Paginated, PaginationParams
+from ..models import SignageOverviewFast, SignageOverviewSlow
 
 __authors__ = ["Will Zahrt"]
 __copyright__ = "Copyright 2024"
@@ -22,16 +20,16 @@ openapi_tags = {
 
 
 @api.get("/slow", tags=["Signage"])
-def get_welcome_status(
-    subject: User = Depends(registered_user), article_svc: ArticleService = Depends()
-) -> WelcomeOverview:
+def get_slow_signage(
+    signage_svc: SignageService = Depends()
+) -> SignageOverviewSlow:
     """Retrieves the welcome status."""
-    return article_svc.get_welcome_overview(subject)
+    return signage_svc.get_slow_data()
 
 
 @api.get("/fast", tags=["Signage"])
-def get_welcome_status(
-    subject: User = Depends(registered_user), article_svc: ArticleService = Depends()
-) -> WelcomeOverview:
+def get_fast_signage(
+    signage_svc: SignageService = Depends()
+) -> SignageOverviewFast:
     """Retrieves the welcome status."""
-    return article_svc.get_welcome_overview(subject)
+    return signage_svc.get_fast_data()

--- a/backend/api/signage.py
+++ b/backend/api/signage.py
@@ -8,7 +8,7 @@ from ..services import SignageService
 
 from ..models import SignageOverviewFast, SignageOverviewSlow
 
-__authors__ = ["Will Zahrt"]
+__authors__ = ["Will Zahrt", "Andrew Lockard"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 

--- a/backend/api/signage.py
+++ b/backend/api/signage.py
@@ -1,14 +1,11 @@
 """Signage API"""
 
 from fastapi import APIRouter, Depends
-
 from ..api.authentication import registered_user
-
 from ..services import SignageService
-
 from ..models import SignageOverviewFast, SignageOverviewSlow
 
-__authors__ = ["Will Zahrt", "Andrew Lockard"]
+__authors__ = ["Will Zahrt", "Andrew Lockard", "Audrey Toney"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
@@ -20,16 +17,12 @@ openapi_tags = {
 
 
 @api.get("/slow", tags=["Signage"])
-def get_slow_signage(
-    signage_svc: SignageService = Depends()
-) -> SignageOverviewSlow:
+def get_slow_signage(signage_svc: SignageService = Depends()) -> SignageOverviewSlow:
     """Retrieves the welcome status."""
     return signage_svc.get_slow_data()
 
 
 @api.get("/fast", tags=["Signage"])
-def get_fast_signage(
-    signage_svc: SignageService = Depends()
-) -> SignageOverviewFast:
+def get_fast_signage(signage_svc: SignageService = Depends()) -> SignageOverviewFast:
     """Retrieves the welcome status."""
     return signage_svc.get_fast_data()

--- a/backend/api/signage.py
+++ b/backend/api/signage.py
@@ -1,0 +1,37 @@
+"""Signage API"""
+
+from fastapi import APIRouter, Depends
+
+from ..api.authentication import registered_user
+
+from ..services.article import ArticleService
+
+from ..models import User
+from ..models.articles import WelcomeOverview, ArticleOverview, ArticleDraft
+from ..models.pagination import Paginated, PaginationParams
+
+__authors__ = ["Will Zahrt"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+api = APIRouter(prefix="/api/signage")
+openapi_tags = {
+    "name": "Signage",
+    "description": "Retrieve signage information.",
+}
+
+
+@api.get("/slow", tags=["Signage"])
+def get_welcome_status(
+    subject: User = Depends(registered_user), article_svc: ArticleService = Depends()
+) -> WelcomeOverview:
+    """Retrieves the welcome status."""
+    return article_svc.get_welcome_overview(subject)
+
+
+@api.get("/fast", tags=["Signage"])
+def get_welcome_status(
+    subject: User = Depends(registered_user), article_svc: ArticleService = Depends()
+) -> WelcomeOverview:
+    """Retrieves the welcome status."""
+    return article_svc.get_welcome_overview(subject)

--- a/backend/api/signage.py
+++ b/backend/api/signage.py
@@ -1,7 +1,6 @@
 """Signage API"""
 
 from fastapi import APIRouter, Depends
-from ..api.authentication import registered_user
 from ..services import SignageService
 from ..models import SignageOverviewFast, SignageOverviewSlow
 
@@ -18,11 +17,25 @@ openapi_tags = {
 
 @api.get("/slow", tags=["Signage"])
 def get_slow_signage(signage_svc: SignageService = Depends()) -> SignageOverviewSlow:
-    """Retrieves the welcome status."""
+    """Gets signage data that does not need to be updated frequently.
+    
+    Parameters:
+        None
+
+    Returns:
+        SignageOverviewSlow - contains news, top users, events, and announcements
+    """
     return signage_svc.get_slow_data()
 
 
 @api.get("/fast", tags=["Signage"])
 def get_fast_signage(signage_svc: SignageService = Depends()) -> SignageOverviewFast:
-    """Retrieves the welcome status."""
+    """Gets signage data that needs to be updated in real time.
+
+    Parameters:
+        None
+    
+    Returns:
+        SignageOverviewFast - contains office hours information for queue time, room and seat availability
+    """
     return signage_svc.get_fast_data()

--- a/backend/entities/office_hours/office_hours_entity.py
+++ b/backend/entities/office_hours/office_hours_entity.py
@@ -4,6 +4,9 @@ from datetime import datetime, date
 from typing import Self
 from sqlalchemy import Date, DateTime, ForeignKey, Integer, String
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from backend.models.academics.my_courses import OfficeHoursOverview
+from backend.models.office_hours.ticket_state import TicketState
 from ...models.office_hours.office_hours import OfficeHours, NewOfficeHours
 from ...models.office_hours.office_hours_details import OfficeHoursDetails
 
@@ -21,6 +24,7 @@ __authors__ = [
     "Sadie Amato",
     "Bailey DeSouza",
     "Meghan Sun",
+    "Andrew Lockard",
 ]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
@@ -154,4 +158,24 @@ class OfficeHoursEntity(EntityBase):
             course_site=self.course_site.to_model(),
             room=self.room.to_model(),
             tickets=[ticket.to_model() for ticket in self.tickets],
+        )
+    
+    def to_overview_model(self) -> OfficeHoursOverview:
+        return OfficeHoursOverview(
+            id=self.id,
+            type=self.type.to_string(),
+            mode=self.mode.to_string(),
+            description=self.description,
+            location=f"{self.room.building} {self.room.room}",
+            location_description=self.location_description,
+            start_time=self.start_time,
+            end_time=self.end_time,
+            queued=len(
+                [
+                    ticket
+                    for ticket in self.tickets
+                    if ticket.state == TicketState.QUEUED
+                ]
+            ),
+            total_tickets=len(self.tickets),
         )

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from .api import (
     room,
     application,
     article,
+    signage,
 )
 from .api.coworking import status, reservation, ambassador, operating_hours
 from .api.academics import section_member, term, course, section, my_courses, hiring
@@ -67,6 +68,7 @@ app = FastAPI(
         hiring.openapi_tags,
         admin_facts.openapi_tags,
         article.openapi_tags,
+        signage.openapi_tags,
     ],
 )
 
@@ -99,6 +101,7 @@ feature_apis = [
     hiring,
     admin_facts,
     article,
+    signage,
 ]
 
 for feature_api in feature_apis:

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -13,6 +13,7 @@ from .event import EventOverview, EventDraft
 from .public_user import PublicUser
 from .room import Room
 from .room_details import RoomDetails
+from .signage import SignageOverviewFast, SignageOverviewSlow
 from .event_registration import (
     EventRegistration,
     NewEventRegistration,

--- a/backend/models/office_hours/__init__.py
+++ b/backend/models/office_hours/__init__.py
@@ -1,0 +1,3 @@
+from .office_hours import OfficeHours, NewOfficeHours, Weekday
+
+__all__ = ["OfficeHours", "NewOfficeHours", "Weekday"]

--- a/backend/models/signage.py
+++ b/backend/models/signage.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from articles import ArticleOverview
+from .articles import ArticleOverview
 from .user import User
 from .coworking import OperatingHours, SeatAvailability
 from .office_hours import OfficeHours

--- a/backend/models/signage.py
+++ b/backend/models/signage.py
@@ -15,8 +15,8 @@ __license__ = "MIT"
 class SignageOverviewSlow(BaseModel):
     """Encapsulates data for the tv."""
 
-    latest_news: list[ArticleOverview]
-    registered_events: list[EventOverview]
+    newest_news: list[ArticleOverview]
+    events: list[EventOverview]
     top_users: list[User]  # May want to make this a PublicUser
     announcements: list[str] | None
 

--- a/backend/models/signage.py
+++ b/backend/models/signage.py
@@ -13,7 +13,7 @@ __license__ = "MIT"
 
 
 class SignageOverviewSlow(BaseModel):
-    """Encapsulates data for the tv."""
+    """Encapsulates less frequent data for the tv."""
 
     newest_news: list[ArticleOverview]
     events: list[EventOverview]
@@ -22,7 +22,7 @@ class SignageOverviewSlow(BaseModel):
 
 
 class SignageOverviewFast(BaseModel):
-    """Encapsulates data for the tv."""
+    """Encapsulates frequent data for the tv."""
 
     active_office_hours: list[OfficeHoursOverview]
     available_rooms: list[str]

--- a/backend/models/signage.py
+++ b/backend/models/signage.py
@@ -1,0 +1,26 @@
+from pydantic import BaseModel
+from articles import ArticleOverview
+from .public_user import PublicUser
+from .coworking import OperatingHours
+from .event import EventOverview
+
+__authors__ = ["Will Zahrt"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+
+class SignageOverviewSlow(BaseModel):
+    """Encapsulates data for the tv."""
+
+    latest_news: list[ArticleOverview]
+    operating_hours: list[OperatingHours]
+    registered_events: list[EventOverview]
+
+
+class SignageOverviewFast(BaseModel):
+    """Encapsulates data for the tv."""
+
+    announcement: ArticleOverview | None
+    latest_news: list[ArticleOverview]
+    operating_hours: list[OperatingHours]
+    registered_events: list[EventOverview]

--- a/backend/models/signage.py
+++ b/backend/models/signage.py
@@ -1,7 +1,8 @@
 from pydantic import BaseModel
 from articles import ArticleOverview
-from .public_user import PublicUser
+from .user import User
 from .coworking import OperatingHours, SeatAvailability
+from .office_hours import OfficeHours
 from .event import EventOverview
 from typing import Sequence
 from .room_details import RoomDetails
@@ -15,14 +16,14 @@ class SignageOverviewSlow(BaseModel):
     """Encapsulates data for the tv."""
 
     latest_news: list[ArticleOverview]
-    # TODO: Need a list of the top ten checkins.
     registered_events: list[EventOverview]
+    top_users: list[User]  # May want to make this a PublicUser
     announcements: list[str] | None
 
 
 class SignageOverviewFast(BaseModel):
     """Encapsulates data for the tv."""
 
-    # TODO: office_hours: list[ArticleOverview]
+    office_hours: list[OfficeHours]
     available_rooms: list[str]
     seat_availability: Sequence[SeatAvailability]

--- a/backend/models/signage.py
+++ b/backend/models/signage.py
@@ -1,8 +1,8 @@
 from pydantic import BaseModel
 from .articles import ArticleOverview
-from .user import User
+from .public_user import PublicUser
 from .coworking import OperatingHours, SeatAvailability
-from .office_hours import OfficeHours
+from .academics.my_courses import OfficeHoursOverview
 from .event import EventOverview
 from typing import Sequence
 from .room_details import RoomDetails
@@ -17,13 +17,13 @@ class SignageOverviewSlow(BaseModel):
 
     newest_news: list[ArticleOverview]
     events: list[EventOverview]
-    top_users: list[User]  # May want to make this a PublicUser
-    announcements: list[str] | None
+    top_users: list[PublicUser]
+    announcements: list[ArticleOverview] | None
 
 
 class SignageOverviewFast(BaseModel):
     """Encapsulates data for the tv."""
 
-    office_hours: list[OfficeHours]
+    active_office_hours: list[OfficeHoursOverview]
     available_rooms: list[str]
     seat_availability: Sequence[SeatAvailability]

--- a/backend/models/signage.py
+++ b/backend/models/signage.py
@@ -18,7 +18,7 @@ class SignageOverviewSlow(BaseModel):
     newest_news: list[ArticleOverview]
     events: list[EventOverview]
     top_users: list[PublicUser]
-    announcements: list[ArticleOverview] | None
+    announcement_titles: list[str] | None
 
 
 class SignageOverviewFast(BaseModel):

--- a/backend/models/signage.py
+++ b/backend/models/signage.py
@@ -15,12 +15,14 @@ class SignageOverviewSlow(BaseModel):
     latest_news: list[ArticleOverview]
     operating_hours: list[OperatingHours]
     registered_events: list[EventOverview]
+    announcement: ArticleOverview | None
+
 
 
 class SignageOverviewFast(BaseModel):
     """Encapsulates data for the tv."""
 
-    announcement: ArticleOverview | None
     latest_news: list[ArticleOverview]
     operating_hours: list[OperatingHours]
     registered_events: list[EventOverview]
+    seat_availability: Sequence[SeatAvailability]

--- a/backend/models/signage.py
+++ b/backend/models/signage.py
@@ -1,10 +1,12 @@
 from pydantic import BaseModel
 from articles import ArticleOverview
 from .public_user import PublicUser
-from .coworking import OperatingHours
+from .coworking import OperatingHours, SeatAvailability
 from .event import EventOverview
+from typing import Sequence
+from .room_details import RoomDetails
 
-__authors__ = ["Will Zahrt"]
+__authors__ = ["Will Zahrt", "Andrew Lockard", "Audrey Toney"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
@@ -13,16 +15,14 @@ class SignageOverviewSlow(BaseModel):
     """Encapsulates data for the tv."""
 
     latest_news: list[ArticleOverview]
-    operating_hours: list[OperatingHours]
+    # TODO: Need a list of the top ten checkins.
     registered_events: list[EventOverview]
-    announcement: ArticleOverview | None
-
+    announcements: list[str] | None
 
 
 class SignageOverviewFast(BaseModel):
     """Encapsulates data for the tv."""
 
-    latest_news: list[ArticleOverview]
-    operating_hours: list[OperatingHours]
-    registered_events: list[EventOverview]
+    # TODO: office_hours: list[ArticleOverview]
+    available_rooms: list[str]
     seat_availability: Sequence[SeatAvailability]

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -8,3 +8,4 @@ from .exceptions import ResourceNotFoundException, UserPermissionException
 from .room import RoomService
 from .article import ArticleService
 from .application import ApplicationService
+from .signage import SignageService

--- a/backend/services/academics/course_site.py
+++ b/backend/services/academics/course_site.py
@@ -33,7 +33,7 @@ from ...entities.user_entity import UserEntity
 from ...entities.academics.section_member_entity import SectionMemberEntity
 from ..exceptions import CoursePermissionException, ResourceNotFoundException
 
-__authors__ = ["Ajay Gandecha", "Kris Jordan"]
+__authors__ = ["Ajay Gandecha", "Kris Jordan", "Andrew Lockard"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
@@ -283,9 +283,7 @@ class CourseSiteService:
         # Load office hours data
         office_hour_event_entities = self._session.scalars(event_query).unique().all()
 
-        return [
-            self._to_oh_event_overview(event) for event in office_hour_event_entities
-        ]
+        return [event.to_overview_model() for event in office_hour_event_entities]
 
     def get_future_office_hour_events(
         self,
@@ -326,10 +324,7 @@ class CourseSiteService:
 
         # Create paginated representation of data and return
         return Paginated(
-            items=[
-                self._to_oh_event_overview(event)
-                for event in office_hour_event_entities
-            ],
+            items=[event.to_overview_model() for event in office_hour_event_entities],
             length=length,
             params=pagination_params,
         )
@@ -373,10 +368,7 @@ class CourseSiteService:
 
         # Create paginated representation of data and return
         return Paginated(
-            items=[
-                self._to_oh_event_overview(event)
-                for event in office_hour_event_entities
-            ],
+            items=[event.to_overview_model() for event in office_hour_event_entities],
             length=length,
             params=pagination_params,
         )
@@ -418,26 +410,6 @@ class CourseSiteService:
         event_query = event_query.where(SectionEntity.id.in_(section_ids))
 
         return event_query
-
-    def _to_oh_event_overview(self, oh_event: OfficeHoursEntity) -> OfficeHoursOverview:
-        return OfficeHoursOverview(
-            id=oh_event.id,
-            type=oh_event.type.to_string(),
-            mode=oh_event.mode.to_string(),
-            description=oh_event.description,
-            location=f"{oh_event.room.building} {oh_event.room.room}",
-            location_description=oh_event.location_description,
-            start_time=oh_event.start_time,
-            end_time=oh_event.end_time,
-            queued=len(
-                [
-                    ticket
-                    for ticket in oh_event.tickets
-                    if ticket.state == TicketState.QUEUED
-                ]
-            ),
-            total_tickets=len(oh_event.tickets),
-        )
 
     def create(self, user: User, new_site: NewCourseSite) -> CourseSite:
         """

--- a/backend/services/signage.py
+++ b/backend/services/signage.py
@@ -7,7 +7,8 @@ from sqlalchemy.orm import Session
 
 from ..database import db_session
 
-from datatime import datetime
+from datetime import datetime, timedelta
+from ..models.coworking import TimeRange
 
 from models import SignageOverviewFast, SignageOverviewSlow
 from services import ReservationService, SeatService
@@ -35,6 +36,7 @@ class SignageService:
         Gets the data for the fast API route
         """
         # Seats
+        now = datetime.now()
         walkin_window = TimeRange(
             start=now,
             end=now + timedelta(hours=6, minutes=10) # Makes sure open seats are available for 2hr walkin reservation

--- a/backend/services/signage.py
+++ b/backend/services/signage.py
@@ -1,0 +1,49 @@
+"""
+Service to collect and organize the information for CSXL Signage
+"""
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..database import db_session
+
+from datatime import datetime
+
+from models import SignageOverviewFast, SignageOverviewSlow
+from services import ReservationService, SeatService
+
+__authors__ = ["Andrew Lockard", "Will Zahrt", "Audrey Toney"]
+__copyright__ = "Copyright 2024"
+__license__ = "MIT"
+
+class SignageService:
+    """
+    Service to collect and organize the information for CSXL Signage
+    """
+    def __init__(
+        self, 
+        reservation_svc: ReservationService = Depends(), 
+        session: Session = Depends(db_session), 
+        seat_svc: SeatService = Depends()
+    ):
+        self._reservation_svc = reservation_svc
+        self._session = session
+        self._seat_svc = seat_svc
+
+    def get_fast_data(self) -> SignageOverviewFast:
+        """
+        Gets the data for the fast API route
+        """
+        # Seats
+        walkin_window = TimeRange(
+            start=now,
+            end=now + timedelta(hours=6, minutes=10) # Makes sure open seats are available for 2hr walkin reservation
+        )
+        seats = self._seat_svc.list()  # All Seats are fair game for walkin purposes
+        seat_availability = self._reservation_svc.seat_availability(
+            seats, walkin_window
+        )
+
+        return SignageOverviewFast(
+            seat_availability = seat_availability
+        )

--- a/backend/services/signage.py
+++ b/backend/services/signage.py
@@ -47,3 +47,6 @@ class SignageService:
         return SignageOverviewFast(
             seat_availability = seat_availability
         )
+
+    def get_slow_data(self) -> SignageOverviewSlow:
+        return SignageOverviewSlow()

--- a/backend/services/signage.py
+++ b/backend/services/signage.py
@@ -35,6 +35,7 @@ MAX_LEADERBOARD_SLOTS = 10
 MAX_EVENTS = 5
 MAX_ANNOUCEMENTS = 3
 
+# TODO: Create Tests for this Service
 class SignageService:
     """
     Service to collect and organize the information for CSXL Signage
@@ -108,8 +109,8 @@ class SignageService:
         news_entities = self._session.scalars(news_query).all()
         newest_news = [news.to_overview_model() for news in news_entities]
 
-        # TODO: Checkin Leaderboard
-        # Need to fix this so that it is only doing reservations that have been checkin/out and it updates based off of a new month
+        # Checkin Leaderboard
+        # TODO: Create public_user field and checkbox on Profile page so users can opt-out of being displayed here (and in future public places)
         start_of_month = datetime.today().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
         top_users_query = (
             select(
@@ -140,15 +141,15 @@ class SignageService:
             .limit(MAX_ANNOUCEMENTS)
         )
         announcement_entities = self._session.scalars(announcement_query).all()
-        announcements = [
-            announcement.to_overview_model() for announcement in announcement_entities
+        announcement_titles = [
+            announcement.to_overview_model().title for announcement in announcement_entities
         ]
 
         return SignageOverviewSlow(
             newest_news=newest_news,
             events=events,
             top_users=top_users,
-            announcements=announcements,
+            announcement_titles=announcement_titles,
         )
 
     def _to_oh_event_overview(self, oh_event: OfficeHoursEntity) -> OfficeHoursOverview:

--- a/backend/services/signage.py
+++ b/backend/services/signage.py
@@ -1,6 +1,7 @@
 """
 Service to collect and organize the information for CSXL Signage
 """
+
 from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.orm import Session
@@ -10,36 +11,58 @@ from ..database import db_session
 from datetime import datetime, timedelta
 from ..models.coworking import TimeRange
 
-from models import SignageOverviewFast, SignageOverviewSlow
-from services import ReservationService, SeatService
+from ..models.signage import SignageOverviewFast, SignageOverviewSlow
+from ..services.coworking import ReservationService, SeatService
+from ..services import RoomService
+
+from ..entities import ArticleEntity
+from ..models.articles import ArticleState
 
 __authors__ = ["Andrew Lockard", "Will Zahrt", "Audrey Toney"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
+
 class SignageService:
     """
     Service to collect and organize the information for CSXL Signage
     """
+
     def __init__(
-        self, 
-        reservation_svc: ReservationService = Depends(), 
-        session: Session = Depends(db_session), 
-        seat_svc: SeatService = Depends()
+        self,
+        reservation_svc: ReservationService = Depends(),
+        session: Session = Depends(db_session),
+        seat_svc: SeatService = Depends(),
+        room_svc: RoomService = Depends(),
     ):
         self._reservation_svc = reservation_svc
         self._session = session
         self._seat_svc = seat_svc
+        self.room_svc = room_svc
 
     def get_fast_data(self) -> SignageOverviewFast:
         """
         Gets the data for the fast API route
         """
+        # Office Hours
+
+        # Rooms
+        all_rooms = self.room_svc.all()
+        available_rooms = list[str]
+
+        # Putting the names of all the available rooms into a list to return
+        for room in all_rooms:
+            if room.reservable:
+                available_rooms.append(room.room)
+
         # Seats
         now = datetime.now()
         walkin_window = TimeRange(
             start=now,
-            end=now + timedelta(hours=6, minutes=10) # Makes sure open seats are available for 2hr walkin reservation
+            end=now
+            + timedelta(
+                hours=6, minutes=10
+            ),  # Makes sure open seats are available for 2hr walkin reservation
         )
         seats = self._seat_svc.list()  # All Seats are fair game for walkin purposes
         seat_availability = self._reservation_svc.seat_availability(
@@ -47,8 +70,28 @@ class SignageService:
         )
 
         return SignageOverviewFast(
-            seat_availability = seat_availability
+            available_rooms=available_rooms, seat_availability=seat_availability
         )
 
     def get_slow_data(self) -> SignageOverviewSlow:
-        return SignageOverviewSlow()
+        # Newest News
+
+        # Checkin Leaderboard
+        # Suggestion: Use a query to make a table with a new column that adds up the number of rows for checkins.
+
+        # Newest Events
+
+        # Announcements
+        announcement_query = (
+            select(ArticleEntity)
+            .where(ArticleEntity.is_announcement)
+            .where(ArticleEntity.state == ArticleState.PUBLISHED)
+            .order_by(ArticleEntity.published.desc())
+            .limit(3)
+        )
+        announcement_entities = self._session.scalars(announcement_query).all()
+        announcements = [
+            announcement.to_overview_model() for announcement in announcement_entities
+        ]
+
+        return SignageOverviewSlow(announcements=announcements)

--- a/backend/services/signage.py
+++ b/backend/services/signage.py
@@ -40,8 +40,8 @@ class SignageService:
 
     def __init__(
         self,
-        reservation_svc: ReservationService = Depends(),
         session: Session = Depends(db_session),
+        reservation_svc: ReservationService = Depends(),
         seat_svc: SeatService = Depends(),
         room_svc: RoomService = Depends(),
     ):

--- a/backend/services/signage.py
+++ b/backend/services/signage.py
@@ -16,7 +16,7 @@ from ..services.coworking import ReservationService, SeatService
 from ..services import RoomService
 
 from ..entities import ArticleEntity, RoomEntity, UserEntity, EventEntity
-from ..entities.coworking import ReservationEntity, Reserva
+from ..entities.coworking import ReservationEntity
 from ..entities.office_hours import OfficeHoursEntity
 from ..models.articles import ArticleState
 

--- a/backend/services/signage.py
+++ b/backend/services/signage.py
@@ -4,13 +4,9 @@ Service to collect and organize the information for CSXL Signage
 
 from fastapi import Depends
 from sqlalchemy import select, func
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
-from backend.entities.academics.section_entity import SectionEntity
-from backend.entities.office_hours.course_site_entity import CourseSiteEntity
-from backend.models.academics.my_courses import OfficeHoursOverview
 from backend.models.coworking.reservation import ReservationState
-from backend.models.office_hours.ticket_state import TicketState
 
 from ..database import db_session
 
@@ -64,7 +60,7 @@ class SignageService:
         )
         active_office_hours_entities = self._session.scalars(office_hours_query).all()
         active_office_hours = [
-            self._to_oh_event_overview(office_hours)
+            office_hours.to_overview_model()
             for office_hours in active_office_hours_entities
         ]
 
@@ -150,25 +146,4 @@ class SignageService:
             events=events,
             top_users=top_users,
             announcement_titles=announcement_titles,
-        )
-
-    def _to_oh_event_overview(self, oh_event: OfficeHoursEntity) -> OfficeHoursOverview:
-        # Brought over from the my_courses service
-        return OfficeHoursOverview(
-            id=oh_event.id,
-            type=oh_event.type.to_string(),
-            mode=oh_event.mode.to_string(),
-            description=oh_event.description,
-            location=f"{oh_event.room.building} {oh_event.room.room}",
-            location_description=oh_event.location_description,
-            start_time=oh_event.start_time,
-            end_time=oh_event.end_time,
-            queued=len(
-                [
-                    ticket
-                    for ticket in oh_event.tickets
-                    if ticket.state == TicketState.QUEUED
-                ]
-            ),
-            total_tickets=len(oh_event.tickets),
         )

--- a/backend/services/signage.py
+++ b/backend/services/signage.py
@@ -31,6 +31,7 @@ MAX_LEADERBOARD_SLOTS = 10
 MAX_EVENTS = 5
 MAX_ANNOUCEMENTS = 3
 
+
 # TODO: Create Tests for this Service
 class SignageService:
     """
@@ -106,8 +107,9 @@ class SignageService:
         newest_news = [news.to_overview_model() for news in news_entities]
 
         # Checkin Leaderboard
-        # TODO: Create public_user field and checkbox on Profile page so users can opt-out of being displayed here (and in future public places)
-        start_of_month = datetime.today().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        start_of_month = datetime.today().replace(
+            day=1, hour=0, minute=0, second=0, microsecond=0
+        )
         top_users_query = (
             select(
                 UserEntity, func.count(ReservationEntity.id).label("reservation_count")
@@ -124,7 +126,9 @@ class SignageService:
         top_users = [user.to_public_model() for user in user_entities]
 
         # Newest Events
-        events_query = select(EventEntity).order_by(EventEntity.start.desc()).limit(MAX_EVENTS)
+        events_query = (
+            select(EventEntity).order_by(EventEntity.start.desc()).limit(MAX_EVENTS)
+        )
         event_entities = self._session.scalars(events_query).all()
         events = [event.to_overview_model() for event in event_entities]
 
@@ -138,7 +142,8 @@ class SignageService:
         )
         announcement_entities = self._session.scalars(announcement_query).all()
         announcement_titles = [
-            announcement.to_overview_model().title for announcement in announcement_entities
+            announcement.to_overview_model().title
+            for announcement in announcement_entities
         ]
 
         return SignageOverviewSlow(

--- a/backend/test/services/coworking/reservation/reservation_data.py
+++ b/backend/test/services/coworking/reservation/reservation_data.py
@@ -118,10 +118,8 @@ def instantiate_global_models(time: dict[str, datetime]):
     # Confirm Room Reservation
     reservation_6 = Reservation(
         id=6,
-        start=operating_hours_data.tomorrow.start
-        + timedelta(hours=25),
-        end=operating_hours_data.tomorrow.start
-        + timedelta(hours=26, minutes=30),
+        start=operating_hours_data.tomorrow.start + timedelta(hours=25),
+        end=operating_hours_data.tomorrow.start + timedelta(hours=26, minutes=30),
         created_at=time[NOW],
         updated_at=time[NOW],
         walkin=False,
@@ -141,9 +139,8 @@ def instantiate_global_models(time: dict[str, datetime]):
         room=room_data.group_a,
         state=ReservationState.CONFIRMED,
         users=[user_data.root],
-        seats=[]
+        seats=[],
     )
-
 
     active_reservations = [reservation_1]
     confirmed_reservations = [reservation_4]

--- a/backend/test/services/fixtures.py
+++ b/backend/test/services/fixtures.py
@@ -11,6 +11,7 @@ from ...services import (
     EventService,
     RoomService,
     ApplicationService,
+    SignageService,
 )
 from ...services.academics import HiringService
 from ...services.article import ArticleService
@@ -47,6 +48,11 @@ def user_svc_integration(session: Session):
 @pytest.fixture()
 def role_svc(session: Session, permission_svc_mock: PermissionService):
     return RoleService(session, permission_svc_mock)
+
+
+@pytest.fixture()
+def signage_svc(session: Session):
+    return SignageService(session)
 
 
 @pytest.fixture()

--- a/backend/test/services/fixtures.py
+++ b/backend/test/services/fixtures.py
@@ -15,9 +15,14 @@ from ...services import (
 )
 from ...services.academics import HiringService
 from ...services.article import ArticleService
-from ...services.coworking import PolicyService, OperatingHoursService
+from ...services.coworking import (
+    PolicyService,
+    OperatingHoursService,
+    ReservationService,
+    SeatService,
+)
 
-__authors__ = ["Kris Jordan", "Ajay Gandecha"]
+__authors__ = ["Kris Jordan", "Ajay Gandecha", "Will Zahrt", "Andrew Lockard"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
@@ -51,8 +56,13 @@ def role_svc(session: Session, permission_svc_mock: PermissionService):
 
 
 @pytest.fixture()
-def signage_svc(session: Session):
-    return SignageService(session)
+def signage_svc(
+    session: Session,
+    reservation_svc: ReservationService,
+    seat_svc: SeatService,
+    room_svc: RoomService,
+):
+    return SignageService(session, reservation_svc, seat_svc, room_svc)
 
 
 @pytest.fixture()

--- a/backend/test/services/room_test.py
+++ b/backend/test/services/room_test.py
@@ -1,4 +1,5 @@
 """Tests for Coworking Rooms Service."""
+
 from unittest.mock import create_autospec
 import pytest
 from backend.services.exceptions import (

--- a/backend/test/services/signage_data.py
+++ b/backend/test/services/signage_data.py
@@ -31,13 +31,13 @@ current_reservation = Reservation(
 )
 
 
-@pytest.fixture(autouse=True)
-def fake_data_fixture(session: Session, time: dict[str, datetime]):
-    """Inserts additional data needed to fully test signage."""
-    insert_fake_data(session, time)
-    session.commit()
-
-
-def insert_fake_data(session: Session, time: dict[str, datetime]):
+def insert_fake_data(session: Session):
     entity = ReservationEntity.from_model(current_reservation)
     session.add(entity)
+    session.commit()
+
+@pytest.fixture(autouse=True)
+def fake_data_fixture(session: Session):
+    """Inserts additional data needed to fully test signage."""
+    insert_fake_data(session)
+    session.commit()

--- a/backend/test/services/signage_data.py
+++ b/backend/test/services/signage_data.py
@@ -1,0 +1,43 @@
+"""One more additional reservation data for signage tests."""
+
+import pytest
+from datetime import datetime, timedelta
+from sqlalchemy import text, select
+from sqlalchemy.orm import Session
+from ...entities.coworking import ReservationEntity
+from ...models.coworking import Reservation, ReservationState, ReservationRequest
+from time import *
+
+from .core_data import user_data
+
+from . import room_data
+
+__authors__ = ["Will Zahrt"]
+
+
+now = datetime.now()
+
+current_reservation = Reservation(
+    id=8,
+    start=now - timedelta(hours=1),
+    end=now + timedelta(hours=2),
+    created_at=now - timedelta(hours=2),
+    updated_at=now - timedelta(hours=1, minutes=30),
+    walkin=False,
+    room=room_data.pair_a,
+    state=ReservationState.CHECKED_IN,
+    users=[user_data.root],
+    seats=[],
+)
+
+
+@pytest.fixture(autouse=True)
+def fake_data_fixture(session: Session, time: dict[str, datetime]):
+    """Inserts additional data needed to fully test signage."""
+    insert_fake_data(session, time)
+    session.commit()
+
+
+def insert_fake_data(session: Session, time: dict[str, datetime]):
+    entity = ReservationEntity.from_model(current_reservation)
+    session.add(entity)

--- a/backend/test/services/signage_data.py
+++ b/backend/test/services/signage_data.py
@@ -12,7 +12,7 @@ from .core_data import user_data
 
 from . import room_data
 
-__authors__ = ["Will Zahrt"]
+__authors__ = ["Will Zahrt", "Andrew Lockard"]
 
 
 now = datetime.now()
@@ -30,11 +30,86 @@ current_reservation = Reservation(
     seats=[],
 )
 
+checked_out_reservation_1 = Reservation(
+    id=9,
+    start=now - timedelta(hours=2),
+    end=now - timedelta(hours=1),
+    created_at=now - timedelta(hours=2),
+    updated_at=now - timedelta(hours=1),
+    walkin=False,
+    room=None,
+    state=ReservationState.CHECKED_OUT,
+    users=[user_data.ambassador],
+    seats=[],
+)
+
+checked_out_reservation_2 = Reservation(
+    id=10,
+    start=now - timedelta(hours=4),
+    end=now - timedelta(hours=3),
+    created_at=now - timedelta(hours=4),
+    updated_at=now - timedelta(hours=3),
+    walkin=False,
+    room=None,
+    state=ReservationState.CHECKED_OUT,
+    users=[user_data.ambassador],
+    seats=[],
+)
+
+checked_out_reservation_3 = Reservation(
+    id=11,
+    start=now - timedelta(hours=2),
+    end=now - timedelta(hours=1),
+    created_at=now - timedelta(hours=2),
+    updated_at=now - timedelta(hours=1),
+    walkin=False,
+    room=None,
+    state=ReservationState.CHECKED_OUT,
+    users=[user_data.root],
+    seats=[],
+)
+
+checked_out_reservation_4 = Reservation(
+    id=12,
+    start=now - timedelta(hours=4),
+    end=now - timedelta(hours=3),
+    created_at=now - timedelta(hours=4),
+    updated_at=now - timedelta(hours=3),
+    walkin=False,
+    room=None,
+    state=ReservationState.CHECKED_OUT,
+    users=[user_data.root],
+    seats=[],
+)
+
+checked_out_reservation_5 = Reservation(
+    id=13,
+    start=now - timedelta(hours=4),
+    end=now - timedelta(hours=3),
+    created_at=now - timedelta(hours=4),
+    updated_at=now - timedelta(hours=3),
+    walkin=False,
+    room=None,
+    state=ReservationState.CHECKED_OUT,
+    users=[user_data.user],
+    seats=[],
+)
+
 
 def insert_fake_data(session: Session):
-    entity = ReservationEntity.from_model(current_reservation)
-    session.add(entity)
-    session.commit()
+    entity1 = ReservationEntity.from_model(current_reservation, session)
+    session.add(entity1)
+    entity2 = ReservationEntity.from_model(checked_out_reservation_1, session)
+    session.add(entity2)
+    entity3 = ReservationEntity.from_model(checked_out_reservation_2, session)
+    session.add(entity3)
+    entity4 = ReservationEntity.from_model(checked_out_reservation_3, session)
+    session.add(entity4)
+    entity5 = ReservationEntity.from_model(checked_out_reservation_4, session)
+    session.add(entity5)
+    entity6 = ReservationEntity.from_model(checked_out_reservation_5, session)
+    session.add(entity6)
+
 
 @pytest.fixture(autouse=True)
 def fake_data_fixture(session: Session):

--- a/backend/test/services/signage_test.py
+++ b/backend/test/services/signage_test.py
@@ -5,6 +5,8 @@ import pytest
 
 from sqlalchemy.orm import Session
 
+from backend.models.public_user import PublicUser
+
 from ...models import SignageOverviewFast, SignageOverviewSlow
 from ...services import SignageService
 
@@ -30,6 +32,7 @@ from .office_hours.office_hours_data import (
     fake_data_fixture as insert_order_8,
 )
 from .signage_data import fake_data_fixture as insert_order_9
+from .articles.article_data import fake_data_fixture as insert_order_10
 
 
 #  Import the fake model data in a namespace for test assertions
@@ -37,21 +40,44 @@ from .coworking import seat_data
 from . import room_data, user_data
 from .coworking.reservation import reservation_data
 from .office_hours import office_hours_data
+from .articles import article_data
+from .event import event_test_data
+from . import signage_data
+
 
 __authors__ = ["Will Zahrt", "Andrew Lockard"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
+
 def test_get_fast_data(signage_svc: SignageService):
     fast_data = signage_svc.get_fast_data()
+
     assert len(fast_data.active_office_hours) == 1
     assert (
         fast_data.active_office_hours[0].id
         == office_hours_data.comp_110_current_office_hours.id
     )
-    available_rooms = [room.id for room in room_data.rooms]
-    assert room_data.pair_a.id not in available_rooms
+
+    assert room_data.pair_a.id not in fast_data.available_rooms
 
     available_seats = [seat for seat in fast_data.seat_availability if seat.reservable]
     assert seat_data.monitor_seat_01 not in available_seats
     assert seat_data.monitor_seat_11 not in available_seats
+
+
+def test_get_slow_data(signage_svc: SignageService):
+    slow_data = signage_svc.get_slow_data()
+
+    assert article_data.announcement not in slow_data.newest_news
+    assert len(slow_data.newest_news) == 2
+
+    assert len(slow_data.events) == 3
+
+    assert len(slow_data.top_users) == 3
+    assert slow_data.top_users[0].id == user_data.ambassador.id
+    assert slow_data.top_users[1].id == user_data.root.id
+    assert slow_data.top_users[2].id == user_data.user.id
+
+    assert len(slow_data.announcement_titles) == 1
+    assert slow_data.announcement_titles[0] == "Sample Announcement"

--- a/backend/test/services/signage_test.py
+++ b/backend/test/services/signage_test.py
@@ -1,6 +1,12 @@
 """Tests for the RoleService class."""
 
 # Tested Dependencies
+from datetime import datetime, timedelta
+import pytest
+from sqlalchemy.orm import Session
+
+from backend.entities.coworking.reservation_entity import ReservationEntity
+from backend.models.coworking.reservation import Reservation, ReservationState
 from ...models import SignageOverviewFast, SignageOverviewSlow
 from ...services import SignageService
 
@@ -9,7 +15,7 @@ from .core_data import setup_insert_data_fixture
 
 # Data Models for Fake Data Inserted in Setup
 from .coworking import seat_data
-from .room_data import *
+import room_data, user_data
 from .coworking.reservation import reservation_data
 from .office_hours import office_hours_data
 
@@ -17,6 +23,27 @@ __authors__ = ["Will Zahrt", "Andrew Lockard"]
 __copyright__ = "Copyright 2023"
 __license__ = "MIT"
 
+now = datetime.now()
+
+current_reservation = Reservation (
+        id=8,
+        start=now - timedelta(hours=1),
+        end=now + timedelta(hours=2),
+        created_at=now - timedelta(hours=2),
+        updated_at=now - timedelta(hours=1, minutes=30),
+        walkin=False,
+        room=room_data.pair_a,
+        state=ReservationState.CHECKED_IN,
+        users=[user_data.root],
+        seats=[]
+    )
+
+@pytest.fixture(autouse=True)
+def insert_additional_fake_data(session: Session):
+    """Inserts additional data needed to fully test signage."""
+    entity = ReservationEntity.from_model(current_reservation)
+    session.add(entity)
+    session.commit()
 
 def test_get_fast_data(signage_svc: SignageService):
     fast_data = signage_svc.get_fast_data()

--- a/backend/test/services/signage_test.py
+++ b/backend/test/services/signage_test.py
@@ -25,18 +25,19 @@ __license__ = "MIT"
 
 now = datetime.now()
 
-current_reservation = Reservation (
-        id=8,
-        start=now - timedelta(hours=1),
-        end=now + timedelta(hours=2),
-        created_at=now - timedelta(hours=2),
-        updated_at=now - timedelta(hours=1, minutes=30),
-        walkin=False,
-        room=room_data.pair_a,
-        state=ReservationState.CHECKED_IN,
-        users=[user_data.root],
-        seats=[]
-    )
+current_reservation = Reservation(
+    id=8,
+    start=now - timedelta(hours=1),
+    end=now + timedelta(hours=2),
+    created_at=now - timedelta(hours=2),
+    updated_at=now - timedelta(hours=1, minutes=30),
+    walkin=False,
+    room=room_data.pair_a,
+    state=ReservationState.CHECKED_IN,
+    users=[user_data.root],
+    seats=[],
+)
+
 
 @pytest.fixture(autouse=True)
 def insert_additional_fake_data(session: Session):
@@ -45,6 +46,7 @@ def insert_additional_fake_data(session: Session):
     session.add(entity)
     session.commit()
 
+
 def test_get_fast_data(signage_svc: SignageService):
     fast_data = signage_svc.get_fast_data()
     assert len(fast_data.active_office_hours) == 1
@@ -52,3 +54,9 @@ def test_get_fast_data(signage_svc: SignageService):
         fast_data.active_office_hours[0].id
         == office_hours_data.comp_110_current_office_hours.id
     )
+    available_rooms = [room.id for room in room_data.rooms]
+    assert room_data.pair_a.id not in available_rooms
+
+    available_seats = [seat for seat in fast_data.seat_availability if seat.reservable]
+    assert seat_data.monitor_seat_01 not in available_seats
+    assert seat_data.monitor_seat_11 not in available_seats

--- a/backend/test/services/signage_test.py
+++ b/backend/test/services/signage_test.py
@@ -1,0 +1,27 @@
+"""Tests for the RoleService class."""
+
+# Tested Dependencies
+from ...models import SignageOverviewFast, SignageOverviewSlow
+from ...services import SignageService
+
+# Data Setup and Injected Service Fixtures
+from .core_data import setup_insert_data_fixture
+
+# Data Models for Fake Data Inserted in Setup
+from .coworking import seat_data
+from .room_data import *
+from .coworking.reservation import reservation_data
+from .office_hours import office_hours_data
+
+__authors__ = ["Will Zahrt", "Andrew Lockard"]
+__copyright__ = "Copyright 2023"
+__license__ = "MIT"
+
+
+def test_get_fast_data(signage_svc: SignageService):
+    fast_data = signage_svc.get_fast_data()
+    assert len(fast_data.active_office_hours) == 1
+    assert (
+        fast_data.active_office_hours[0].id
+        == office_hours_data.comp_110_current_office_hours.id
+    )

--- a/backend/test/services/signage_test.py
+++ b/backend/test/services/signage_test.py
@@ -10,12 +10,25 @@ from backend.models.coworking.reservation import Reservation, ReservationState
 from ...models import SignageOverviewFast, SignageOverviewSlow
 from ...services import SignageService
 
-# Data Setup and Injected Service Fixtures
-from .core_data import setup_insert_data_fixture
+# Imported fixtures provide dependencies injected for the tests as parameters.
+from .fixtures import signage_svc
 
-# Data Models for Fake Data Inserted in Setup
+# Data Setup and Injected Service Fixtures
+from .coworking.seat_data import fake_data_fixture as insert_fake_seat_data
+from .room_data import fake_data_fixture as insert_fake_room_data
+from .user_data import fake_data_fixture as insert_fake_user_data
+from .coworking.reservation.reservation_data import (
+    fake_data_fixture as insert_fake_reservation_data,
+)
+from .office_hours.office_hours_data import (
+    fake_data_fixture as insert_fake_office_hours_data,
+)
+from .signage_data import fake_data_fixture as insert_fake_sigange_data
+
+
+#  Import the fake model data in a namespace for test assertions
 from .coworking import seat_data
-import room_data, user_data
+from . import room_data, user_data
 from .coworking.reservation import reservation_data
 from .office_hours import office_hours_data
 
@@ -25,26 +38,26 @@ __license__ = "MIT"
 
 now = datetime.now()
 
-current_reservation = Reservation(
-    id=8,
-    start=now - timedelta(hours=1),
-    end=now + timedelta(hours=2),
-    created_at=now - timedelta(hours=2),
-    updated_at=now - timedelta(hours=1, minutes=30),
-    walkin=False,
-    room=room_data.pair_a,
-    state=ReservationState.CHECKED_IN,
-    users=[user_data.root],
-    seats=[],
-)
+# current_reservation = Reservation(
+#     id=8,
+#     start=now - timedelta(hours=1),
+#     end=now + timedelta(hours=2),
+#     created_at=now - timedelta(hours=2),
+#     updated_at=now - timedelta(hours=1, minutes=30),
+#     walkin=False,
+#     room=room_data.pair_a,
+#     state=ReservationState.CHECKED_IN,
+#     users=[user_data.root],
+#     seats=[],
+# )
 
 
-@pytest.fixture(autouse=True)
-def insert_additional_fake_data(session: Session):
-    """Inserts additional data needed to fully test signage."""
-    entity = ReservationEntity.from_model(current_reservation)
-    session.add(entity)
-    session.commit()
+# @pytest.fixture(autouse=True)
+# def insert_additional_fake_data(session: Session):
+#     """Inserts additional data needed to fully test signage."""
+#     entity = ReservationEntity.from_model(current_reservation)
+#     session.add(entity)
+#     session.commit()
 
 
 def test_get_fast_data(signage_svc: SignageService):

--- a/backend/test/services/signage_test.py
+++ b/backend/test/services/signage_test.py
@@ -1,29 +1,35 @@
 """Tests for the RoleService class."""
 
 # Tested Dependencies
-from datetime import datetime, timedelta
 import pytest
+
 from sqlalchemy.orm import Session
 
-from backend.entities.coworking.reservation_entity import ReservationEntity
-from backend.models.coworking.reservation import Reservation, ReservationState
 from ...models import SignageOverviewFast, SignageOverviewSlow
 from ...services import SignageService
 
 # Imported fixtures provide dependencies injected for the tests as parameters.
+
 from .fixtures import signage_svc
+from .coworking.time import time
+from .coworking.fixtures import *
 
 # Data Setup and Injected Service Fixtures
-from .coworking.seat_data import fake_data_fixture as insert_fake_seat_data
-from .room_data import fake_data_fixture as insert_fake_room_data
-from .user_data import fake_data_fixture as insert_fake_user_data
+from .core_data import setup_insert_data_fixture as insert_order_0
+from .academics.term_data import fake_data_fixture as insert_order_1
+from .academics.course_data import fake_data_fixture as insert_order_2
+from .academics.section_data import fake_data_fixture as insert_order_3
+from .room_data import fake_data_fixture as insert_order_4
+from .coworking.seat_data import fake_data_fixture as insert_order_5
+from .coworking.operating_hours_data import fake_data_fixture as insert_order_6
 from .coworking.reservation.reservation_data import (
-    fake_data_fixture as insert_fake_reservation_data,
+    fake_data_fixture as insert_order_7,
 )
+
 from .office_hours.office_hours_data import (
-    fake_data_fixture as insert_fake_office_hours_data,
+    fake_data_fixture as insert_order_8,
 )
-from .signage_data import fake_data_fixture as insert_fake_sigange_data
+from .signage_data import fake_data_fixture as insert_order_9
 
 
 #  Import the fake model data in a namespace for test assertions
@@ -33,32 +39,8 @@ from .coworking.reservation import reservation_data
 from .office_hours import office_hours_data
 
 __authors__ = ["Will Zahrt", "Andrew Lockard"]
-__copyright__ = "Copyright 2023"
+__copyright__ = "Copyright 2024"
 __license__ = "MIT"
-
-now = datetime.now()
-
-# current_reservation = Reservation(
-#     id=8,
-#     start=now - timedelta(hours=1),
-#     end=now + timedelta(hours=2),
-#     created_at=now - timedelta(hours=2),
-#     updated_at=now - timedelta(hours=1, minutes=30),
-#     walkin=False,
-#     room=room_data.pair_a,
-#     state=ReservationState.CHECKED_IN,
-#     users=[user_data.root],
-#     seats=[],
-# )
-
-
-# @pytest.fixture(autouse=True)
-# def insert_additional_fake_data(session: Session):
-#     """Inserts additional data needed to fully test signage."""
-#     entity = ReservationEntity.from_model(current_reservation)
-#     session.add(entity)
-#     session.commit()
-
 
 def test_get_fast_data(signage_svc: SignageService):
     fast_data = signage_svc.get_fast_data()

--- a/frontend/src/app/tv/tv.service.ts
+++ b/frontend/src/app/tv/tv.service.ts
@@ -1,0 +1,44 @@
+/**
+ * The TV Service abstracts HTTP requests to the backend
+ * from the components.
+ *
+ * @author Will Zahrt
+ * @copyright 2024
+ * @license MIT
+ */
+
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { Observable, map } from 'rxjs';
+import {
+  ArticleDraft,
+  ArticleOverview,
+  ArticleOverviewJson,
+  parseArticleOverviewJson
+} from '../welcome/welcome.model';
+import {
+  DEFAULT_PAGINATION_PARAMS,
+  PaginationParams,
+  Paginator
+} from '../pagination';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class TvService {
+  /** Encapsulated paginators */
+  private eventsPaginator: Paginator<ArticleOverview> =
+    new Paginator<ArticleOverview>('/api/articles/list');
+
+  /** Constructor */
+  constructor(protected http: HttpClient) {}
+
+  /**
+   * Retrieves a page of events based on pagination parameters.
+   * @param params: Pagination parameters.
+   * @returns {Observable<Paginated<ArticleOverview, PaginationParams>>}
+   */
+  list(params: PaginationParams = DEFAULT_PAGINATION_PARAMS) {
+    return this.eventsPaginator.loadPage(params, parseArticleOverviewJson);
+  }
+}


### PR DESCRIPTION
## Overview

Two routes were created, `GET /api/signage/slow` and `GET /api/signage/fast`, to provide information to the frontend for the CSXL signage system in an  efficient way. These routes separate the data by update frequency—information that needs quick updates and data that can be refreshed every hour or so. Tests for these routes were added in `backend/tests/services/signage.py`.

## Slow Route

The slow route provides the five most recent news items, the next five upcoming events, the top ten users with the most check-ins (including room and CSXL check-ins) for the current month (resetting on the 1st), and the three latest announcement titles. These quantities can be adjusted in the signage service file.

## Fast Route

The fast route provides all currently active office hours using the `OfficeHoursOverview` model. This model also includes the number of people in the queue, intended for TV display.  Finally, this route also lists the currently available rooms along with seat availability in the CSXL.

## Tests

Since both routes are straightforward scripts without branching logic, we wrote a single test for each. Additional sample data was added to the `signage_data.py` file to cover scenarios not handled by existing data, such as having a leaderboard and an active room reservation.

## Additional Changes

The `to_office_hours_overview` method was moved from the service layer to the entity layer, as it was also needed in the Signage service.
