### PR TITLE
Add simple proof of concept WebSocket test for production purposes

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -10,6 +10,8 @@ http://localhost:1560
 
 reverse_proxy /api http://localhost:1561
 reverse_proxy /api/* http://localhost:1561
+reverse_proxy /ws http://localhost:1561
+reverse_proxy /ws/* http://localhost:1561
 reverse_proxy /docs http://localhost:1561
 reverse_proxy /docs/* http://localhost:1561
 reverse_proxy /auth http://localhost:1561

--- a/backend/api/websocket.py
+++ b/backend/api/websocket.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter
+from starlette.types import Scope, Receive, Send
+from fastapi.websockets import WebSocket, WebSocketDisconnect
+from starlette.middleware.base import BaseHTTPMiddleware
+
+
+class WebSocketMiddleware(BaseHTTPMiddleware):
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:  # type: ignore
+        if scope["type"] == "websocket":
+            websocket = WebSocket(scope, receive=receive, send=send)
+            await websocket.accept()
+        else:
+            return await super().__call__(scope, receive, send)
+
+
+api = APIRouter(prefix="/ws")
+
+
+@api.websocket("/echo")
+async def echo(websocket: WebSocket):
+    await websocket.accept()
+
+    try:
+        while True:
+            message = await websocket.receive_json()
+            await websocket.send_json({"type": "echo", "data": message})
+    except WebSocketDisconnect:
+        ...

--- a/backend/main.py
+++ b/backend/main.py
@@ -19,6 +19,7 @@ from .api import (
     room,
     application,
     article,
+    websocket,
 )
 from .api.coworking import status, reservation, ambassador, operating_hours
 from .api.academics import section_member, term, course, section, my_courses, hiring
@@ -100,6 +101,7 @@ feature_apis = [
     hiring,
     admin_facts,
     article,
+    websocket,
 ]
 
 for feature_api in feature_apis:
@@ -107,6 +109,9 @@ for feature_api in feature_apis:
 
 # Static file mount used for serving Angular front-end in production, as well as static assets
 app.mount("/", static_files.StaticFileMiddleware(directory=Path("./static")))
+
+# Register WebSocket middleware
+app.mount("/", websocket.WebSocketMiddleware)
 
 
 # Add application-wide exception handling middleware for commonly encountered API Exceptions

--- a/frontend/src/app/about/about.component.ts
+++ b/frontend/src/app/about/about.component.ts
@@ -1,18 +1,41 @@
-import { Component } from '@angular/core';
+import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
+import { Component, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { SlackInviteBox } from '../navigation/widgets/slack-invite-box/slack-invite-box.widget';
+import { Subscription } from 'rxjs';
+
 @Component({
   selector: 'app-about',
   templateUrl: './about.component.html'
 })
-export class AboutComponent {
+export class AboutComponent implements OnInit, OnDestroy {
+  private socket$: WebSocketSubject<any>;
+  private socketSubscription?: Subscription;
+
   public static Route = {
     path: 'about',
     title: 'About the XL',
     component: AboutComponent
   };
 
-  constructor(protected dialog: MatDialog) {}
+  constructor(protected dialog: MatDialog) {
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
+    const url = `${protocol}://${window.location.host}/ws/echo`;
+    this.socket$ = webSocket({ url });
+  }
+
+  ngOnInit(): void {
+    let counter = 0;
+    this.socketSubscription = this.socket$.subscribe((message) => {
+      console.log(`Received: ${message}`);
+      setTimeout(() => this.socket$.next(`counter: ${counter++}`), 1000);
+    });
+    this.socket$.next('onInit');
+  }
+
+  ngOnDestroy(): void {
+    this.socketSubscription?.unsubscribe();
+  }
 
   onSlackInviteClick(): void {
     const dialogRef = this.dialog.open(SlackInviteBox, {


### PR DESCRIPTION
Extracting (and slightly refactoring) WebSocket example from your larger PR to be sure connections still work through the ONYEN login proxy we sit behind. Going to deploy this now.

If this works, I believe the primary change needed in #634 is going to be extracting WebSocket concerns out of the StaticFilesMiddleware.

Additionally, we can base `ws`/`wss` on the protocol of the window's location so that we have working connections in both prod and dev.