### PR TITLE
(fix:743) Statistics Filter Hotfix

### DIFF
--- a/backend/models/pagination.py
+++ b/backend/models/pagination.py
@@ -43,4 +43,4 @@ class Paginated(BaseModel, Generic[T]):
 
     items: list[T]
     length: int
-    params: PaginationParams | EventPaginationParams
+    params: PaginationParams | EventPaginationParams | TicketPaginationParams


### PR DESCRIPTION
This hotfix ensures that filters applied to tickets do not get overwritten on page changes. Turns out this was caused because the correct pagination parameters did not propagate to the frontend.

*Resolves #743*