### PR TITLE
Task/710-ticket-history: Implement Ticket History 

### DIFF
--- a/backend/api/academics/my_courses.py
+++ b/backend/api/academics/my_courses.py
@@ -2,10 +2,13 @@
 
 APIs relative to a specific user."""
 
+import json
 from fastapi import APIRouter, Depends
 from ..authentication import registered_user
 from ...services.academics.course_site import CourseSiteService
-
+from ...services.office_hours.office_hours_statistics import (
+    OfficeHoursStatisticsService,
+)
 from ...models.user import User
 
 from ...models.academics.my_courses import (
@@ -13,6 +16,7 @@ from ...models.academics.my_courses import (
     CourseMemberOverview,
     OfficeHoursOverview,
     CourseSiteOverview,
+    OfficeHourTicketOverview,
 )
 from ...models.office_hours.course_site import (
     NewCourseSite,
@@ -20,7 +24,7 @@ from ...models.office_hours.course_site import (
     UpdatedCourseSite,
 )
 from ...models.office_hours.course_site_details import CourseSiteDetails
-from ...models.pagination import PaginationParams, Paginated
+from ...models.pagination import PaginationParams, Paginated, TicketPaginationParams
 
 __authors__ = ["Kris Jordan", "Ajay Gandecha"]
 __copyright__ = "Copyright 2024"
@@ -177,3 +181,36 @@ def update_course_site(
         CourseSite: Course updated
     """
     return course_site_svc.update(subject, course_site)
+
+
+@api.get("/{course_site_id}/statistics/ticket-history", tags=["My Courses"])
+def get_paginated_ticket_history(
+    course_site_id: int,
+    page: int = 0,
+    page_size: int = 10,
+    student_ids: str = "",
+    staff_ids: str = "",
+    range_start: str = "",
+    range_end: str = "",
+    subject: User = Depends(registered_user),
+    oh_statistics_svc: OfficeHoursStatisticsService = Depends(),
+) -> Paginated[OfficeHourTicketOverview]:
+    """
+    Gets the past office hour event overviews for a given class.
+
+    Returns:
+        Paginated[OfficeHoursOverview]
+    """
+
+    ticket_pagination_params = TicketPaginationParams(
+        page=page,
+        page_size=page_size,
+        student_ids=json.loads(student_ids) if len(student_ids) > 0 else [],
+        staff_ids=json.loads(staff_ids) if len(staff_ids) > 0 else [],
+        range_start=range_start,
+        range_end=range_end,
+    )
+
+    return oh_statistics_svc.get_paginated_tickets(
+        subject, course_site_id, ticket_pagination_params
+    )

--- a/backend/entities/office_hours/ticket_entity.py
+++ b/backend/entities/office_hours/ticket_entity.py
@@ -8,6 +8,7 @@ from ...models.office_hours.ticket_state import TicketState
 from ...models.office_hours.ticket_type import TicketType
 from ...models.office_hours.ticket import OfficeHoursTicket, NewOfficeHoursTicket
 from ...models.office_hours.ticket_details import OfficeHoursTicketDetails
+from ...models.academics.my_courses import OfficeHourTicketOverview
 from .user_created_tickets_table import user_created_tickets_table
 
 
@@ -137,6 +138,18 @@ class OfficeHoursTicketEntity(EntityBase):
             caller_notes=self.caller_notes,
             office_hours_id=self.office_hours_id,
             caller_id=self.caller_id,
+        )
+
+    def to_overview_model(self) -> OfficeHourTicketOverview:
+        return OfficeHourTicketOverview(
+            id=self.id,
+            created_at=self.created_at,
+            called_at=self.called_at,
+            state=self.state.to_string(),
+            type=self.type.to_string(),
+            description=self.description,
+            creators=[creator.user.to_public_model() for creator in self.creators],
+            caller=(self.caller.user.to_public_model() if self.caller else None),
         )
 
     def to_details_model(self) -> OfficeHoursTicketDetails:

--- a/backend/models/pagination.py
+++ b/backend/models/pagination.py
@@ -19,6 +19,15 @@ class PaginationParams(BaseModel):
     filter: str = ""
 
 
+class TicketPaginationParams(PaginationParams):
+    """Parameters passed from the client to paginate ticket results."""
+
+    range_start: str = ""
+    range_end: str = ""
+    student_ids: list[int]
+    staff_ids: list[int]
+
+
 class EventPaginationParams(PaginationParams):
     """Parameters passed from the client to paginate event results."""
 

--- a/backend/services/office_hours/__init__.py
+++ b/backend/services/office_hours/__init__.py
@@ -1,3 +1,4 @@
 from .office_hours import OfficeHoursService
 from .office_hours_recurrence import OfficeHoursRecurrenceService
 from .ticket import OfficeHourTicketService
+from .office_hours_statistics import OfficeHoursStatisticsService

--- a/backend/services/office_hours/office_hours_statistics.py
+++ b/backend/services/office_hours/office_hours_statistics.py
@@ -69,8 +69,9 @@ class OfficeHoursStatisticsService:
             range_start = pagination_params.range_start
             range_end = pagination_params.range_end
             criteria = and_(
-                OfficeHoursTicketEntity.start >= datetime.fromisoformat(range_start),
-                OfficeHoursTicketEntity.start <= datetime.fromisoformat(range_end),
+                OfficeHoursTicketEntity.created_at
+                >= datetime.fromisoformat(range_start),
+                OfficeHoursTicketEntity.created_at <= datetime.fromisoformat(range_end),
             )
             statement = statement.where(criteria)
             length_statement = length_statement.where(criteria)

--- a/backend/services/office_hours/office_hours_statistics.py
+++ b/backend/services/office_hours/office_hours_statistics.py
@@ -1,0 +1,112 @@
+from datetime import datetime
+from fastapi import Depends
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from sqlalchemy import func, select, and_, func
+
+from ...entities.academics.section_member_entity import SectionMemberEntity
+from ...entities.office_hours import user_created_tickets_table
+from ...entities.office_hours.course_site_entity import CourseSiteEntity
+from ...entities.office_hours.office_hours_entity import OfficeHoursEntity
+
+from ...database import db_session
+
+from ...entities.office_hours.ticket_entity import OfficeHoursTicketEntity
+from ...models.pagination import Paginated, TicketPaginationParams
+from ...models.user import User
+from ...models.academics.my_courses import OfficeHourTicketOverview
+from ...services.office_hours.office_hours import OfficeHoursService
+
+
+__authors__ = ["Ajay Gandecha", "Jade Keegan"]
+__copyright__ = "Copyright 2025"
+__license__ = "MIT"
+
+
+class OfficeHourStatisticsService:
+    """
+    Service that performs all of the actions for office hour tickets.
+    """
+
+    def __init__(
+        self,
+        session: Session = Depends(db_session),
+        _office_hours_svc: OfficeHoursService = Depends(),
+    ):
+        """
+        Initializes the database session.
+        """
+        self._session = session
+        self._office_hours_svc = _office_hours_svc
+
+    def get_paginated_ticket_history(
+        self, user: User, site_id: int, pagination_params: TicketPaginationParams
+    ) -> list[OfficeHourTicketOverview]:
+        # Check permissions
+        self._office_hours_svc._check_site_admin_permissions(user, site_id)
+
+        statement = (
+            select(OfficeHoursTicketEntity)
+            .join(OfficeHoursEntity)
+            .join(CourseSiteEntity)
+            .where(CourseSiteEntity.id == site_id)
+        )
+
+        length_statement = (
+            select(func.count())
+            .select_from(OfficeHoursTicketEntity)
+            .join(OfficeHoursEntity)
+            .join(CourseSiteEntity)
+            .where(CourseSiteEntity.id == site_id)
+        )
+
+        # Filter by Start/End Range
+        if pagination_params.range_start != "":
+            range_start = pagination_params.range_start
+            range_end = pagination_params.range_end
+            criteria = and_(
+                OfficeHoursTicketEntity.start >= datetime.fromisoformat(range_start),
+                OfficeHoursTicketEntity.start <= datetime.fromisoformat(range_end),
+            )
+            statement = statement.where(criteria)
+            length_statement = length_statement.where(criteria)
+
+        # Filter by student who created ticket
+        if pagination_params.student_ids.length != 0:
+            statement = (
+                statement.join(user_created_tickets_table)
+                .join(SectionMemberEntity)
+                .where(SectionMemberEntity.user_id.in_(pagination_params.student_ids))
+            )
+            length_statement = (
+                length_statement.join(user_created_tickets_table)
+                .join(SectionMemberEntity)
+                .where(SectionMemberEntity.user_id.in_(pagination_params.student_ids))
+            )
+
+        # Filter by staff member who called ticket
+        if pagination_params.staff_ids.length != 0:
+            statement = statement.where(
+                OfficeHoursTicketEntity.caller_id.in_(pagination_params.student_ids)
+            )
+            length_statement = length_statement.where(
+                OfficeHoursTicketEntity.caller_id.in_(pagination_params.student_ids)
+            )
+
+        # Calculate where to begin retrieving rows and how many to retrieve
+        offset = pagination_params.page * pagination_params.page_size
+        limit = pagination_params.page_size
+
+        # Retrieve limited items
+        statement = statement.offset(offset).limit(limit)
+
+        # Execute statement and retrieve entities
+        length = self._session.execute(length_statement).scalar()
+        entities = self._session.execute(statement).scalars()
+
+        # Convert `UserEntity`s to model and return page
+        return Paginated(
+            items=[entity.to_overview_model() for entity in entities],
+            length=length,
+            params=pagination_params,
+        )

--- a/backend/services/office_hours/ticket.py
+++ b/backend/services/office_hours/ticket.py
@@ -95,7 +95,7 @@ class OfficeHourTicketService:
         self._session.commit()
 
         # Return the changed ticket
-        return self._to_oh_ticket_overview(ticket_entity)
+        return ticket_entity.to_overview_model()
 
     def cancel_ticket(self, user: User, ticket_id: int) -> OfficeHourTicketOverview:
         """
@@ -140,7 +140,7 @@ class OfficeHourTicketService:
         self._session.commit()
 
         # Return the changed ticket
-        return self._to_oh_ticket_overview(ticket_entity)
+        return ticket_entity.to_overview_model()
 
     def close_ticket(self, user: User, ticket_id: int) -> OfficeHourTicketOverview:
         """
@@ -189,7 +189,7 @@ class OfficeHourTicketService:
         self._session.commit()
 
         # Return the changed ticket
-        return self._to_oh_ticket_overview(ticket_entity)
+        return ticket_entity.to_overview_model()
 
     def create_ticket(
         self, user: User, ticket: NewOfficeHoursTicket
@@ -281,4 +281,4 @@ class OfficeHourTicketService:
         self._session.commit()
 
         # Return details model
-        return self._to_oh_ticket_overview(oh_ticket_entity)
+        return oh_ticket_entity.to_overview_model()

--- a/backend/services/office_hours/ticket.py
+++ b/backend/services/office_hours/ticket.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.orm import Session
+
 from ...database import db_session
 from ...models.user import User
 from ...models.academics.section_member import RosterRole
@@ -15,7 +16,6 @@ from ...models.academics.my_courses import (
 from ...models.office_hours.ticket import (
     TicketState,
     NewOfficeHoursTicket,
-    OfficeHoursTicket,
 )
 
 from ...entities.academics.section_entity import SectionEntity
@@ -43,20 +43,6 @@ class OfficeHourTicketService:
         Initializes the database session.
         """
         self._session = session
-
-    def _to_oh_ticket_overview(
-        self, ticket: OfficeHoursTicketEntity
-    ) -> OfficeHourTicketOverview:
-        return OfficeHourTicketOverview(
-            id=ticket.id,
-            created_at=ticket.created_at,
-            called_at=ticket.called_at,
-            state=ticket.state.to_string(),
-            type=ticket.type.to_string(),
-            description=ticket.description,
-            creators=[creator.user.to_public_model() for creator in ticket.creators],
-            caller=(ticket.caller.user.to_public_model() if ticket.caller else None),
-        )
 
     def call_ticket(self, user: User, ticket_id: int) -> OfficeHourTicketOverview:
         """

--- a/backend/test/services/office_hours/fixtures.py
+++ b/backend/test/services/office_hours/fixtures.py
@@ -8,7 +8,11 @@ from ....services.office_hours.office_hours_recurrence import (
     OfficeHoursRecurrenceService,
 )
 from ....services import PermissionService
-from ....services.office_hours import OfficeHourTicketService, OfficeHoursService
+from ....services.office_hours import (
+    OfficeHourTicketService,
+    OfficeHoursService,
+    OfficeHoursStatisticsService,
+)
 
 __authors__ = ["Meghan Sun", "Jade Keegan"]
 __copyright__ = "Copyright 2024"
@@ -43,3 +47,9 @@ def oh_ticket_svc(session: Session):
 def oh_recurrence_svc(session: Session):
     """OfficeHoursRecurrenceService fixture."""
     return OfficeHoursRecurrenceService(session, OfficeHoursService(session))
+
+
+@pytest.fixture()
+def oh_statistics_svc(session: Session):
+    """OfficeHoursStatisticsService fixture."""
+    return OfficeHoursStatisticsService(session, OfficeHoursService(session))

--- a/backend/test/services/office_hours/office_hours_statistics_test.py
+++ b/backend/test/services/office_hours/office_hours_statistics_test.py
@@ -1,0 +1,50 @@
+"""Tests for the OfficeHoursStatisticsService."""
+
+import pytest
+
+from ....services.exceptions import (
+    CoursePermissionException,
+    RecurringOfficeHourEventException,
+    ResourceNotFoundException,
+)
+
+from ....services.office_hours import OfficeHoursStatisticsService
+from ....models.pagination import TicketPaginationParams
+
+# Imported fixtures provide dependencies injected for the tests as parameters.
+from .fixtures import oh_statistics_svc
+
+# Import the setup_teardown fixture explicitly to load entities in database
+from ..core_data import setup_insert_data_fixture as insert_order_0
+from ..academics.term_data import fake_data_fixture as insert_order_1
+from ..academics.course_data import fake_data_fixture as insert_order_2
+from ..academics.section_data import fake_data_fixture as insert_order_3
+from ..room_data import fake_data_fixture as insert_order_4
+from ..office_hours.office_hours_data import fake_data_fixture as insert_order_5
+from ..event.event_demo_data import date_maker
+
+# Important fake model data in namespace for test assertions
+from .. import user_data
+from ..office_hours import office_hours_data
+
+__authors__ = ["Jade Keegan", "Ajay Gandecha"]
+__copyright__ = "Copyright 2025"
+__license__ = "MIT"
+
+
+def test_get_paginated_tickets(oh_statistics_svc: OfficeHoursStatisticsService):
+    """Ensures that users with the appropriate site permissions can get paginated tickets."""
+    ticket_params = TicketPaginationParams(
+        range_start="",
+        range_end="",
+        student_ids=[],
+        staff_ids=[],
+    )
+
+    ticket_history = oh_statistics_svc.get_paginated_tickets(
+        user_data.instructor,
+        office_hours_data.comp_110_site.id,
+        ticket_params,
+    )
+
+    assert len(ticket_history.items) == 1

--- a/backend/test/services/office_hours/office_hours_statistics_test.py
+++ b/backend/test/services/office_hours/office_hours_statistics_test.py
@@ -48,3 +48,88 @@ def test_get_paginated_tickets(oh_statistics_svc: OfficeHoursStatisticsService):
     )
 
     assert len(ticket_history.items) == 1
+
+
+def test_get_paginated_tickets_student_filter(
+    oh_statistics_svc: OfficeHoursStatisticsService,
+):
+    """Ensures that filtering by student works correctly."""
+    ticket_params = TicketPaginationParams(
+        range_start="",
+        range_end="",
+        student_ids=[user_data.student.id],
+        staff_ids=[],
+    )
+
+    ticket_history = oh_statistics_svc.get_paginated_tickets(
+        user_data.instructor,
+        office_hours_data.comp_110_site.id,
+        ticket_params,
+    )
+
+    assert (
+        len(ticket_history.items) == 1
+        and ticket_history.items[0].creators[0].id == user_data.student.id
+    )
+
+
+def test_get_paginated_tickets_staff_filter(
+    oh_statistics_svc: OfficeHoursStatisticsService,
+):
+    """Ensures that filtering by staff works correctly."""
+    ticket_params = TicketPaginationParams(
+        range_start="",
+        range_end="",
+        student_ids=[],
+        staff_ids=[user_data.instructor.id],
+    )
+
+    ticket_history = oh_statistics_svc.get_paginated_tickets(
+        user_data.instructor,
+        office_hours_data.comp_110_site.id,
+        ticket_params,
+    )
+
+    assert (
+        len(ticket_history.items) == 1
+        and ticket_history.items[0].caller.id == user_data.instructor.id
+    )
+
+
+def test_get_paginated_tickets_date_filter(
+    oh_statistics_svc: OfficeHoursStatisticsService,
+):
+    """Ensures that filtering by date works correctly."""
+    ticket_params = TicketPaginationParams(
+        range_start=date_maker(-2, 0, 0).isoformat(),
+        range_end=date_maker(1, 0, 0).isoformat(),
+        student_ids=[],
+        staff_ids=[],
+    )
+
+    ticket_history = oh_statistics_svc.get_paginated_tickets(
+        user_data.instructor,
+        office_hours_data.comp_110_site.id,
+        ticket_params,
+    )
+
+    assert len(ticket_history.items) == 1
+
+
+def test_get_paginated_tickets_unauthenticated(
+    oh_statistics_svc: OfficeHoursStatisticsService,
+):
+    """Ensures that filtering by date works correctly."""
+    ticket_params = TicketPaginationParams(
+        range_start="",
+        range_end="",
+        student_ids=[],
+        staff_ids=[],
+    )
+
+    with pytest.raises(CoursePermissionException):
+        oh_statistics_svc.get_paginated_tickets(
+            user_data.student,
+            office_hours_data.comp_110_site.id,
+            ticket_params,
+        )

--- a/backend/test/services/office_hours/office_hours_statistics_test.py
+++ b/backend/test/services/office_hours/office_hours_statistics_test.py
@@ -133,3 +133,23 @@ def test_get_paginated_tickets_unauthenticated(
             office_hours_data.comp_110_site.id,
             ticket_params,
         )
+
+
+def test_get_paginated_tickets_multiple_filters(
+    oh_statistics_svc: OfficeHoursStatisticsService,
+):
+    """Ensures that multiple filters can be applied at the same time."""
+    ticket_params = TicketPaginationParams(
+        range_start=date_maker(-2, 0, 0).isoformat(),
+        range_end=date_maker(1, 0, 0).isoformat(),
+        student_ids=[user_data.student.id],
+        staff_ids=[user_data.instructor.id],
+    )
+
+    ticket_history = oh_statistics_svc.get_paginated_tickets(
+        user_data.instructor,
+        office_hours_data.comp_110_site.id,
+        ticket_params,
+    )
+
+    assert len(ticket_history.items) == 1

--- a/backend/test/services/office_hours/office_hours_test.py
+++ b/backend/test/services/office_hours/office_hours_test.py
@@ -119,7 +119,7 @@ def test_get_oh_event_role_not_member(oh_svc: OfficeHoursService):
 
 
 def test_create_oh_event_instructor(oh_svc: OfficeHoursService):
-    """Ensures that instructors can create office hour events."""
+    """Ensures that instructrors can create office hour events."""
     new_event = oh_svc.create(
         user_data.instructor,
         office_hours_data.comp_110_site.id,


### PR DESCRIPTION
This pull request implements the API and necessary models to retrieve paginated tickets for a course site. This data will be ultimately shown in the new "statistics" view for courses.

## Testing
1. Run the backend tests as outlined in the [testing doc](https://github.com/unc-csxl/csxl.unc.edu/blob/main/docs/testing.md) and confirm that all tests are passing.
2. On the local server, auth as Ina Instructor.
3. Go to the profile page and copy the bearer token.
4. Open the `localhost:1560/docs` page. 
5. Find the API route for statistics. It should be under the "My Courses" tag with the route `/{course_site_id}/statistics/ticket-history`.
6. Ensure that the API route returns the correct tickets based on any combination of date range, student ID, and staff ID filters.
- Note that student IDs and staff IDs are being input as STRINGIFIED LISTS. So, if you want to filter by students with ID 4 and 5, you would put in the string "[4,5]".
- Dates should also be input as strings. You can get an existing ticket to see what format the date string is expected to be in.

## Developer Notes
@mimo2025 and @leferlito, this PR also implements the pagination model (`TicketPaginationParams`) and `OfficeHoursStatisticsService` which can be used in #692.

All backend tests pass with 100% coverage.

*Closes #710*