### PR TITLE
(task:757) Add Markdown Support for Event Descriptions

### DIFF
--- a/frontend/src/app/event/event-details/event-details.component.html
+++ b/frontend/src/app/event/event-details/event-details.component.html
@@ -70,7 +70,7 @@
       }
     </mat-chip-set>
 
-    <p class="description">
+    <p markdown class="description">
       {{ event().description }}
     </p>
   </mat-card-content>

--- a/frontend/src/app/event/event-editor/event-editor.component.html
+++ b/frontend/src/app/event/event-editor/event-editor.component.html
@@ -66,7 +66,7 @@
 
       <!-- Description -->
       <mat-form-field appearance="outline" color="accent">
-        <mat-label>Description</mat-label>
+        <mat-label>Description (Markdown Supported)</mat-label>
         <textarea
           matInput
           placeholder="Event description here."

--- a/frontend/src/app/event/widgets/event-card/event-card.widget.html
+++ b/frontend/src/app/event/widgets/event-card/event-card.widget.html
@@ -65,7 +65,7 @@
       </mat-chip-row>
       }
     </mat-chip-set>
-    <p class="description">
+    <p markdown class="description">
       {{ event.description }}
     </p>
   </mat-card-content>

--- a/frontend/src/app/event/widgets/featured-event-card/featured-event-card.widget.html
+++ b/frontend/src/app/event/widgets/featured-event-card/featured-event-card.widget.html
@@ -53,7 +53,7 @@
       }
     </mat-chip-set>
 
-    <p class="description">
+    <p markdown class="description">
       {{ event.description }}
     </p>
   </mat-card-content>

--- a/frontend/src/app/signage/widgets/event-card/event-card.widget.html
+++ b/frontend/src/app/signage/widgets/event-card/event-card.widget.html
@@ -68,7 +68,7 @@
           }
         }
       </mat-chip-set>
-      <p class="description headline-small">
+      <p markdown class="description headline-small">
         {{ events()[shownEvent].description }}
       </p>
       @if (events().length > 1) {


### PR DESCRIPTION
This small PR adds markdown support for event descriptions so that user-inputted events can include markdown elements (such as bold and italic text, as well as paragraph spacing).

The signage component has also been updated to show markdownified event descriptions.

*Resolves #757*