### PR TITLE
Allow searching for users by first and last name

### DIFF
--- a/backend/services/user.py
+++ b/backend/services/user.py
@@ -99,13 +99,14 @@ class UserService:
         """
         statement = select(UserEntity)
         criteria = or_(
-            UserEntity.first_name.ilike(f"%{query}%"),
-            UserEntity.last_name.ilike(f"%{query}%"),
+            func.concat(UserEntity.first_name, " ", UserEntity.last_name).ilike(
+                f"%{query}%"
+            ),
             UserEntity.onyen.ilike(f"%{query}%"),
             UserEntity.email.ilike(f"%{query}%"),
             cast(UserEntity.pid, String).ilike(f"%{query}%"),
         )
-        statement = statement.where(criteria).limit(10)
+        statement = statement.where(criteria).limit(50)
         entities = self._session.execute(statement).scalars()
         return [entity.to_model() for entity in entities]
 

--- a/backend/test/services/user_test.py
+++ b/backend/test/services/user_test.py
@@ -78,6 +78,15 @@ def test_search_by_last_name(user_svc: UserService):
     assert users[0].email == ambassador.email
 
 
+def test_search_full_name(user_svc: UserService):
+    users = user_svc.search(ambassador, "Amy Ambassad")
+    assert len(users) == 1
+    assert users[0].id == ambassador.id
+    assert users[0].pid == ambassador.pid
+    assert users[0].onyen == ambassador.onyen
+    assert users[0].email == ambassador.email
+
+
 def test_search_by_onyen(user_svc: UserService):
     """Test that a user can be retrieved by Searching for part of their onyen."""
     users = user_svc.search(ambassador, "xlst")


### PR DESCRIPTION
Previously, search results for users were limited to 10 and you could not search for the combination of first and last name. This PR fixes it. Validated with an additional unit test.