### PR TITLE
Roster Import Description Patch

### DIFF
--- a/frontend/src/app/my-courses/course/roster/roster.component.ts
+++ b/frontend/src/app/my-courses/course/roster/roster.component.ts
@@ -110,7 +110,7 @@ export class RosterComponent {
   /** Opens the dialog for importing the roster */
   importFromCanvas(): void {
     let dialogRef = this.dialog.open(ImportRosterDialog, {
-      height: '500px',
+      height: '540px',
       width: '600px',
       data: this.myCoursesService.courseOverview(
         this.route.parent!.snapshot.params['course_site_id']

--- a/frontend/src/app/my-courses/dialogs/import-roster/import-roster.dialog.html
+++ b/frontend/src/app/my-courses/dialogs/import-roster/import-roster.dialog.html
@@ -7,8 +7,9 @@
     <p><strong class="semibold">Steps to Download Roster CSV:</strong></p>
     <ol>
       <li>Navigate to the "Grades" tab in your Canvas course page.</li>
+      <li><em>Filter</em> your gradebook to include just one section. If you have two or more sections in your class, you will want to export these from Canvas and import this into the CSXL website separately.</li>
       <li>On the top right, press the dropdown "Export".</li>
-      <li>Select "Export Entire Gradebook".</li>
+      <li>Select "Export Current Gradebook View".</li>
       <li>Now, fill in the prompts below to upload your roster into the CSXL site.</li>
     </ol>
 

--- a/frontend/src/app/my-courses/dialogs/import-roster/import-roster.dialog.ts
+++ b/frontend/src/app/my-courses/dialogs/import-roster/import-roster.dialog.ts
@@ -69,7 +69,10 @@ export class ImportRosterDialog {
               // Close the dialog
               this.close();
             },
-            error: (err) => this.snackBar.open(err, '', { duration: 2000 })
+            error: (err) =>
+              this.snackBar.open('Error: ' + err.error.detail, '', {
+                duration: 2000
+              })
           });
       };
       reader.onerror = (_) => {


### PR DESCRIPTION
This small PR adds clarity to import roster instructions and ensure that the error message is displayed on the dialog (rather than the inconspicuous `[object Object]`.

<img width="965" alt="Screenshot 2025-01-14 at 2 39 15 PM" src="https://github.com/user-attachments/assets/369eef5f-f9c8-4048-a4f5-02b78d761ac2" />
