### PR TITLE
(task:723) Implement Ticket Data Export to CSV

### DIFF
--- a/backend/models/office_hours/ticket.py
+++ b/backend/models/office_hours/ticket.py
@@ -44,3 +44,18 @@ class OfficeHoursTicket(NewOfficeHoursTicket):
     have_concerns: bool = False
     caller_notes: str = ""
     caller_id: int | None
+
+class OfficeHoursTicketCsvRow(BaseModel):
+    """
+    Pydantic model to represent a user's ticket in CSV format, which is used for
+    exporting ticket data to a CSV file in the ticket statistics feature.
+    """
+    student: str
+    description: str
+    type: str
+    created_at: str
+    called_at: str
+    called_by: str
+    closed_at: str
+    duration_minutes: int
+    wait_time_minutes: int

--- a/backend/services/office_hours/office_hours_statistics.py
+++ b/backend/services/office_hours/office_hours_statistics.py
@@ -293,3 +293,28 @@ class OfficeHoursStatisticsService:
             term_start=term.start,
             term_end=term.end,
         )
+
+    def get_ticket_csv(
+        self, user: User, site_id: int, pagination_params: TicketPaginationParams
+    ):
+        """
+        Get a CSV of the tickets for a given course site.
+        """
+        # Check permissions
+        self._office_hours_svc._check_site_admin_permissions(user, site_id)
+
+        # Create query to load all ticket data
+        statement, _ = self.create_ticket_query(site_id, pagination_params)
+
+        # Perform a joined load so that caller and creators data are populated for the
+        # resulting ticket entities
+        statement = statement.options(
+            joinedload(OfficeHoursTicketEntity.caller),
+            joinedload(OfficeHoursTicketEntity.creators),
+        )
+
+        # Load entities
+        entities = self._session.execute(statement).unique().scalars()
+
+        # Convert entities to CSV format with expected data
+        return [entity.to_csv_model() for entity in entities]

--- a/backend/test/services/office_hours/office_hours_statistics_test.py
+++ b/backend/test/services/office_hours/office_hours_statistics_test.py
@@ -319,3 +319,62 @@ def test_get_paginated_tickets_multiple_filters(
     assert statistics.average_duration == approx(1.0)
     assert statistics.total_conceptual == 1
     assert statistics.total_assignment == 0
+
+
+def test_get_ticket_csv(
+    oh_statistics_svc: OfficeHoursStatisticsService,
+):
+    """Ensures that the CSV file is generated correctly."""
+    ticket_params = TicketPaginationParams(
+        range_start="",
+        range_end="",
+        student_ids=[],
+        staff_ids=[],
+    )
+
+    ticket_csv = oh_statistics_svc.get_ticket_csv(
+        user_data.instructor,
+        office_hours_data.comp_110_site.id,
+        ticket_params,
+    )
+
+    assert len(ticket_csv) == 1
+
+
+def test_get_ticket_csv_unauthenticated(
+    oh_statistics_svc: OfficeHoursStatisticsService,
+):
+    """Ensures that students cannot view the CSV file."""
+    ticket_params = TicketPaginationParams(
+        range_start="",
+        range_end="",
+        student_ids=[],
+        staff_ids=[],
+    )
+
+    with pytest.raises(CoursePermissionException):
+        oh_statistics_svc.get_ticket_csv(
+            user_data.student,
+            office_hours_data.comp_110_site.id,
+            ticket_params,
+        )
+
+
+def test_get_ticket_csv_with_filters(
+    oh_statistics_svc: OfficeHoursStatisticsService,
+):
+    """Ensures that the CSV file is generated correctly with filters."""
+    ticket_params = TicketPaginationParams(
+        range_start="",
+        range_end="",
+        student_ids=[user_data.student.id],
+        staff_ids=[user_data.instructor.id],
+    )
+
+    ticket_csv = oh_statistics_svc.get_ticket_csv(
+        user_data.instructor,
+        office_hours_data.comp_110_site.id,
+        ticket_params,
+    )
+
+    assert len(ticket_csv) == 1

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -65,7 +65,7 @@
             </div>
               <!-- Download button -->
               <button
-                mat-flat-button
+                mat-flat-button (click)="downloadTicketData()"
                 class="secondary-button"
               >
                 <mat-icon id="download-button-icon">download</mat-icon>

--- a/frontend/src/app/my-courses/my-courses.service.ts
+++ b/frontend/src/app/my-courses/my-courses.service.ts
@@ -45,6 +45,7 @@ import {
 import { Observable, map } from 'rxjs';
 import { NagivationAdminGearService } from '../navigation/navigation-admin-gear.service';
 import { Paginated } from '../pagination';
+import saveAs from 'file-saver';
 
 /** Enum for days of the week */
 export enum Weekday {
@@ -425,5 +426,24 @@ export class MyCoursesService {
       `/api/my-courses/${courseSiteId}/statistics` + '?' + query.toString();
 
     return this.http.get<OfficeHoursTicketStatistics>(route);
+  }
+
+  /**
+   * Get the office hours ticket CSV file.
+   * @param courseSiteId: ID of the course site to get the ticket CSV for
+   * @param params: Pagination parameters
+   */
+  getOfficeHoursTicketCsv(
+    courseSiteId: number,
+    params: OfficeHourStatisticsPaginationParams | null
+  ) {
+    let route = params
+      ? `/api/my-courses/${courseSiteId}/statistics/csv` +
+        '?' +
+        new URLSearchParams(params).toString()
+      : `/api/my-courses/${courseSiteId}/statistics/csv`;
+    return this.http.get(route, {
+      responseType: 'blob'
+    });
   }
 }


### PR DESCRIPTION
This pull request adds functionality so that staff of a course are able to download office hours data for a course in CSV format. This data includes the students names, the staff member that called the ticket, the ticket type and description, and details about when the ticket was opened, called, and closed (as well as helpful calculations for the wait time and help time, in minutes).

One new backend service method and API were added. The service method is tested with 100% coverage.

*Closes #723*