### PR TITLE
Task/724-roster-menu: Add Copy Email, View Stats, and Download Roster to OH Roster Page

### DIFF
--- a/backend/entities/office_hours/ticket_entity.py
+++ b/backend/entities/office_hours/ticket_entity.py
@@ -149,6 +149,7 @@ class OfficeHoursTicketEntity(EntityBase):
             id=self.id,
             created_at=self.created_at,
             called_at=self.called_at,
+            closed_at=self.closed_at,
             state=self.state.to_string(),
             type=self.type.to_string(),
             description=self.description,

--- a/backend/models/academics/my_courses.py
+++ b/backend/models/academics/my_courses.py
@@ -59,6 +59,7 @@ class TermOverview(BaseModel):
 
 
 class CourseMemberOverview(BaseModel):
+    id: int
     pid: int
     first_name: str
     last_name: str

--- a/backend/models/academics/my_courses.py
+++ b/backend/models/academics/my_courses.py
@@ -86,6 +86,7 @@ class OfficeHourTicketOverview(BaseModel):
     id: int
     created_at: datetime
     called_at: datetime | None
+    closed_at: datetime | None
     state: str
     type: str
     description: str

--- a/backend/models/office_hours/ticket.py
+++ b/backend/models/office_hours/ticket.py
@@ -44,3 +44,18 @@ class OfficeHoursTicket(NewOfficeHoursTicket):
     have_concerns: bool = False
     caller_notes: str = ""
     caller_id: int | None
+
+class OfficeHoursTicketCsvRow(BaseModel):
+    """
+    Pydantic model to represent a user's ticket in CSV format, which is used for
+    exporting ticket data to a CSV file in the ticket statistics feature.
+    """
+    student: str
+    description: str
+    type: str
+    created_at: str
+    called_at: str
+    called_by: str
+    closed_at: str
+    duration_minutes: int
+    wait_time_minutes: int

--- a/backend/services/academics/course_site.py
+++ b/backend/services/academics/course_site.py
@@ -252,6 +252,7 @@ class CourseSiteService:
         self, section_member: SectionMemberEntity, is_student: bool
     ) -> CourseMemberOverview:
         return CourseMemberOverview(
+            id=section_member.user.id,
             pid=section_member.user.pid,
             first_name=section_member.user.first_name,
             last_name=section_member.user.last_name,

--- a/backend/services/office_hours/office_hours_statistics.py
+++ b/backend/services/office_hours/office_hours_statistics.py
@@ -293,3 +293,28 @@ class OfficeHoursStatisticsService:
             term_start=term.start,
             term_end=term.end,
         )
+
+    def get_ticket_csv(
+        self, user: User, site_id: int, pagination_params: TicketPaginationParams
+    ):
+        """
+        Get a CSV of the tickets for a given course site.
+        """
+        # Check permissions
+        self._office_hours_svc._check_site_admin_permissions(user, site_id)
+
+        # Create query to load all ticket data
+        statement, _ = self.create_ticket_query(site_id, pagination_params)
+
+        # Perform a joined load so that caller and creators data are populated for the
+        # resulting ticket entities
+        statement = statement.options(
+            joinedload(OfficeHoursTicketEntity.caller),
+            joinedload(OfficeHoursTicketEntity.creators),
+        )
+
+        # Load entities
+        entities = self._session.execute(statement).unique().scalars()
+
+        # Convert entities to CSV format with expected data
+        return [entity.to_csv_model() for entity in entities]

--- a/backend/test/services/office_hours/office_hours_statistics_test.py
+++ b/backend/test/services/office_hours/office_hours_statistics_test.py
@@ -319,3 +319,62 @@ def test_get_paginated_tickets_multiple_filters(
     assert statistics.average_duration == approx(1.0)
     assert statistics.total_conceptual == 1
     assert statistics.total_assignment == 0
+
+
+def test_get_ticket_csv(
+    oh_statistics_svc: OfficeHoursStatisticsService,
+):
+    """Ensures that the CSV file is generated correctly."""
+    ticket_params = TicketPaginationParams(
+        range_start="",
+        range_end="",
+        student_ids=[],
+        staff_ids=[],
+    )
+
+    ticket_csv = oh_statistics_svc.get_ticket_csv(
+        user_data.instructor,
+        office_hours_data.comp_110_site.id,
+        ticket_params,
+    )
+
+    assert len(ticket_csv) == 1
+
+
+def test_get_ticket_csv_unauthenticated(
+    oh_statistics_svc: OfficeHoursStatisticsService,
+):
+    """Ensures that students cannot view the CSV file."""
+    ticket_params = TicketPaginationParams(
+        range_start="",
+        range_end="",
+        student_ids=[],
+        staff_ids=[],
+    )
+
+    with pytest.raises(CoursePermissionException):
+        oh_statistics_svc.get_ticket_csv(
+            user_data.student,
+            office_hours_data.comp_110_site.id,
+            ticket_params,
+        )
+
+
+def test_get_ticket_csv_with_filters(
+    oh_statistics_svc: OfficeHoursStatisticsService,
+):
+    """Ensures that the CSV file is generated correctly with filters."""
+    ticket_params = TicketPaginationParams(
+        range_start="",
+        range_end="",
+        student_ids=[user_data.student.id],
+        staff_ids=[user_data.instructor.id],
+    )
+
+    ticket_csv = oh_statistics_svc.get_ticket_csv(
+        user_data.instructor,
+        office_hours_data.comp_110_site.id,
+        ticket_params,
+    )
+
+    assert len(ticket_csv) == 1

--- a/frontend/src/app/app.module.ts
+++ b/frontend/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { LayoutModule } from '@angular/cdk/layout';
 
 /* Material UI Dependencies */
+import { MatMenuModule } from '@angular/material/menu';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
 import { MatDialogModule } from '@angular/material/dialog';
@@ -69,6 +70,7 @@ import { MatChipsModule } from '@angular/material/chips';
     ReactiveFormsModule,
     /* Material UI */
     MatButtonModule,
+    MatMenuModule,
     MatChipsModule,
     MatCardModule,
     MatDialogModule,

--- a/frontend/src/app/my-courses/course/roster/roster.component.css
+++ b/frontend/src/app/my-courses/course/roster/roster.component.css
@@ -30,3 +30,7 @@
     margin-left: auto;
     gap: 12px;
 }
+
+#download-button-icon {
+    margin-right: -8px;
+}

--- a/frontend/src/app/my-courses/course/roster/roster.component.html
+++ b/frontend/src/app/my-courses/course/roster/roster.component.html
@@ -14,6 +14,13 @@
             Import From Canvas
           </button>
         }
+         <!-- Download button -->
+          <button
+          mat-flat-button (click)="downloadCourseRoster()"
+          class="secondary-button"
+        >
+          <mat-icon id="download-button-icon">download</mat-icon>
+        </button>
       </div>
     </mat-card-header>
     <mat-card-content>
@@ -40,7 +47,20 @@
           </ng-container>
           <ng-container matColumnDef="email">
             <th mat-header-cell *matHeaderCellDef>Email</th>
-            <td mat-cell *matCellDef="let element">{{ element.email }}</td>
+            <td mat-cell *matCellDef="let element">
+              {{ element.email }}
+              <button mat-icon-button (click)="copyToClipboard(element.email)">
+                <mat-icon>content_copy</mat-icon>
+              </button>
+            </td>
+          </ng-container>
+          <ng-container matColumnDef="actions">
+            <th mat-header-cell *matHeaderCellDef></th>
+            <td mat-cell *matCellDef="let element">
+              <button mat-icon-button (click)="openUserStatistics(element)">
+                <mat-icon>equalizer</mat-icon>
+              </button>
+            </td>
           </ng-container>
           <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
           <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>

--- a/frontend/src/app/my-courses/course/roster/roster.component.ts
+++ b/frontend/src/app/my-courses/course/roster/roster.component.ts
@@ -158,19 +158,23 @@ export class RosterComponent {
     });
   }
 
-  /** Navigate to statistics page and populate student in student filter */
-  openUserStatistics(student: CourseMemberOverview): void {
+  /** Navigate to statistics page and populate student or staff in the filter */
+  openUserStatistics(member: CourseMemberOverview): void {
+    const isStudent = member.role === 'Student'; // Check if the member is a student
+    const queryParamKey = isStudent ? 'studentId' : 'staffId'; // Use appropriate query parameter
+
     this.snackBar.open(
-      `Navigating to statistics for ${student.first_name} ${student.last_name}`,
+      `Navigating to statistics for ${member.first_name} ${member.last_name}`,
       'Close',
       {
         duration: 3000 // Snackbar will be visible for 3 seconds
       }
     );
+
     this.router.navigate(['../statistics'], {
       relativeTo: this.route,
       queryParams: {
-        studentId: student.id
+        [queryParamKey]: member.id // Pass `studentId` or `staffId` based on the role
       }
     });
   }

--- a/frontend/src/app/my-courses/course/roster/roster.component.ts
+++ b/frontend/src/app/my-courses/course/roster/roster.component.ts
@@ -160,11 +160,8 @@ export class RosterComponent {
 
   /** Navigate to statistics page and populate student in student filter */
   openUserStatistics(student: CourseMemberOverview): void {
-    console.log('Student object:', student); // Log the student object
-    console.log('Student ID:', student.id); // Log the student ID
-
     this.snackBar.open(
-      `Navigating to statistics for ${student.first_name} ${student.last_name} (ID: ${student.id})`,
+      `Navigating to statistics for ${student.first_name} ${student.last_name}`,
       'Close',
       {
         duration: 3000 // Snackbar will be visible for 3 seconds

--- a/frontend/src/app/my-courses/course/roster/roster.component.ts
+++ b/frontend/src/app/my-courses/course/roster/roster.component.ts
@@ -131,7 +131,7 @@ export class RosterComponent {
   /** Copies student email to clipboard */
   copyToClipboard(email: string): void {
     navigator.clipboard.writeText(email).then(() => {
-      this.snackBar.open('Copied to clipboard.', '', {
+      this.snackBar.open('Copied to clipboard', '', {
         duration: 2000
       });
     });
@@ -142,7 +142,7 @@ export class RosterComponent {
     this.myCoursesService.getCourseRosterCsv(this.courseSiteId).subscribe({
       next: (response) => {
         saveAs(response, 'course-roster.csv');
-        this.snackBar.open('Course roster downloaded.', '', {
+        this.snackBar.open('Course roster downloaded', '', {
           duration: 2000
         });
       },
@@ -159,9 +159,17 @@ export class RosterComponent {
   }
 
   /** Navigate to statistics page and populate student in student filter */
-  openUserStatistics(student: PublicProfile): void {
-    // thought PublicProfile because we need to query on id not pid i think (might need to take in CourseMemberOverview not sure tho)
-    // it currently navigates to statistics but still trying to figure out how to add the params in based row of the roster
+  openUserStatistics(student: CourseMemberOverview): void {
+    console.log('Student object:', student); // Log the student object
+    console.log('Student ID:', student.id); // Log the student ID
+
+    this.snackBar.open(
+      `Navigating to statistics for ${student.first_name} ${student.last_name} (ID: ${student.id})`,
+      'Close',
+      {
+        duration: 3000 // Snackbar will be visible for 3 seconds
+      }
+    );
     this.router.navigate(['../statistics'], {
       relativeTo: this.route,
       queryParams: {

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -106,7 +106,7 @@
                       </div>
                     </div>
                     <div class="ticket-row-trailing-content">
-                      <button mat-icon-button>
+                      <button mat-icon-button (click)="openTicketDetails(item)">
                         <mat-icon>more_vert</mat-icon>
                       </button>
                     </div>

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -65,7 +65,7 @@
             </div>
               <!-- Download button -->
               <button
-                mat-flat-button
+                mat-flat-button (click)="downloadTicketData()"
                 class="secondary-button"
               >
                 <mat-icon id="download-button-icon">download</mat-icon>

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.ts
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.ts
@@ -161,6 +161,23 @@ export class StatisticsComponent {
       .getOfficeHoursStatisticsFilterOptions(this.courseSiteId)
       .subscribe((data) => {
         this.filterOptions.set(data);
+
+        // Read the query parameters
+        const studentId = this.route.snapshot.queryParamMap.get('studentId');
+
+        // If a student ID is provided, find and pre-select it in the filter
+        if (studentId) {
+          const student = data.students.find((s) => s.id === +studentId);
+
+          if (student) {
+            this.selectedStudentFilterOptions.set([
+              {
+                displayText: `${student.first_name} ${student.last_name}`,
+                item: student
+              }
+            ]);
+          }
+        }
       });
   }
 

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.ts
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.ts
@@ -164,16 +164,29 @@ export class StatisticsComponent {
 
         // Read the query parameters
         const studentId = this.route.snapshot.queryParamMap.get('studentId');
+        const staffId = this.route.snapshot.queryParamMap.get('staffId');
 
         // If a student ID is provided, find and pre-select it in the filter
         if (studentId) {
           const student = data.students.find((s) => s.id === +studentId);
-
           if (student) {
             this.selectedStudentFilterOptions.set([
               {
                 displayText: `${student.first_name} ${student.last_name}`,
                 item: student
+              }
+            ]);
+          }
+        }
+
+        // If a staff ID is provided, find and pre-select it in the staff filter
+        if (staffId) {
+          const staff = data.staff.find((s) => s.id === +staffId);
+          if (staff) {
+            this.selectedStaffFilterOptions.set([
+              {
+                displayText: `${staff.first_name} ${staff.last_name}`,
+                item: staff
               }
             ]);
           }

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.ts
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.ts
@@ -32,6 +32,8 @@ import {
 import { PublicProfile } from 'src/app/profile/profile.service';
 import { Paginated } from 'src/app/pagination';
 import { PageEvent } from '@angular/material/paginator';
+import { MatDialog } from '@angular/material/dialog';
+import { TicketDetailsDialog } from '../../dialogs/ticket-details/ticket-details.dialog';
 import saveAs from 'file-saver';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
@@ -149,6 +151,7 @@ export class StatisticsComponent {
   constructor(
     private route: ActivatedRoute,
     protected myCoursesService: MyCoursesService,
+    protected dialog: MatDialog,
     protected snackBar: MatSnackBar
   ) {
     // Get the course site ID from the route parameters
@@ -167,6 +170,15 @@ export class StatisticsComponent {
     this.selectedStaffFilterOptions.set([]);
     this.selectedStartDate.set(undefined);
     this.selectedEndDate.set(undefined);
+  }
+
+  /** Open the ticket details dialog */
+  openTicketDetails(ticket: OfficeHourTicketOverview) {
+    this.dialog.open(TicketDetailsDialog, {
+      height: '500px',
+      width: '450px',
+      data: { ticket }
+    });
   }
 
   /**

--- a/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.css
+++ b/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.css
@@ -1,0 +1,12 @@
+.semibold {
+  font-weight: 500;
+}
+
+.mat-divider {
+  margin-top: 16px;
+  margin-bottom: 16px;
+}
+
+.user-tag {
+  margin-right: 8px;
+}

--- a/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.html
+++ b/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.html
@@ -1,0 +1,33 @@
+<h2 mat-dialog-title>Ticket Details</h2>
+<mat-dialog-content>
+  <p>
+    <span class="semibold">Ticket Type: </span>
+    {{ data.ticket.type }}
+  </p>
+  <p>
+    <span class="semibold">Created: </span>
+    {{ data.ticket.created_at | date:'EEEE, MMMM d, y' }} at {{ data.ticket.created_at | date:'hh:mm a' }}
+  </p>
+  <p>
+    <span class="semibold">Student Wait Time: </span>
+    {{ this.studentWaitTime.toFixed(0) }} minute{{ this.studentWaitTime > 1 ? "s" : "" }}
+  </p>
+  <p>
+    <span class="semibold">Assisted From: </span>
+    {{ data.ticket.called_at | date:'hh:mm a' }} - {{ data.ticket.closed_at | date:'hh:mm a' }}
+    ({{ this.studentWaitTime.toFixed(0) }} minute{{ this.studentWaitTime > 1 ? "s" : "" }})
+  </p>
+  
+  <mat-divider />
+  <span class="semibold user-tag">Student:</span>
+  <user-chip-list [users]="data.ticket.creators"></user-chip-list>
+  
+  <span class="semibold user-tag">Caller:</span>
+  <user-chip-list [users]="data.ticket.caller? [data.ticket.caller] : []" nameSuffix=" (Staff)"></user-chip-list>
+
+  <mat-divider />
+  <p mat-card-subtitle>Description</p>
+  <p markdown>
+    {{ data.ticket.description }}
+  </p>
+</mat-dialog-content>

--- a/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.ts
+++ b/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.ts
@@ -1,0 +1,33 @@
+import { Component, Inject } from '@angular/core';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MyCoursesService } from '../../my-courses.service';
+import { OfficeHourTicketOverview } from '../../my-courses.model';
+
+@Component({
+  selector: 'dialog-ticket-details',
+  templateUrl: './ticket-details.dialog.html',
+  styleUrl: './ticket-details.dialog.css'
+})
+export class TicketDetailsDialog {
+  studentWaitTime = 0;
+  ticketDuration = 0;
+
+  constructor(
+    protected dialogRef: MatDialogRef<TicketDetailsDialog>,
+    @Inject(MAT_DIALOG_DATA)
+    public data: { ticket: OfficeHourTicketOverview },
+    protected myCoursesService: MyCoursesService
+  ) {
+    let createdAt = new Date(data.ticket.created_at);
+    let calledAt = new Date(data.ticket.called_at!);
+    let closedAt = new Date(data.ticket.closed_at!);
+    this.studentWaitTime =
+      (calledAt.getTime() - createdAt.getTime()) / 1000 / 60;
+
+    this.ticketDuration = (closedAt.getTime() - calledAt.getTime()) / 1000 / 60;
+  }
+
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/src/app/my-courses/my-courses.model.ts
+++ b/frontend/src/app/my-courses/my-courses.model.ts
@@ -118,6 +118,7 @@ export interface OfficeHourTicketOverviewJson {
   id: number;
   created_at: string;
   called_at: string | undefined;
+  closed_at: string | undefined;
   state: string;
   type: number;
   description: string;
@@ -129,6 +130,7 @@ export interface OfficeHourTicketOverview {
   id: number;
   created_at: Date;
   called_at: Date | undefined;
+  closed_at: Date | undefined;
   state: string;
   type: number;
   description: string;
@@ -391,6 +393,9 @@ export const parseOfficeHourTicketOverviewJson = (
     created_at: new Date(responseModel.created_at),
     called_at: responseModel.called_at
       ? new Date(responseModel.called_at)
+      : undefined,
+    closed_at: responseModel.closed_at
+      ? new Date(responseModel.closed_at)
       : undefined
   });
 };

--- a/frontend/src/app/my-courses/my-courses.model.ts
+++ b/frontend/src/app/my-courses/my-courses.model.ts
@@ -69,6 +69,7 @@ export interface TermOverviewJson {
 }
 
 export interface CourseMemberOverview {
+  id: number;
   pid: number;
   first_name: string;
   last_name: string;

--- a/frontend/src/app/my-courses/my-courses.module.ts
+++ b/frontend/src/app/my-courses/my-courses.module.ts
@@ -55,6 +55,7 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { StatisticsComponent } from './course/statistics/statistics.component';
 import { OfficeHoursStatisticsCardWidget } from './widgets/office-hours-statistics-card/office-hours-statistics-card.widget';
 import { TicketDetailsDialog } from './dialogs/ticket-details/ticket-details.dialog';
+import { MatMenuModule } from '@angular/material/menu';
 
 @NgModule({
   declarations: [
@@ -86,6 +87,7 @@ import { TicketDetailsDialog } from './dialogs/ticket-details/ticket-details.dia
     RouterModule,
     SharedModule,
     MatCardModule,
+    MatMenuModule,
     MatDividerModule,
     MatButtonModule,
     MatIconModule,

--- a/frontend/src/app/my-courses/my-courses.module.ts
+++ b/frontend/src/app/my-courses/my-courses.module.ts
@@ -54,6 +54,7 @@ import { MatRadioModule } from '@angular/material/radio';
 import { MatCheckbox } from '@angular/material/checkbox';
 import { StatisticsComponent } from './course/statistics/statistics.component';
 import { OfficeHoursStatisticsCardWidget } from './widgets/office-hours-statistics-card/office-hours-statistics-card.widget';
+import { TicketDetailsDialog } from './dialogs/ticket-details/ticket-details.dialog';
 
 @NgModule({
   declarations: [
@@ -76,6 +77,7 @@ import { OfficeHoursStatisticsCardWidget } from './widgets/office-hours-statisti
     CreateCourseSiteDialog,
     ImportRosterDialog,
     DeleteRecurringEventDialog,
+    TicketDetailsDialog,
     OfficeHoursStatisticsCardWidget
   ],
   imports: [

--- a/frontend/src/app/my-courses/my-courses.service.ts
+++ b/frontend/src/app/my-courses/my-courses.service.ts
@@ -446,4 +446,15 @@ export class MyCoursesService {
       responseType: 'blob'
     });
   }
+
+  /**
+   * Get the course roster CSV file.
+   * @param courseSiteId: ID of the course site to get the roster CSV for
+   */
+  getCourseRosterCsv(courseSiteId: number) {
+    const route = `/api/my-courses/${courseSiteId}/roster/csv`;
+    return this.http.get(route, {
+      responseType: 'blob'
+    });
+  }
 }

--- a/frontend/src/app/my-courses/my-courses.service.ts
+++ b/frontend/src/app/my-courses/my-courses.service.ts
@@ -45,6 +45,7 @@ import {
 import { Observable, map } from 'rxjs';
 import { NagivationAdminGearService } from '../navigation/navigation-admin-gear.service';
 import { Paginated } from '../pagination';
+import saveAs from 'file-saver';
 
 /** Enum for days of the week */
 export enum Weekday {
@@ -425,5 +426,24 @@ export class MyCoursesService {
       `/api/my-courses/${courseSiteId}/statistics` + '?' + query.toString();
 
     return this.http.get<OfficeHoursTicketStatistics>(route);
+  }
+
+  /**
+   * Get the office hours ticket CSV file.
+   * @param courseSiteId: ID of the course site to get the ticket CSV for
+   * @param params: Pagination parameters
+   */
+  getOfficeHoursTicketCsv(
+    courseSiteId: number,
+    params: OfficeHourStatisticsPaginationParams | null
+  ) {
+    let route = params
+      ? `/api/my-courses/${courseSiteId}/statistics/csv` +
+        '?' +
+        new URLSearchParams(params).toString()
+      : `/api/my-courses/${courseSiteId}/statistics/csv`;
+    return this.http.get(route, {
+      responseType: 'blob'
+    });
   }
 }

--- a/frontend/src/app/my-courses/widgets/office-hours-statistics-card/office-hours-statistics-card.widget.html
+++ b/frontend/src/app/my-courses/widgets/office-hours-statistics-card/office-hours-statistics-card.widget.html
@@ -10,7 +10,7 @@
       </p>
       @if(rightStatistic() && rightStatisticLabel()) {
         <p class="statistics-card-statistic">
-          <span class="text-badge surface-background label-large"
+          <span class="text-badge surface-container-high label-large"
             >{{ rightStatistic() }}</span
           >{{ rightStatisticLabel() }}
         </p>

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -149,21 +149,21 @@ body {
 
   .primary-button {
     .mat-icon {
-      color: white !important;
+      color: mat.get-theme-color($theme, on-primary) !important;
     }
     @include mat.button-color($theme, $color-variant: primary);
   }
 
   .secondary-button {
     .mat-icon {
-      color: white !important;
+      color: mat.get-theme-color($theme, on-secondary) !important;
     }
     @include mat.button-color($theme, $color-variant: secondary);
   }
 
   .tertiary-button {
     .mat-icon {
-      color: white !important;
+      color: mat.get-theme-color($theme, on-tertiary) !important;
     }
     @include mat.button-color($theme, $color-variant: tertiary);
   }


### PR DESCRIPTION
This PR adds three new features to the Office Hours Roster Page:
	•	Copy Email – Allows staff to quickly copy a student’s email address to the clipboard.
	•	View Statistics – Navigates to the course statistics page and auto-selects the student in the filter.
	•	Download Course Roster – Enables staff to download a copy of the course roster as a .csv.

## Testing 
### Copy Email Feature
1. Navigate to the OH Roster page.
2. Click on the copy icon next to the student's email.
3. A snackbar should appear, confirming that the email was copied to the clipboard.

### View Statistics Feature
1. Navigate to the OH Roster page.
2. Click on the equalizer icon towards the far right of the row that you are interested in.
3. You will then be navigated to the statistics page, and the student will be auto-selected in the filters.
4. A snackbar should appear, confirming that you are navigating to statistics for that specific student.

### Download Roster Feature
1. Navigate to the OH Roster page.
2. Click on the download button in the right corner.
3. A snackbar should appear, confirming that you have downloaded the course roster.
4. You should be able to view the course-roster.csv file in your downloads.

<img width="1503" alt="Screenshot 2025-04-01 at 7 28 38 PM" src="https://github.com/user-attachments/assets/6dc73b4d-bb09-4006-b147-9fa2df817667" />