### PR TITLE
Reorder My-Courses

### DIFF
--- a/frontend/src/app/my-courses/my-courses-page/my-courses-page.component.html
+++ b/frontend/src/app/my-courses/my-courses-page/my-courses-page.component.html
@@ -23,8 +23,16 @@
         <h3 class="title-medium term-header">{{ term.name }}</h3>
         <div class="course-card-container">
           @for (course of term.sites; track course.id) {
-            <course-card [termId]="term.id" [course]="course" />
+            @if(course.role != "Student") {
+              <course-card [termId]="term.id" [course]="course" />
+            }
           }
+          @for (course of term.sites; track course.id) {
+            @if(course.role == "Student") {
+              <course-card [termId]="term.id" [course]="course" />
+            }
+          }
+
         </div>
       }
       @if (showPreviousCourses()) {
@@ -32,7 +40,14 @@
           <h3 class="title-medium term-header">{{ term.name }}</h3>
           <div class="course-card-container">
             @for (course of term.sites; track course.id) {
-              <course-card [course]="course" />
+              @if(course.role != "Student") {
+                <course-card [course]="course" />
+              }
+            }
+            @for (course of term.sites; track course.id) {
+              @if(course.role == "Student") {
+                <course-card [course]="course" />
+              }
             }
           </div>
         }

--- a/frontend/src/app/my-courses/my-courses-page/my-courses-page.component.html
+++ b/frontend/src/app/my-courses/my-courses-page/my-courses-page.component.html
@@ -22,22 +22,28 @@
     <mat-card-content>
       <mat-divider />
       @for (term of this.myCoursesService.currentTerms(); track term.id) {
-        <h2 class="title-medium term-header">{{ "Instructor Courses" }}</h2>
-        <div class="course-card-container">
-          @for (course of term.sites; track course.id) {
-            @if(course.role != "Student"){
-              <course-card [termId]="term.id" [course]="course" />
+
+        @if (hasInstructorCourses(term)) {
+          <h2 class="title-medium term-header">{{ "Instructor Courses" }}</h2>
+          <div class="course-card-container">
+            @for (course of term.sites; track course.id) {
+              @if(course.role != "Student") {
+                <course-card [termId]="term.id" [course]="course" />
+              }
             }
-          }
-        </div>
-        <h2 class="title-medium term-header">{{ "Student Courses" }}</h2>
-        <div class="course-card-container">
-          @for (course of term.sites; track course.id) {
-            @if(course.role == "Student"){
-              <course-card [termId]="term.id" [course]="course" />
+          </div>
+        }
+      
+        @if (hasStudentCourses(term)) {
+          <h2 class="title-medium term-header">{{ "Student Courses" }}</h2>
+          <div class="course-card-container">
+            @for (course of term.sites; track course.id) {
+              @if(course.role == "Student") {
+                <course-card [termId]="term.id" [course]="course" />
+              }
             }
-          }
-        </div>
+          </div>
+        }
       }
       @if (showPreviousCourses()) {
         @for (term of this.myCoursesService.pastTerms(); track term.id) {

--- a/frontend/src/app/my-courses/my-courses-page/my-courses-page.component.html
+++ b/frontend/src/app/my-courses/my-courses-page/my-courses-page.component.html
@@ -3,7 +3,9 @@
 <div class="container">  
   <mat-pane>
     <mat-card-header id="pane-header">
-      <mat-card-title>My Courses</mat-card-title>
+      @for (term of this.myCoursesService.currentTerms(); track term.name) {
+        <mat-card-title>{{term.name}}</mat-card-title>
+      }
       <div class="header-buttons">
         <button mat-stroked-button color="secondary" routerLink="/catalog/offerings">
           <!-- <mat-icon>search</mat-icon> -->
@@ -20,19 +22,21 @@
     <mat-card-content>
       <mat-divider />
       @for (term of this.myCoursesService.currentTerms(); track term.id) {
-        <h3 class="title-medium term-header">{{ term.name }}</h3>
+        <h2 class="title-medium term-header">{{ "Instructor Courses" }}</h2>
         <div class="course-card-container">
           @for (course of term.sites; track course.id) {
-            @if(course.role != "Student") {
+            @if(course.role != "Student"){
               <course-card [termId]="term.id" [course]="course" />
             }
           }
+        </div>
+        <h2 class="title-medium term-header">{{ "Student Courses" }}</h2>
+        <div class="course-card-container">
           @for (course of term.sites; track course.id) {
-            @if(course.role == "Student") {
+            @if(course.role == "Student"){
               <course-card [termId]="term.id" [course]="course" />
             }
           }
-
         </div>
       }
       @if (showPreviousCourses()) {
@@ -40,13 +44,13 @@
           <h3 class="title-medium term-header">{{ term.name }}</h3>
           <div class="course-card-container">
             @for (course of term.sites; track course.id) {
-              @if(course.role != "Student") {
-                <course-card [course]="course" />
+              @if(course.role != "Student"){
+              <course-card [course]="course" />
               }
             }
             @for (course of term.sites; track course.id) {
-              @if(course.role == "Student") {
-                <course-card [course]="course" />
+              @if(course.role == "Student"){
+              <course-card [course]="course" />
               }
             }
           </div>

--- a/frontend/src/app/my-courses/my-courses-page/my-courses-page.component.html
+++ b/frontend/src/app/my-courses/my-courses-page/my-courses-page.component.html
@@ -22,7 +22,6 @@
     <mat-card-content>
       <mat-divider />
       @for (term of this.myCoursesService.currentTerms(); track term.id) {
-
         @if (hasInstructorCourses(term)) {
           <h2 class="title-medium term-header">{{ "Instructor Courses" }}</h2>
           <div class="course-card-container">
@@ -33,7 +32,6 @@
             }
           </div>
         }
-      
         @if (hasStudentCourses(term)) {
           <h2 class="title-medium term-header">{{ "Student Courses" }}</h2>
           <div class="course-card-container">

--- a/frontend/src/app/my-courses/my-courses-page/my-courses-page.component.ts
+++ b/frontend/src/app/my-courses/my-courses-page/my-courses-page.component.ts
@@ -3,6 +3,7 @@ import { MyCoursesService } from '../my-courses.service';
 import { Router } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
 import { CreateCourseSiteDialog } from '../dialogs/create-course-site/create-course-site.dialog';
+import { TermOverview } from '../my-courses.model';
 
 @Component({
   selector: 'app-my-courses-page',
@@ -34,4 +35,16 @@ export class MyCoursesPageComponent {
       data: this.myCoursesService.allTerms()
     });
   }
+
+  /** Returns whether or not user has a non-student role in a course during a term */
+  hasInstructorCourses(term: TermOverview): boolean {
+    return term.sites.some(course => course.role !== 'Student');
+  }
+  
+    /** Returns whether or not user has a student role in a course during a term */
+  hasStudentCourses(term: TermOverview): boolean {
+    return term.sites.some(course => course.role === 'Student');
+  }
 }
+
+


### PR DESCRIPTION
This PR solves the problem of inconsistencies with the order of courses on the my-courses page. This is typically an issue for TAs who have both types of courses, and the original idea was to simply have admin courses always appear first. However, the idea to mirror the GradeScope design of separating the two seemed plausible due to the amount of free space on the page.

### Changes
- Created two functions `hasInstructorCourses(term)` and `hasStudentCourses(term)` that return true or false based on if a user has at least one type of that course in the provided term.
- In the HTML, the functions are called for each type with the corresponding headers and course cards being displayed if necessary.
- Replaced duplicated "My Courses" title with the current term.
- Past courses are updated to simply list admin courses first rather than mirroring the GradeScope format.

### Testing
- Demo course data adjusted to create different scenarios of users with only instructor courses, student courses, and both types. Those changes were not pushed (I believe the OH Chime PR also adjusted the file).

#### TA with both
![Screenshot 2025-02-16 at 4 15 12 PM](https://github.com/user-attachments/assets/23b01d81-fe4d-48d8-9223-a269ece487b7)

#### Instructor with no student courses 
![Screenshot 2025-02-16 at 4 15 58 PM](https://github.com/user-attachments/assets/d84a3b2d-6a06-4a09-bb8f-5af23573a057)

#### Student with no instructor courses
![Screenshot 2025-02-16 at 4 34 46 PM](https://github.com/user-attachments/assets/e1a1ef72-8c4c-474d-9488-78cbbcb4dd61)



