### PR TITLE
Rainy Weather Icon Hotfix

### DIFF
--- a/frontend/src/app/signage/weather.service.ts
+++ b/frontend/src/app/signage/weather.service.ts
@@ -99,11 +99,11 @@ export class WeatherService {
       // Codes 40-49 indicate fog.
       return weather_types['foggy'];
     } else if (
-      (weatherData.weatherCode >= 60 && weatherData.weatherCode <= 66) ||
-      (weatherData.weatherCode >= 80 && weatherData.weatherCode <= 82)
+      (weatherData.weatherCode >= 50 && weatherData.weatherCode <= 69) ||
+      (weatherData.weatherCode >= 80 && weatherData.weatherCode <= 84)
     ) {
-      // Codes 60-66 indicate non-freezing rain.
-      // Codes 80-82 indicate different rain shower types.
+      // Codes 50-69 indicate drizzle, rain, and freezing rain.
+      // Codes 80-84 indicate different rain shower types (mixed w/ snow)
       return weather_types['rainy'];
     } else if (
       (weatherData.weatherCode >= 70 && weatherData.weatherCode <= 75) ||


### PR DESCRIPTION
I was passing by the CSXL today and noticed that the weather icon defaulted to sunny even though it was obviously cloudy outside. I opened the Open Mateo API and saw that the weather code was set to 53: Moderate Drizzle. 

Thus, I have widened the scope of the rainy icon to account for different types of drizzle and freezing rain as well.