### PR TITLE
(fix:728) Fix Dark Mode Styling Issue Summary Page and Dark Mode Buttons Sitewide

### DIFF
--- a/frontend/src/app/my-courses/widgets/office-hours-statistics-card/office-hours-statistics-card.widget.html
+++ b/frontend/src/app/my-courses/widgets/office-hours-statistics-card/office-hours-statistics-card.widget.html
@@ -10,7 +10,7 @@
       </p>
       @if(rightStatistic() && rightStatisticLabel()) {
         <p class="statistics-card-statistic">
-          <span class="text-badge surface-background label-large"
+          <span class="text-badge surface-container-high label-large"
             >{{ rightStatistic() }}</span
           >{{ rightStatisticLabel() }}
         </p>

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -149,21 +149,21 @@ body {
 
   .primary-button {
     .mat-icon {
-      color: white !important;
+      color: mat.get-theme-color($theme, on-primary) !important;
     }
     @include mat.button-color($theme, $color-variant: primary);
   }
 
   .secondary-button {
     .mat-icon {
-      color: white !important;
+      color: mat.get-theme-color($theme, on-secondary) !important;
     }
     @include mat.button-color($theme, $color-variant: secondary);
   }
 
   .tertiary-button {
     .mat-icon {
-      color: white !important;
+      color: mat.get-theme-color($theme, on-tertiary) !important;
     }
     @include mat.button-color($theme, $color-variant: tertiary);
   }


### PR DESCRIPTION
This PR modifies the Material styling for the summary page to work better with dark mode.

### Before:

<img width="173" alt="Screenshot 2025-03-21 at 7 03 18 PM" src="https://github.com/user-attachments/assets/6cc1ff2b-0e66-4a36-ab5a-5aa7da9ada4a" />

### After

<img width="268" alt="Screenshot 2025-03-21 at 7 03 29 PM" src="https://github.com/user-attachments/assets/bb6a8b37-11c9-49d0-a58e-fb93490d8c3a" />

In addition, this PR also includes a site-wide fix for the button text color in dark mode. Before, text on secondary and tertiary buttons were white rather than the `on-secondary` and `on-tertiary` colors respectively, creating bad contrast. This has now been fixed.

### Before:

<img width="54" alt="Screenshot 2025-03-21 at 7 04 23 PM" src="https://github.com/user-attachments/assets/dbbe304e-5cc6-4eee-bc7e-255e44fe4633" />

### After:

<img width="81" alt="Screenshot 2025-03-21 at 7 04 37 PM" src="https://github.com/user-attachments/assets/d8687ad3-d670-461e-ae18-76efed0426b6" />


*Closes #728*