### PR TITLE
(task:713) Implement Material Dropdown Filter Chip

### DIFF
--- a/frontend/src/app/my-courses/course/course.component.ts
+++ b/frontend/src/app/my-courses/course/course.component.ts
@@ -21,6 +21,7 @@ import {
 } from '../my-courses.model';
 import { map } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
+import { NagivationAdminGearService } from 'src/app/navigation/navigation-admin-gear.service';
 
 @Component({
   selector: 'app-course',
@@ -38,6 +39,11 @@ export class CourseComponent {
           label: 'Office Hours',
           path: `/course/${this.route.snapshot.params['course_site_id']}/office-hours`,
           icon: 'person_raised_hand'
+        },
+        {
+          label: 'Statistics',
+          path: `/course/${this.route.snapshot.params['course_site_id']}/statistics`,
+          icon: 'analytics'
         },
         {
           label: 'Roster',
@@ -69,7 +75,8 @@ export class CourseComponent {
   constructor(
     private route: ActivatedRoute,
     protected myCoursesService: MyCoursesService,
-    protected http: HttpClient
+    protected http: HttpClient,
+    protected gearService: NagivationAdminGearService
   ) {
     let id = +this.route.snapshot.params['course_site_id'];
     this.http
@@ -81,6 +88,13 @@ export class CourseComponent {
             ?.role == 'Instructor';
 
         this.isInstructor.set(isInstructor);
+
+        if (isInstructor) {
+          this.gearService.showAdminGear(
+            'Course Settings',
+            `/course/${id}/settings`
+          );
+        }
       });
   }
 }

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.css
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.css
@@ -1,0 +1,33 @@
+::ng-deep .mat-pane {
+    margin-right: 32px !important;
+}
+
+.container {
+    height: 100%;
+
+    ::ng-deep .mat-pane {
+        max-width: 100% !important;
+        min-height: 73vh;
+        margin-bottom: 32px !important;
+    }
+}
+
+.mat-mdc-card-header {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding-bottom: 16px;
+}
+
+.ticket-history-toolbar {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+}
+
+.ticket-history-toolbar-options {
+    display: flex;
+    flex-direction: row;
+    gap: 16px;
+}

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -8,7 +8,12 @@
         <div class="ticket-history-toolbar">
           <mat-card-subtitle>Happening Now</mat-card-subtitle>
           <div class="ticket-history-toolbar-options">
-            <mat-filter-chip dropdownAlignment="right">Test</mat-filter-chip>
+            <mat-filter-chip
+              placeholder="Filter"
+              leadingIcon="person_raised_hand"
+              dropdownAlignment="right" 
+              [searchableItems]="[{displayText: 'Item 1', item: 'item1'}, {displayText: 'Item 2', item: 'item2'}, {displayText: 'Item 3', item: 'item3'}]"
+            />
           </div>
         </div>
       </mat-card-content>

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -1,0 +1,18 @@
+<div class="container">
+    <mat-pane>
+      <mat-card-header>
+        <mat-card-title>Statistics</mat-card-title>
+        <mat-divider />
+      </mat-card-header>
+      <mat-card-content>
+        <div class="ticket-history-toolbar">
+          <mat-card-subtitle>Happening Now</mat-card-subtitle>
+          <div class="ticket-history-toolbar-options">
+            <mat-chip>Open</mat-chip>
+            <mat-chip>Open</mat-chip>
+            <mat-chip>Open</mat-chip>
+          </div>
+        </div>
+      </mat-card-content>
+    </mat-pane> 
+</div>

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -8,9 +8,7 @@
         <div class="ticket-history-toolbar">
           <mat-card-subtitle>Happening Now</mat-card-subtitle>
           <div class="ticket-history-toolbar-options">
-            <mat-chip>Open</mat-chip>
-            <mat-chip>Open</mat-chip>
-            <mat-chip>Open</mat-chip>
+            <mat-filter-chip dropdownAlignment="right">Test</mat-filter-chip>
           </div>
         </div>
       </mat-card-content>

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -11,8 +11,9 @@
             <mat-filter-chip
               placeholder="Filter"
               leadingIcon="person_raised_hand"
-              dropdownAlignment="right" 
+              dropdownAlignment="right"
               [searchableItems]="[{displayText: 'Item 1', item: 'item1'}, {displayText: 'Item 2', item: 'item2'}, {displayText: 'Item 3', item: 'item3'}, {displayText: 'Item 4', item: 'item4'}, {displayText: 'Item 5', item: 'item5'}]"
+              [filterLogic]="filterLogic"
             />
           </div>
         </div>

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -12,7 +12,7 @@
               placeholder="Filter"
               leadingIcon="person_raised_hand"
               dropdownAlignment="right" 
-              [searchableItems]="[{displayText: 'Item 1', item: 'item1'}, {displayText: 'Item 2', item: 'item2'}, {displayText: 'Item 3', item: 'item3'}]"
+              [searchableItems]="[{displayText: 'Item 1', item: 'item1'}, {displayText: 'Item 2', item: 'item2'}, {displayText: 'Item 3', item: 'item3'}, {displayText: 'Item 4', item: 'item4'}, {displayText: 'Item 5', item: 'item5'}]"
             />
           </div>
         </div>

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.ts
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.ts
@@ -1,0 +1,24 @@
+/**
+ * The Roster Component enables instructors to view the roster of their courses.
+ *
+ * @author Ajay Gandecha <agandecha@unc.edu>
+ * @author Jade Keegan
+ * @copyright 2024
+ * @license MIT
+ */
+
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-statistics',
+  templateUrl: './statistics.component.html',
+  styleUrl: './statistics.component.css'
+})
+export class StatisticsComponent {
+  /** Route information to be used in the routing module */
+  public static Route = {
+    path: 'statistics',
+    title: 'Course',
+    component: StatisticsComponent
+  };
+}

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.ts
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.ts
@@ -8,6 +8,7 @@
  */
 
 import { Component } from '@angular/core';
+import { MatFilterChipFilterLogic } from 'src/app/shared/mat/filter-chip/filter-chip.component';
 
 @Component({
   selector: 'app-statistics',
@@ -20,5 +21,9 @@ export class StatisticsComponent {
     path: 'statistics',
     title: 'Course',
     component: StatisticsComponent
+  };
+
+  filterLogic: MatFilterChipFilterLogic<string> = (item, query) => {
+    return item.displayText.toLowerCase().includes(query.toLowerCase());
   };
 }

--- a/frontend/src/app/my-courses/my-courses-routing.module.ts
+++ b/frontend/src/app/my-courses/my-courses-routing.module.ts
@@ -20,6 +20,7 @@ import { OfficeHoursQueueComponent } from './course/office-hours/office-hours-qu
 import { OfficeHoursGetHelpComponent } from './course/office-hours/office-hours-get-help/office-hours-get-help.component';
 import { SettingsComponent } from './course/settings/settings.component';
 import { OfficeHoursEditorComponent } from './course/office-hours/office-hours-editor/office-hours-editor.component';
+import { StatisticsComponent } from './course/statistics/statistics.component';
 
 const routes: Routes = [
   MyCoursesPageComponent.Route,
@@ -37,7 +38,8 @@ const routes: Routes = [
       OfficeHoursPageComponent.Route,
       OfficeHoursQueueComponent.Route,
       OfficeHoursGetHelpComponent.Route,
-      OfficeHoursEditorComponent.Route
+      OfficeHoursEditorComponent.Route,
+      StatisticsComponent.Route
     ]
   }
 ];

--- a/frontend/src/app/my-courses/my-courses.module.ts
+++ b/frontend/src/app/my-courses/my-courses.module.ts
@@ -52,6 +52,7 @@ import { MatNativeDateModule } from '@angular/material/core';
 import { DeleteRecurringEventDialog } from './dialogs/delete-recurring-event/delete-recurring-event.dialog';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatCheckbox } from '@angular/material/checkbox';
+import { StatisticsComponent } from './course/statistics/statistics.component';
 
 @NgModule({
   declarations: [
@@ -66,6 +67,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
     OfficeHoursGetHelpComponent,
     OfficeHoursEditorComponent,
     SettingsComponent,
+    StatisticsComponent,
     CourseCardWidget,
     OfficeHourEventCardWidget,
     CalledTicketCardWidget,

--- a/frontend/src/app/my-courses/my-courses.service.ts
+++ b/frontend/src/app/my-courses/my-courses.service.ts
@@ -39,6 +39,7 @@ import {
   NewOfficeHoursRecurrencePattern
 } from './my-courses.model';
 import { Observable, map } from 'rxjs';
+import { NagivationAdminGearService } from '../navigation/navigation-admin-gear.service';
 
 /** Enum for days of the week */
 export enum Weekday {
@@ -92,7 +93,8 @@ export class MyCoursesService {
   /** Constructor */
   constructor(
     protected http: HttpClient,
-    protected snackBar: MatSnackBar
+    protected snackBar: MatSnackBar,
+    protected gearService: NagivationAdminGearService
   ) {
     this.getTermOverviews();
   }

--- a/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.css
+++ b/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.css
@@ -1,8 +1,11 @@
 
 .dialog {
     padding-top: 0;
+    padding-left: 8px;
+    padding-right: 8px;
 }
 
 .search-field {
     width: 100%;
+    margin-bottom: -1.25em;
 }

--- a/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.css
+++ b/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.css
@@ -1,0 +1,8 @@
+
+.dialog {
+    padding-top: 0;
+}
+
+.search-field {
+    width: 100%;
+}

--- a/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.html
+++ b/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.html
@@ -1,0 +1,8 @@
+<mat-dialog-content class="dialog surface-container-high">
+    <mat-form-field class="search-field">
+        <input matInput type="text">
+          <button matSuffix mat-icon-button aria-label="Clear">
+            <mat-icon>close</mat-icon>
+          </button>
+      </mat-form-field>
+</mat-dialog-content>

--- a/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.html
+++ b/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.html
@@ -1,12 +1,12 @@
+<mat-form-field class="search-field">
+  <input matInput type="text" [(ngModel)]="searchQuery">
+    <button matSuffix mat-icon-button (click)="onQueryClear()">
+      <mat-icon>close_small</mat-icon>
+    </button>
+</mat-form-field>
 <mat-dialog-content class="dialog surface-container-high">
-    <mat-form-field class="search-field">
-        <input matInput type="text">
-          <button matSuffix mat-icon-button>
-            <mat-icon>close</mat-icon>
-          </button>
-      </mat-form-field>
       <mat-selection-list #list (selectionChange)="onSelectionChange(list.selectedOptions.selected)">
-        @for(item of searchableItems; track item) {
+        @for(item of searchResults(); track item) {
             <mat-list-option togglePosition="before" [value]="item">
                 {{ item.displayText }}
             </mat-list-option>

--- a/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.html
+++ b/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.html
@@ -1,8 +1,15 @@
 <mat-dialog-content class="dialog surface-container-high">
     <mat-form-field class="search-field">
         <input matInput type="text">
-          <button matSuffix mat-icon-button aria-label="Clear">
+          <button matSuffix mat-icon-button>
             <mat-icon>close</mat-icon>
           </button>
       </mat-form-field>
+      <mat-selection-list #list (selectionChange)="onSelectionChange(list.selectedOptions.selected)">
+        @for(item of searchableItems; track item) {
+            <mat-list-option togglePosition="before" [value]="item">
+                {{ item.displayText }}
+            </mat-list-option>
+        }
+      </mat-selection-list>
 </mat-dialog-content>

--- a/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.html
+++ b/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.html
@@ -7,7 +7,7 @@
 <mat-dialog-content class="dialog surface-container-high">
       <mat-selection-list #list (selectionChange)="onSelectionChange(list.selectedOptions.selected)">
         @for(item of searchResults(); track item) {
-            <mat-list-option togglePosition="before" [value]="item">
+            <mat-list-option togglePosition="before" [value]="item" [selected]="((selectedItems$ | async) ?? []).includes(item)">
                 {{ item.displayText }}
             </mat-list-option>
         }

--- a/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.ts
+++ b/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.ts
@@ -1,8 +1,47 @@
-import { Component } from '@angular/core';
+/**
+ * Dropdown dialog that appears when filtering in the
+ * mat-filter-chip component.
+ *
+ * @author Ajay Gandecha <ajay@cs.unc.edu>
+ * @license MIT
+ * @copyright 2025
+ */
+
+import {
+  Component,
+  effect,
+  EventEmitter,
+  input,
+  model,
+  signal,
+  WritableSignal
+} from '@angular/core';
+import { MatFilterChipSearchableItem } from '../filter-chip.component';
+import { ReplaySubject, Subject } from 'rxjs';
+import { MatListOption } from '@angular/material/list';
+import { MatDialogRef } from '@angular/material/dialog';
 
 @Component({
   selector: 'mat-filter-chip-dialog',
   templateUrl: './filter-chip-dialog.component.html',
   styleUrl: './filter-chip-dialog.component.css'
 })
-export class MatFilterChipDialog<SelectItemT> {}
+export class MatFilterChipDialog<SelectItemT> {
+  // Chip's selected items.
+  // The subject stores the selected items and emits the latest value to subscribers.
+  // The selectedItems$ observable can be subscribed to for updates.
+  selectedItems: Subject<MatFilterChipSearchableItem<SelectItemT>[]> =
+    new ReplaySubject(1);
+  selectedItems$ = this.selectedItems.asObservable();
+  // Input used for the list of items that can be selected.
+  searchableItems: MatFilterChipSearchableItem<SelectItemT>[] = [];
+
+  // Handle the event for when the selected items change.
+  onSelectionChange(newItems: MatListOption[]) {
+    this.selectedItems.next(newItems.map((item) => item.value));
+  }
+
+  constructor(
+    public dialogRef: MatDialogRef<MatFilterChipDialog<SelectItemT>>
+  ) {}
+}

--- a/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.ts
+++ b/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'mat-filter-chip-dialog',
+  templateUrl: './filter-chip-dialog.component.html',
+  styleUrl: './filter-chip-dialog.component.css'
+})
+export class MatFilterChipDialog<SelectItemT> {}

--- a/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.ts
+++ b/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.ts
@@ -7,15 +7,7 @@
  * @copyright 2025
  */
 
-import {
-  Component,
-  effect,
-  EventEmitter,
-  input,
-  model,
-  signal,
-  WritableSignal
-} from '@angular/core';
+import { Component, computed, model } from '@angular/core';
 import { MatFilterChipSearchableItem } from '../filter-chip.component';
 import { ReplaySubject, Subject } from 'rxjs';
 import { MatListOption } from '@angular/material/list';
@@ -36,9 +28,24 @@ export class MatFilterChipDialog<SelectItemT> {
   // Input used for the list of items that can be selected.
   searchableItems: MatFilterChipSearchableItem<SelectItemT>[] = [];
 
+  // Store the current search query
+  searchQuery = model<string>('');
+  // Filter the items based on the search query
+  searchResults = computed(() => {
+    const query = this.searchQuery().toLowerCase();
+    return this.searchableItems.filter((item) =>
+      item.displayText.toLowerCase().startsWith(query)
+    );
+  });
+
   // Handle the event for when the selected items change.
   onSelectionChange(newItems: MatListOption[]) {
     this.selectedItems.next(newItems.map((item) => item.value));
+  }
+
+  // Clears the current search query.
+  onQueryClear() {
+    this.searchQuery.set('');
   }
 
   constructor(

--- a/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.ts
+++ b/frontend/src/app/shared/mat/filter-chip/dialog/filter-chip-dialog.component.ts
@@ -8,8 +8,11 @@
  */
 
 import { Component, computed, model } from '@angular/core';
-import { MatFilterChipSearchableItem } from '../filter-chip.component';
-import { ReplaySubject, Subject } from 'rxjs';
+import {
+  MatFilterChipFilterLogic,
+  MatFilterChipSearchableItem
+} from '../filter-chip.component';
+import { filter, ReplaySubject, Subject } from 'rxjs';
 import { MatListOption } from '@angular/material/list';
 import { MatDialogRef } from '@angular/material/dialog';
 
@@ -30,12 +33,13 @@ export class MatFilterChipDialog<SelectItemT> {
 
   // Store the current search query
   searchQuery = model<string>('');
+  // Stores the logic for how to apply filters based on the search query
+  filterLogic!: MatFilterChipFilterLogic<SelectItemT>;
+
   // Filter the items based on the search query
   searchResults = computed(() => {
     const query = this.searchQuery().toLowerCase();
-    return this.searchableItems.filter((item) =>
-      item.displayText.toLowerCase().startsWith(query)
-    );
+    return this.searchableItems.filter((item) => this.filterLogic(item, query));
   });
 
   // Handle the event for when the selected items change.

--- a/frontend/src/app/shared/mat/filter-chip/filter-chip.component.css
+++ b/frontend/src/app/shared/mat/filter-chip/filter-chip.component.css
@@ -1,0 +1,33 @@
+::ng-deep .mat-filter-chip-content:hover, mat-icon {
+    cursor: pointer;
+}
+
+.mat-filter-chip-dialog-backdrop {
+    background-color: transparent;
+}
+
+.mat-filter-chip-content {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.mat-filter-chip-main-content {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.mat-filter-chip-accessory {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.mat-filter-chip-divider {
+    height: 30px;
+}
+
+.mat-filter-chip-leading-icon {
+    padding-left: 0 !important;
+}

--- a/frontend/src/app/shared/mat/filter-chip/filter-chip.component.html
+++ b/frontend/src/app/shared/mat/filter-chip/filter-chip.component.html
@@ -1,0 +1,7 @@
+<mat-chip #chip (click)="openDialog($event)">
+    @if(leadingIcon()) {
+        <mat-icon matChipAvatar>{{ leadingIcon() }}</mat-icon>
+    }
+    Test
+    <mat-icon matChipTrailingIcon>arrow_drop_down</mat-icon>
+</mat-chip>

--- a/frontend/src/app/shared/mat/filter-chip/filter-chip.component.html
+++ b/frontend/src/app/shared/mat/filter-chip/filter-chip.component.html
@@ -1,7 +1,17 @@
-<mat-chip #chip (click)="openDialog($event)">
-    @if(leadingIcon()) {
-        <mat-icon matChipAvatar>{{ leadingIcon() }}</mat-icon>
-    }
-    Test
-    <mat-icon matChipTrailingIcon>arrow_drop_down</mat-icon>
+<mat-chip #chip [highlighted]="selectedItems().length > 0"  disableRipple>
+    <div class="mat-filter-chip-content">
+        <div class="mat-filter-chip-main-content" (click)="openDialog($event)" >
+            @if(leadingIcon()) {
+                <mat-icon matChipTrailingIcon class="font-primary mat-filter-chip-leading-icon">{{ leadingIcon() }}</mat-icon>
+            }
+            {{ displayText() }}
+            <mat-icon matChipTrailingIcon>arrow_drop_down</mat-icon>
+        </div>
+        @if(selectedItems().length > 0) {
+            <div class="mat-filter-chip-accessory" (click)="clearSelections()">
+                <mat-divider [vertical]="true" class="mat-filter-chip-divider"></mat-divider>
+                <mat-icon matChipTrailingIcon>close</mat-icon>    
+            </div>
+        }
+    </div>
 </mat-chip>

--- a/frontend/src/app/shared/mat/filter-chip/filter-chip.component.ts
+++ b/frontend/src/app/shared/mat/filter-chip/filter-chip.component.ts
@@ -25,6 +25,20 @@ export type MatFilterChipSearchableItem<SelectItemT> = {
   displayText: string;
 };
 
+/**
+ * Defines a functional type to be used to check whether any filterable item
+ * matches the text query. This is generic so that it can be applied to any
+ * type of item input.
+ *
+ * @params item The item to check against the query.
+ * @params query The text query to check against the item.
+ * @returns boolean Whether or not the item matches the query.
+ */
+export type MatFilterChipFilterLogic<SelectItemT> = (
+  item: MatFilterChipSearchableItem<SelectItemT>,
+  query: string
+) => boolean;
+
 @Component({
   selector: 'mat-filter-chip',
   templateUrl: './filter-chip.component.html',
@@ -42,6 +56,9 @@ export class MatFilterChipComponent<SelectItemT> {
   selectedItems = model<MatFilterChipSearchableItem<SelectItemT>[]>([]);
   // Input used for the list of items that can be selected.
   searchableItems = input<MatFilterChipSearchableItem<SelectItemT>[]>([]);
+
+  // Stores the logic for how to apply filters based on the search query
+  filterLogic!: MatFilterChipFilterLogic<SelectItemT>;
 
   // Stores whether or not the dropdown is open.
   dropdownOpen = signal<boolean>(false);
@@ -94,6 +111,7 @@ export class MatFilterChipComponent<SelectItemT> {
 
     // Pass data directly to the component instance.
     dialogRef.componentInstance.searchableItems = this.searchableItems();
+    dialogRef.componentInstance.filterLogic = this.filterLogic;
     dialogRef.componentInstance.selectedItems.next(this.selectedItems());
     // Listen for changes in the list of selected items and update accordingly.
     const selectedItemsSubscription =

--- a/frontend/src/app/shared/mat/filter-chip/filter-chip.component.ts
+++ b/frontend/src/app/shared/mat/filter-chip/filter-chip.component.ts
@@ -1,0 +1,71 @@
+/**
+ * Custom implementation of a filter chip based off of Material 3
+ * standards.
+ *
+ * @see https://m3.material.io/components/chips/guidelines
+ *
+ * @author Ajay Gandecha <ajay@cs.unc.edu>
+ * @license MIT
+ * @copyright 2025
+ */
+
+import { Component, input, Input, model, signal } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { MatFilterChipDialog } from './dialog/filter-chip-dialog.component';
+
+@Component({
+  selector: 'mat-filter-chip',
+  templateUrl: './filter-chip.component.html',
+  styleUrl: './filter-chip.component.css'
+})
+export class MatFilterChipComponent<SelectItemT> {
+  // Leading icon to show when the chip is in the default state
+  leadingIcon = input<string | null>(null);
+  // Whether or not the dropdown should be left or right aligned.
+  dropdownAlignment = input<'left' | 'right'>('left');
+
+  // Two-way binding for the chip's selected items.
+  selectedItems = model<SelectItemT[]>([]);
+  // Input used for the list of items that can be selected.
+  searchableItems = input<SelectItemT[]>([]);
+
+  // Stores whether or not the dropdown is open.
+  dropdownOpen = signal<boolean>(false);
+  toggleDropdown = () => this.dropdownOpen.set(!this.dropdownOpen());
+
+  // Search query for the search bar in the dialog.
+  searchQuery = signal<string>('');
+
+  constructor(protected dialog: MatDialog) {}
+
+  openDialog(event: MouseEvent) {
+    // Constants to save the height and width of the dialog
+    const height = 300;
+    const width = 300;
+    const borderRadiusOffset = 16;
+    // Determine the absolute position of the dialog, which should be
+    // underneath the filter chip. The alignment option should position
+    // the dialog to be aligned with the left or right side of the chip.
+    const elementBounds = (
+      event.currentTarget as HTMLElement
+    ).getBoundingClientRect();
+    const topPosition = elementBounds.bottom;
+    const leftPosition =
+      this.dropdownAlignment() === 'left'
+        ? elementBounds.left - borderRadiusOffset
+        : elementBounds.left - 300 + elementBounds.width + borderRadiusOffset;
+
+    this.dialog.open(MatFilterChipDialog<SelectItemT>, {
+      height: height + 'px',
+      width: width + 'px',
+      position: {
+        top: topPosition + 'px',
+        left: leftPosition + 'px'
+      },
+      // Hides the backdrop so that the dialog can be displayed directly
+      // over the content. This is standard in M3's use of dialogs
+      // in Google Calendar and other projects.
+      hasBackdrop: false
+    });
+  }
+}

--- a/frontend/src/app/shared/mat/filter-chip/filter-chip.component.ts
+++ b/frontend/src/app/shared/mat/filter-chip/filter-chip.component.ts
@@ -64,7 +64,7 @@ export class MatFilterChipComponent<SelectItemT> {
   openDialog(event: MouseEvent) {
     // Constants to save the height and width of the dialog
     const height = 300;
-    const width = 300;
+    const width = 200;
     const borderRadiusOffset = 16;
     const topOffset = 8;
     // Determine the absolute position of the dialog, which should be
@@ -77,7 +77,7 @@ export class MatFilterChipComponent<SelectItemT> {
     const leftPosition =
       this.dropdownAlignment() === 'left'
         ? elementBounds.left - borderRadiusOffset
-        : elementBounds.left - 300 + elementBounds.width + borderRadiusOffset;
+        : elementBounds.left - width + borderRadiusOffset;
 
     const dialogRef = this.dialog.open(MatFilterChipDialog<SelectItemT>, {
       height: height + 'px',

--- a/frontend/src/app/shared/mat/filter-chip/filter-chip.component.ts
+++ b/frontend/src/app/shared/mat/filter-chip/filter-chip.component.ts
@@ -66,13 +66,14 @@ export class MatFilterChipComponent<SelectItemT> {
     const height = 300;
     const width = 300;
     const borderRadiusOffset = 16;
+    const topOffset = 8;
     // Determine the absolute position of the dialog, which should be
     // underneath the filter chip. The alignment option should position
     // the dialog to be aligned with the left or right side of the chip.
     const elementBounds = (
       event.currentTarget as HTMLElement
     ).getBoundingClientRect();
-    const topPosition = elementBounds.bottom;
+    const topPosition = elementBounds.bottom + topOffset;
     const leftPosition =
       this.dropdownAlignment() === 'left'
         ? elementBounds.left - borderRadiusOffset

--- a/frontend/src/app/shared/mat/filter-chip/filter-chip.component.ts
+++ b/frontend/src/app/shared/mat/filter-chip/filter-chip.component.ts
@@ -58,7 +58,7 @@ export class MatFilterChipComponent<SelectItemT> {
   searchableItems = input<MatFilterChipSearchableItem<SelectItemT>[]>([]);
 
   // Stores the logic for how to apply filters based on the search query
-  filterLogic!: MatFilterChipFilterLogic<SelectItemT>;
+  filterLogic = input<MatFilterChipFilterLogic<SelectItemT>>(() => true);
 
   // Stores whether or not the dropdown is open.
   dropdownOpen = signal<boolean>(false);
@@ -111,7 +111,7 @@ export class MatFilterChipComponent<SelectItemT> {
 
     // Pass data directly to the component instance.
     dialogRef.componentInstance.searchableItems = this.searchableItems();
-    dialogRef.componentInstance.filterLogic = this.filterLogic;
+    dialogRef.componentInstance.filterLogic = this.filterLogic();
     dialogRef.componentInstance.selectedItems.next(this.selectedItems());
     // Listen for changes in the list of selected items and update accordingly.
     const selectedItemsSubscription =

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -43,6 +43,8 @@ import {
 import { MarkdownDirective } from './directives/markdown.directive';
 import { EventRegistrationCardWidget } from './event-registration-card/event-registration-card.widget';
 import { AboutPaneWidget } from './about-pane/about-pane.widget';
+import { MatFilterChipComponent } from './mat/filter-chip/filter-chip.component';
+import { MatFilterChipDialog } from './mat/filter-chip/dialog/filter-chip-dialog.component';
 
 @NgModule({
   declarations: [
@@ -59,7 +61,9 @@ import { AboutPaneWidget } from './about-pane/about-pane.widget';
     OperatingHoursCapitalizationPipe,
     MarkdownDirective,
     EventRegistrationCardWidget,
-    AboutPaneWidget
+    AboutPaneWidget,
+    MatFilterChipComponent,
+    MatFilterChipDialog
   ],
   imports: [
     CommonModule,
@@ -96,7 +100,8 @@ import { AboutPaneWidget } from './about-pane/about-pane.widget';
     CoworkingHoursCard,
     MarkdownDirective,
     EventRegistrationCardWidget,
-    AboutPaneWidget
+    AboutPaneWidget,
+    MatFilterChipComponent
   ],
   providers: [GroupEventsPipe]
 })

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -106,6 +106,11 @@ body {
     color: mat.get-theme-color($theme, secondary) !important;
   }
 
+  .surface-container-high {
+    background-color: mat.get-theme-color($theme, surface-container-high) !important;
+    color: mat.get-theme-color($theme, on-surface) !important;
+  }
+
   /// Ensures that all tables are horizontally scrollable.
   /// All tables have to be wrapped by a div with the
   /// `table-responsive` class.
@@ -465,6 +470,13 @@ body {
       $theme,
       secondary-container
     ) !important;
+  }
+
+  mat-filter-chip-dialog {
+    @include mat.form-field-overrides((
+      container-color: transparent,
+      hover-state-layer-opacity: 0
+  ));
   }
 }
 .mdc-notched-outline__notch {

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -474,7 +474,7 @@ body {
 
   mat-filter-chip-dialog {
     @include mat.form-field-overrides((
-      container-color: transparent,
+      container-color: mat.get-theme-color($theme, surface-container-high),
       hover-state-layer-opacity: 0
   ));
   }


### PR DESCRIPTION
This PR creates a custom, reusable dropdown filter chip component that can be used across the UI when designing filterable interfaces.

## Design

### Default Appearance

<img width="126" alt="Screenshot 2025-02-26 at 7 30 13 PM" src="https://github.com/user-attachments/assets/65e5fd92-b8e0-4740-a96f-530ad4cd77ac" />

The regular filter chip shows placeholder text and an icon, which are both configurable.

### Filter Appearance

<img width="313" alt="Screenshot 2025-02-26 at 7 28 49 PM" src="https://github.com/user-attachments/assets/3975e314-e5c9-4d42-88ac-a82e97314e4c" />

Clicking on the chip displays a filterable multi-selection list, allowing for multiple inputs to be selected at once. The first selected item is shown on the chip. If more than one item are selected, the number of items selected in addition to the one shown is displayed. This follows Material conventions, and a chip like this can be found on the official Google Drive app:

<img width="258" alt="Screenshot 2025-02-26 at 7 32 34 PM" src="https://github.com/user-attachments/assets/bab6c5c5-726a-47f3-9e8a-e7c51c3fc529" />

There is also a button to easily clear the filterable selection.

## Usage

The new filter chip item has been placed in the `SharedModule` and therefore can be used throughout the site. It has certain required fields - example usage is shown below:

```html
<mat-filter-chip
  placeholder="Filter"
  leadingIcon="person_raised_hand"
  dropdownAlignment="right"
  [searchableItems]="[{displayText: 'Item 1', item: 'item1'}, {displayText: 'Item 2', item: 'item2'}, {displayText: 'Item 3', item: 'item3'}, {displayText: 'Item 4', item: 'item4'}, {displayText: 'Item 5', item: 'item5'}]"
  [filterLogic]="filterLogic"
/>
````

* `placeholder`: Text to show when no items are selected.
* `leadingIcon`: Textual representation of the [Material Icon](https://fonts.google.com/icons) to show on the left side of the chip.
* `dropdownAlignment`: Can be set to either `"left"` or `"right"`. This is used to align the dropdown with the chip that opened it. For items on the left of the screen, the left alignment makes sense. If filter chips are on the right side of the screen, the right alignment will prevent the dialog from spilling out of the screen.
* `searchableItems`: This is a list of items with the following type: `{ displayText: string, item: T}`. Any object or model can be used as data for the chip, but an extra `displayText` field should be attached to every item so that the chip can identify which items to show on the screen.
* `filterLogic`: This allows for custom filtering logic to be used by the search bar, depending on the use case of the chip and its implementation. This is in the format of: `(item: FilterItem<T>, query: string) => bool` where the `FilterItem<T>` is the items in the `searchableItems` list above.

## Other Changes

* This PR also adds the office hours statistics component, where an example of this chip implemented is shown.

*Closes #713*