### PR TITLE
Improve Exception UX in Instructor Hiring Preferences

### DIFF
--- a/frontend/src/app/hiring/hiring-preferences/hiring-preferences.component.css
+++ b/frontend/src/app/hiring/hiring-preferences/hiring-preferences.component.css
@@ -59,6 +59,12 @@
   transition: transform 250ms cubic-bezier(0, 0, 0.2, 1);
 }
 
+.cdk-drop-list-disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: not-allowed;
+}
+
 .text-badge {
   font-size: 10px;
   height: 22px;

--- a/frontend/src/app/hiring/hiring-preferences/hiring-preferences.component.html
+++ b/frontend/src/app/hiring/hiring-preferences/hiring-preferences.component.html
@@ -16,6 +16,7 @@
         #notPreferredList="cdkDropList"
         [cdkDropListData]="notPreferred"
         [cdkDropListConnectedTo]="[notProcessedList, preferredList]"
+        [cdkDropListDisabled]="isDropProcessing"
         class="drop-list"
         (cdkDropListDropped)="drop($event)">
         @for (item of notPreferred; track item.id) {
@@ -49,6 +50,7 @@
         #notProcessedList="cdkDropList"
         [cdkDropListData]="notProcessed"
         [cdkDropListConnectedTo]="[notPreferredList, preferredList]"
+        [cdkDropListDisabled]="isDropProcessing"
         class="drop-list"
         (cdkDropListDropped)="drop($event)">
         @for (item of notProcessed; track item.id) {
@@ -100,6 +102,7 @@
         #preferredList="cdkDropList"
         [cdkDropListData]="preferred"
         [cdkDropListConnectedTo]="[notPreferredList, notProcessedList]"
+        [cdkDropListDisabled]="isDropProcessing"
         class="drop-list"
         (cdkDropListDropped)="drop($event)">
         @for (item of preferred; track item.id) {

--- a/frontend/src/app/hiring/hiring-preferences/hiring-preferences.component.ts
+++ b/frontend/src/app/hiring/hiring-preferences/hiring-preferences.component.ts
@@ -45,6 +45,8 @@ export class HiringPreferencesComponent {
 
   courseSiteId: number;
 
+  isDropProcessing: boolean = false;
+
   /** Constructor */
   constructor(
     private route: ActivatedRoute,
@@ -65,6 +67,7 @@ export class HiringPreferencesComponent {
   }
 
   drop(event: CdkDragDrop<ApplicationReviewOverview[]>) {
+    this.isDropProcessing = true;
     if (event.previousContainer === event.container) {
       moveItemInArray(
         event.container.data,
@@ -112,8 +115,12 @@ export class HiringPreferencesComponent {
           this.notPreferred = hiringStatus.not_preferred;
           this.notProcessed = hiringStatus.not_processed;
           this.preferred = hiringStatus.preferred;
+          this.isDropProcessing = false;
         },
-        error: (error) => this.saveErrorSnackBar(error)
+        error: (error) => {
+          this.saveErrorSnackBar(error);
+          this.isDropProcessing = false;
+        }
       });
   }
 


### PR DESCRIPTION
This PR adds error messages when instructors attempt to select TA preferences but the API request fails. This is most often encountered when request payloads are intercepted by UNC's campus firewall and a 403 error is emitted. A custom error message gives the instructor an indication that the requests failed due to not being on a campus network or VPN.

Additionally, drag and drop is disabled while preferences are being arranged. This is necessary for high demand courses where preference persistence is expensive and avoids race conditions when sorting preferences goes faster than the backend keeps up with.

This PR was verified locally by editing the API endpoint to present 403 errors and emulate long requests. Those changes were not committed.