### PR TITLE
Signage fix weather errors

### DIFF
--- a/frontend/src/app/signage/signage.component.html
+++ b/frontend/src/app/signage/signage.component.html
@@ -1,19 +1,17 @@
 <div class="mat-sidenav big-div">
     <div class='header'>
-        <!-- <div class='left-items'> -->
-            <mat-card-header>
-                <mat-card-title class="title">{{date | date:'EEEE MMMM d, h:mm aaa'}}</mat-card-title>
-            </mat-card-header>
+        <mat-card-header>
+            <mat-card-title class="title">{{date | date:'EEEE MMMM d, h:mm aaa'}}</mat-card-title>
+        </mat-card-header>
             <div class="weather">
                 <img
                 class="weather-image"
-                src="{{current_weather_icon}}"
+                src="{{assginWeatherIcon(signageService.weatherData())}}"
                 alt="Weather Icon" />
                 <mat-card-header>
-                    <mat-card-title class="title">{{weatherData.current.temperature2m | number: '1.0-0'}}°F</mat-card-title>
+                    <mat-card-title class="title">{{signageService.weatherData().temperature2m | number: '1.0-0'}}°F</mat-card-title>
                 </mat-card-header>
-                </div>
-        <!-- </div> -->
+            </div>
         <div class="announcement">announcement</div>
     </div>
     <div class='column'>

--- a/frontend/src/app/signage/signage.model.ts
+++ b/frontend/src/app/signage/signage.model.ts
@@ -56,6 +56,13 @@ export interface FastSignageData {
   seat_availability: SeatAvailability[];
 }
 
+export interface WeatherData {
+  temperature2m: number;
+  isDay: number;
+  weatherCode: number;
+  windSpeed10m: number;
+}
+
 export const parseSignageOfficeHoursJson = (
   json: SignageOfficeHoursJSON
 ): SignageOfficeHours => {

--- a/frontend/src/app/signage/signage.service.ts
+++ b/frontend/src/app/signage/signage.service.ts
@@ -84,7 +84,6 @@ export class SignageService implements OnInit {
   fetchWeatherData() {
     fetchWeatherApi(url, params).then((responses) => {
       const response = responses[0];
-      const utcOffsetSeconds = response.utcOffsetSeconds();
       const current = response.current()!;
 
       // Process the weather data

--- a/frontend/src/app/signage/widgets/event-card/event-card.widget.ts
+++ b/frontend/src/app/signage/widgets/event-card/event-card.widget.ts
@@ -21,7 +21,7 @@ export class EventCardWidget implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['events']) {
-      this.shown_event %= this.events.length;
+      this.shown_event = 0;
     }
   }
 

--- a/frontend/src/app/signage/widgets/leaderboard/leaderboard.widget.ts
+++ b/frontend/src/app/signage/widgets/leaderboard/leaderboard.widget.ts
@@ -20,7 +20,7 @@ export class LeaderboardWidget implements OnChanges {
   /** Inputs and outputs go here */
   @Input() profiles: PublicProfile[] = []; // Should be a max of 10 elements
   shown_indicies: number[] = [
-    ...Array(this.profiles.length > 5 ? 5 : this.profiles.length).keys()
+    ...Array(Math.min(5, this.profiles.length)).keys()
   ];
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -31,7 +31,7 @@ export class LeaderboardWidget implements OnChanges {
     ) {
       // Only run this if there is less than 5 on the leaderboard right now
       this.shown_indicies = [
-        ...Array(this.profiles.length > 5 ? 5 : this.profiles.length).keys()
+        ...Array(Math.min(5, this.profiles.length)).keys()
       ];
     }
   }
@@ -40,9 +40,7 @@ export class LeaderboardWidget implements OnChanges {
     if (this.shown_indicies.includes(1)) {
       // Generates an array of numbers 5 to length of profile
       this.shown_indicies = [
-        ...Array(
-          this.profiles.length >= 10 ? 5 : this.profiles.length - 5
-        ).keys()
+        ...Array(Math.min(5, this.profiles.length - 5)).keys()
       ].map((i) => i + 5);
     } else {
       // At this point we can assume that the array is larger than 5 elements

--- a/frontend/src/app/signage/widgets/news-card/news-card.widget.ts
+++ b/frontend/src/app/signage/widgets/news-card/news-card.widget.ts
@@ -20,7 +20,7 @@ export class NewsCardWidget implements OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['articles']) {
-      this.shown_article %= this.articles.length;
+      this.shown_article = 0;
     }
   }
 


### PR DESCRIPTION
This intermediate signage PR changes the weather to use the CSXL conventions of signals instead of observables. This also reduced some complexity on the signage component level. This ended up revealing some race conditions on the `ngOnChanges` method of the slow data. The fix was found through deepseek and was simply setting the index to 0 on the change. Unfortunately this does mean that every 20 or so minutes when the slow data loads, all the slow widgets will reset off time with the spinners.