### PR TITLE
(task:751) Office Hours Statistics Hotfixes

### DIFF
--- a/backend/models/pagination.py
+++ b/backend/models/pagination.py
@@ -43,4 +43,4 @@ class Paginated(BaseModel, Generic[T]):
 
     items: list[T]
     length: int
-    params: PaginationParams | EventPaginationParams
+    params: PaginationParams | EventPaginationParams | TicketPaginationParams

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -25,7 +25,7 @@ export class AppComponent implements OnInit {
       .subscribe(() => {
         // When the route navigation is completed, get the child
         this.childRoute =
-          this.route.firstChild?.snapshot.url[0].path || 'root';
+          this.route.firstChild?.snapshot.url[0]?.path || 'root';
       });
   }
 }

--- a/frontend/src/app/my-courses/course/course.component.ts
+++ b/frontend/src/app/my-courses/course/course.component.ts
@@ -30,45 +30,45 @@ import { NagivationAdminGearService } from 'src/app/navigation/navigation-admin-
 })
 export class CourseComponent {
   /** Links for the tab bar */
+  isStaff: WritableSignal<boolean> = signal(false);
   isInstructor: WritableSignal<boolean> = signal(false);
+
+  officeHoursLink = {
+    label: 'Office Hours',
+    path: `/course/${this.route.snapshot.params['course_site_id']}/office-hours`,
+    icon: 'person_raised_hand'
+  };
+
+  statisticsLink = {
+    label: 'Statistics',
+    path: `/course/${this.route.snapshot.params['course_site_id']}/statistics`,
+    icon: 'analytics'
+  };
+
+  rosterLink = {
+    label: 'Roster',
+    path: `/course/${this.route.snapshot.params['course_site_id']}/roster`,
+    icon: 'groups'
+  };
+
+  settingsLink = {
+    label: 'Settings',
+    path: `/course/${this.route.snapshot.params['course_site_id']}/settings`,
+    icon: 'settings'
+  };
 
   links = computed(() => {
     if (this.isInstructor()) {
       return [
-        {
-          label: 'Office Hours',
-          path: `/course/${this.route.snapshot.params['course_site_id']}/office-hours`,
-          icon: 'person_raised_hand'
-        },
-        {
-          label: 'Statistics',
-          path: `/course/${this.route.snapshot.params['course_site_id']}/statistics`,
-          icon: 'analytics'
-        },
-        {
-          label: 'Roster',
-          path: `/course/${this.route.snapshot.params['course_site_id']}/roster`,
-          icon: 'groups'
-        },
-        {
-          label: 'Settings',
-          path: `/course/${this.route.snapshot.params['course_site_id']}/settings`,
-          icon: 'settings'
-        }
+        this.officeHoursLink,
+        this.statisticsLink,
+        this.rosterLink,
+        this.settingsLink
       ];
+    } else if (this.isStaff()) {
+      return [this.officeHoursLink, this.statisticsLink, this.rosterLink];
     } else {
-      return [
-        {
-          label: 'Office Hours',
-          path: `/course/${this.route.snapshot.params['course_site_id']}/office-hours`,
-          icon: 'person_raised_hand'
-        },
-        {
-          label: 'Roster',
-          path: `/course/${this.route.snapshot.params['course_site_id']}/roster`,
-          icon: 'groups'
-        }
-      ];
+      return [this.officeHoursLink, this.rosterLink];
     }
   });
 
@@ -83,13 +83,16 @@ export class CourseComponent {
       .get<TermOverviewJson[]>('/api/my-courses')
       .pipe(map(parseTermOverviewJsonList))
       .subscribe((terms) => {
-        let isInstructor =
-          terms.flatMap((term) => term.sites).find((site) => site.id === id)
-            ?.role == 'Instructor';
+        const termRole = terms
+          .flatMap((term) => term.sites)
+          .find((site) => site.id === id)?.role;
 
-        this.isInstructor.set(isInstructor);
+        this.isStaff.set(
+          termRole == 'UTA' || termRole == 'GTA' || termRole == 'Instructor'
+        );
+        this.isInstructor.set(termRole == 'Instructor');
 
-        if (isInstructor) {
+        if (this.isInstructor()) {
           this.gearService.showAdminGear(
             'Course Settings',
             `/course/${id}/settings`


### PR DESCRIPTION
This PR adds two hotfixes for the office hours statistics feature.

* Makes the statistics tab visible for UTAs and GTAs of courses.
* Fix the filtering bug mentioned by @aliciabao in #743.
* (also) Fixes an extraneous error that was popping up on office hours pages in the console.

Note: Due to design concerns, this PR will hold off on #753 - we should discuss this in the next meeting.

*Resolves #751*