### PR TITLE
Search users by prefix matches and order results by first, last name

### DIFF
--- a/backend/services/user.py
+++ b/backend/services/user.py
@@ -97,17 +97,44 @@ class UserService:
         Returns:
             list[User]: The list of users matching the query.
         """
-        statement = select(UserEntity)
-        criteria = or_(
-            func.concat(UserEntity.first_name, " ", UserEntity.last_name).ilike(
-                f"%{query}%"
-            ),
-            UserEntity.onyen.ilike(f"%{query}%"),
-            UserEntity.email.ilike(f"%{query}%"),
-            cast(UserEntity.pid, String).ilike(f"%{query}%"),
+        # First attempt: Query for users by name, onyen, or PID from start of string
+        statement = (
+            select(UserEntity)
+            .where(
+                or_(
+                    func.concat(UserEntity.first_name, " ", UserEntity.last_name).ilike(
+                        f"{query}%"
+                    ),
+                    UserEntity.last_name.ilike(f"{query}%"),
+                    UserEntity.onyen.ilike(f"{query}%"),
+                    cast(UserEntity.pid, String).ilike(f"{query}%"),
+                )
+            )
+            .order_by(UserEntity.first_name, UserEntity.last_name)
+            .limit(50)
         )
-        statement = statement.where(criteria).limit(50)
-        entities = self._session.execute(statement).scalars()
+        entities = self._session.execute(statement).scalars().all()
+
+        # Second attempt: match in the middle of strings and also search email
+        if len(entities) == 0:
+            statement = (
+                select(UserEntity)
+                .where(
+                    or_(
+                        func.concat(
+                            UserEntity.first_name, " ", UserEntity.last_name
+                        ).ilike(f"%{query}%"),
+                        UserEntity.last_name.ilike(f"%{query}%"),
+                        UserEntity.onyen.ilike(f"%{query}%"),
+                        UserEntity.email.ilike(f"%{query}%"),
+                        cast(UserEntity.pid, String).ilike(f"%{query}%"),
+                    )
+                )
+                .order_by(UserEntity.first_name, UserEntity.last_name)
+                .limit(50)
+            )
+            entities = self._session.execute(statement).scalars().all()
+
         return [entity.to_model() for entity in entities]
 
     def list(


### PR DESCRIPTION
This commit further improves user search as number of users in the system grows.

First, it prioritizes start of string matches (e.g. "Ia" matches "Ian" but not "Christian") in first pass. Only matches middle of strings if no prefix matches are found.

Second, it orders results by first name then last name for a much better UX of disambiguating matches as the number of users in our system has grown significantly.