### PR TITLE
Task/722-ticket-dialog: Create Ticket Details Dialog

### DIFF
--- a/backend/entities/office_hours/ticket_entity.py
+++ b/backend/entities/office_hours/ticket_entity.py
@@ -145,6 +145,7 @@ class OfficeHoursTicketEntity(EntityBase):
             id=self.id,
             created_at=self.created_at,
             called_at=self.called_at,
+            closed_at=self.closed_at,
             state=self.state.to_string(),
             type=self.type.to_string(),
             description=self.description,

--- a/backend/models/academics/my_courses.py
+++ b/backend/models/academics/my_courses.py
@@ -86,6 +86,7 @@ class OfficeHourTicketOverview(BaseModel):
     id: int
     created_at: datetime
     called_at: datetime | None
+    closed_at: datetime | None
     state: str
     type: str
     description: str

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -106,7 +106,7 @@
                       </div>
                     </div>
                     <div class="ticket-row-trailing-content">
-                      <button mat-icon-button>
+                      <button mat-icon-button (click)="openTicketDetails(item)">
                         <mat-icon>more_vert</mat-icon>
                       </button>
                     </div>

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.ts
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.ts
@@ -151,7 +151,7 @@ export class StatisticsComponent {
   constructor(
     private route: ActivatedRoute,
     protected myCoursesService: MyCoursesService,
-    protected dialog: MatDialog
+    protected dialog: MatDialog,
     protected snackBar: MatSnackBar
   ) {
     // Get the course site ID from the route parameters
@@ -172,13 +172,15 @@ export class StatisticsComponent {
     this.selectedEndDate.set(undefined);
   }
 
+  /** Open the ticket details dialog */
   openTicketDetails(ticket: OfficeHourTicketOverview) {
     this.dialog.open(TicketDetailsDialog, {
       height: '500px',
       width: '450px',
       data: { ticket }
     });
-    
+  }
+
   /**
    * Downloads the ticket data as a CSV file.
    */

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.ts
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.ts
@@ -32,6 +32,8 @@ import {
 import { PublicProfile } from 'src/app/profile/profile.service';
 import { Paginated } from 'src/app/pagination';
 import { PageEvent } from '@angular/material/paginator';
+import { MatDialog } from '@angular/material/dialog';
+import { TicketDetailsDialog } from '../../dialogs/ticket-details/ticket-details.dialog';
 
 @Component({
   selector: 'app-statistics',
@@ -146,7 +148,8 @@ export class StatisticsComponent {
 
   constructor(
     private route: ActivatedRoute,
-    protected myCoursesService: MyCoursesService
+    protected myCoursesService: MyCoursesService,
+    protected dialog: MatDialog
   ) {
     // Get the course site ID from the route parameters
     this.courseSiteId = +this.route.parent!.snapshot.params['course_site_id'];
@@ -164,5 +167,13 @@ export class StatisticsComponent {
     this.selectedStaffFilterOptions.set([]);
     this.selectedStartDate.set(undefined);
     this.selectedEndDate.set(undefined);
+  }
+
+  openTicketDetails(ticket: OfficeHourTicketOverview) {
+    this.dialog.open(TicketDetailsDialog, {
+      height: '500px',
+      width: '450px',
+      data: { ticket }
+    });
   }
 }

--- a/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.css
+++ b/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.css
@@ -1,0 +1,12 @@
+.semibold {
+  font-weight: 500;
+}
+
+.mat-divider {
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.user-tag {
+  margin-right: 8px;
+}

--- a/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.html
+++ b/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.html
@@ -27,7 +27,7 @@
 
   <mat-divider />
   <p mat-card-subtitle>Description</p>
-  <p>
+  <p markdown>
     {{ data.ticket.description }}
   </p>
 </mat-dialog-content>

--- a/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.html
+++ b/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.html
@@ -19,17 +19,12 @@
   </p>
   
   <mat-divider />
-  <div class="ticket-users">
-    <div class="user-info">
-      <span class="semibold user-tag">Student:</span>
-      <user-chip-list [users]="data.ticket.creators"></user-chip-list>
-    </div>
-    <div class="user-info">
-      <span class="semibold user-tag">Caller:</span>
-      <user-chip-list [users]="data.ticket.caller? [data.ticket.caller] : []" nameSuffix=" (Staff)"></user-chip-list>
-    </div>
-  </div>
+  <span class="semibold user-tag">Student:</span>
+  <user-chip-list [users]="data.ticket.creators"></user-chip-list>
   
+  <span class="semibold user-tag">Caller:</span>
+  <user-chip-list [users]="data.ticket.caller? [data.ticket.caller] : []" nameSuffix=" (Staff)"></user-chip-list>
+
   <mat-divider />
   <p mat-card-subtitle>Description</p>
   <p>

--- a/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.html
+++ b/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.html
@@ -1,0 +1,38 @@
+<h2 mat-dialog-title>Ticket Details</h2>
+<mat-dialog-content>
+  <p>
+    <span class="semibold">Ticket Type: </span>
+    {{ data.ticket.type }}
+  </p>
+  <p>
+    <span class="semibold">Created: </span>
+    {{ data.ticket.created_at | date:'EEEE, MMMM d, y' }} at {{ data.ticket.created_at | date:'hh:mm a' }}
+  </p>
+  <p>
+    <span class="semibold">Student Wait Time: </span>
+    {{ this.studentWaitTime.toFixed(0) }} minute{{ this.studentWaitTime > 1 ? "s" : "" }}
+  </p>
+  <p>
+    <span class="semibold">Assisted From: </span>
+    {{ data.ticket.called_at | date:'hh:mm a' }} - {{ data.ticket.closed_at | date:'hh:mm a' }}
+    ({{ this.studentWaitTime.toFixed(0) }} minute{{ this.studentWaitTime > 1 ? "s" : "" }})
+  </p>
+  
+  <mat-divider />
+  <div class="ticket-users">
+    <div class="user-info">
+      <span class="semibold user-tag">Student:</span>
+      <user-chip-list [users]="data.ticket.creators"></user-chip-list>
+    </div>
+    <div class="user-info">
+      <span class="semibold user-tag">Caller:</span>
+      <user-chip-list [users]="data.ticket.caller? [data.ticket.caller] : []" nameSuffix=" (Staff)"></user-chip-list>
+    </div>
+  </div>
+  
+  <mat-divider />
+  <p mat-card-subtitle>Description</p>
+  <p>
+    {{ data.ticket.description }}
+  </p>
+</mat-dialog-content>

--- a/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.ts
+++ b/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.ts
@@ -1,0 +1,33 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MyCoursesService } from '../../my-courses.service';
+import { OfficeHourTicketOverview } from '../../my-courses.model';
+
+@Component({
+  selector: 'dialog-ticket-details',
+  templateUrl: './ticket-details.dialog.html',
+  styleUrl: './ticket-details.dialog.css'
+})
+export class TicketDetailsDialog {
+  studentWaitTime = 0;
+  ticketDuration = 0;
+
+  constructor(
+    protected dialogRef: MatDialogRef<TicketDetailsDialog>,
+    @Inject(MAT_DIALOG_DATA)
+    public data: { ticket: OfficeHourTicketOverview },
+    protected myCoursesService: MyCoursesService
+  ) {
+    let createdAt = new Date(data.ticket.created_at);
+    let calledAt = new Date(data.ticket.called_at!);
+    let closedAt = new Date(data.ticket.closed_at!);
+    this.studentWaitTime =
+      (calledAt.getTime() - createdAt.getTime()) / 1000 / 60;
+
+    this.ticketDuration = (closedAt.getTime() - calledAt.getTime()) / 1000 / 60;
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/src/app/my-courses/my-courses.model.ts
+++ b/frontend/src/app/my-courses/my-courses.model.ts
@@ -118,6 +118,7 @@ export interface OfficeHourTicketOverviewJson {
   id: number;
   created_at: string;
   called_at: string | undefined;
+  closed_at: string | undefined;
   state: string;
   type: number;
   description: string;
@@ -129,6 +130,7 @@ export interface OfficeHourTicketOverview {
   id: number;
   created_at: Date;
   called_at: Date | undefined;
+  closed_at: Date | undefined;
   state: string;
   type: number;
   description: string;
@@ -391,6 +393,9 @@ export const parseOfficeHourTicketOverviewJson = (
     created_at: new Date(responseModel.created_at),
     called_at: responseModel.called_at
       ? new Date(responseModel.called_at)
+      : undefined,
+    closed_at: responseModel.closed_at
+      ? new Date(responseModel.closed_at)
       : undefined
   });
 };

--- a/frontend/src/app/my-courses/my-courses.module.ts
+++ b/frontend/src/app/my-courses/my-courses.module.ts
@@ -54,6 +54,7 @@ import { MatRadioModule } from '@angular/material/radio';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { StatisticsComponent } from './course/statistics/statistics.component';
 import { OfficeHoursStatisticsCardWidget } from './widgets/office-hours-statistics-card/office-hours-statistics-card.widget';
+import { TicketDetailsDialog } from './dialogs/ticket-details/ticket-details.dialog';
 
 @NgModule({
   declarations: [
@@ -76,6 +77,7 @@ import { OfficeHoursStatisticsCardWidget } from './widgets/office-hours-statisti
     CreateCourseSiteDialog,
     ImportRosterDialog,
     DeleteRecurringEventDialog,
+    TicketDetailsDialog,
     OfficeHoursStatisticsCardWidget
   ],
   imports: [


### PR DESCRIPTION
This PR implements the ticket details dialog, which allows users to see further information about tickets listed on the Office Hours Statistics Page.

## Testing
1. Navigate to the OH Statistics page.
2. Click the hamburger menu to the right of one of the past ticket list items.
3. A dialog should appear as shown below.
![image](https://github.com/user-attachments/assets/d14d6f30-bfcc-4e10-a6ee-f4e940b6fb6f)

> _Resolves #722_