### PR TITLE
(task:689) Ticket Concerns and TA Notes

### DIFF
--- a/backend/api/office_hours/ticket.py
+++ b/backend/api/office_hours/ticket.py
@@ -9,7 +9,7 @@ from ...services.office_hours.ticket import OfficeHourTicketService
 from ...models.user import User
 from ...models.office_hours.ticket import (
     NewOfficeHoursTicket,
-    OfficeHoursTicketDeletePayload,
+    OfficeHoursTicketClosePayload,
 )
 
 from ...models.academics.my_courses import OfficeHourTicketOverview
@@ -60,7 +60,7 @@ def cancel_ticket(
 @api.put("/{id}/close", tags=["Office Hours"])
 def close_ticket(
     id: int,
-    payload: OfficeHoursTicketDeletePayload,
+    payload: OfficeHoursTicketClosePayload,
     subject: User = Depends(registered_user),
     oh_ticket_svc: OfficeHourTicketService = Depends(),
 ) -> OfficeHourTicketOverview:

--- a/backend/api/office_hours/ticket.py
+++ b/backend/api/office_hours/ticket.py
@@ -7,7 +7,10 @@ from fastapi import APIRouter, Depends
 from ..authentication import registered_user
 from ...services.office_hours.ticket import OfficeHourTicketService
 from ...models.user import User
-from ...models.office_hours.ticket import NewOfficeHoursTicket
+from ...models.office_hours.ticket import (
+    NewOfficeHoursTicket,
+    OfficeHoursTicketDeletePayload,
+)
 
 from ...models.academics.my_courses import OfficeHourTicketOverview
 
@@ -57,6 +60,7 @@ def cancel_ticket(
 @api.put("/{id}/close", tags=["Office Hours"])
 def close_ticket(
     id: int,
+    payload: OfficeHoursTicketDeletePayload,
     subject: User = Depends(registered_user),
     oh_ticket_svc: OfficeHourTicketService = Depends(),
 ) -> OfficeHourTicketOverview:
@@ -66,7 +70,7 @@ def close_ticket(
     Returns:
         OfficeHourQueueOverview
     """
-    return oh_ticket_svc.close_ticket(subject, id)
+    return oh_ticket_svc.close_ticket(subject, id, payload)
 
 
 @api.post("/", tags=["Office Hours"])

--- a/backend/entities/office_hours/ticket_entity.py
+++ b/backend/entities/office_hours/ticket_entity.py
@@ -155,6 +155,8 @@ class OfficeHoursTicketEntity(EntityBase):
             description=self.description,
             creators=[creator.user.to_public_model() for creator in self.creators],
             caller=(self.caller.user.to_public_model() if self.caller else None),
+            has_concerns=self.have_concerns,
+            caller_notes=self.caller_notes,
         )
 
     def to_details_model(self) -> OfficeHoursTicketDetails:

--- a/backend/models/academics/my_courses.py
+++ b/backend/models/academics/my_courses.py
@@ -92,6 +92,8 @@ class OfficeHourTicketOverview(BaseModel):
     description: str
     creators: list[PublicUser]
     caller: PublicUser | None
+    has_concerns: bool | None
+    caller_notes: str | None
 
 
 class OfficeHourStatisticsOverview(BaseModel):

--- a/backend/models/office_hours/ticket.py
+++ b/backend/models/office_hours/ticket.py
@@ -63,7 +63,7 @@ class OfficeHoursTicketCsvRow(BaseModel):
     wait_time_minutes: int
 
 
-class OfficeHoursTicketDeletePayload(BaseModel):
+class OfficeHoursTicketClosePayload(BaseModel):
     """
     Pydantic model to represent a payload for deleting a ticket.
     """

--- a/backend/models/office_hours/ticket.py
+++ b/backend/models/office_hours/ticket.py
@@ -45,11 +45,13 @@ class OfficeHoursTicket(NewOfficeHoursTicket):
     caller_notes: str = ""
     caller_id: int | None
 
+
 class OfficeHoursTicketCsvRow(BaseModel):
     """
     Pydantic model to represent a user's ticket in CSV format, which is used for
     exporting ticket data to a CSV file in the ticket statistics feature.
     """
+
     student: str
     description: str
     type: str
@@ -59,3 +61,12 @@ class OfficeHoursTicketCsvRow(BaseModel):
     closed_at: str
     duration_minutes: int
     wait_time_minutes: int
+
+
+class OfficeHoursTicketDeletePayload(BaseModel):
+    """
+    Pydantic model to represent a payload for deleting a ticket.
+    """
+
+    has_concerns: bool
+    caller_notes: str

--- a/backend/services/office_hours/ticket.py
+++ b/backend/services/office_hours/ticket.py
@@ -16,6 +16,7 @@ from ...models.academics.my_courses import (
 from ...models.office_hours.ticket import (
     TicketState,
     NewOfficeHoursTicket,
+    OfficeHoursTicketDeletePayload,
 )
 
 from ...entities.academics.section_entity import SectionEntity
@@ -142,7 +143,9 @@ class OfficeHourTicketService:
         # Return the changed ticket
         return ticket_entity.to_overview_model()
 
-    def close_ticket(self, user: User, ticket_id: int) -> OfficeHourTicketOverview:
+    def close_ticket(
+        self, user: User, ticket_id: int, payload: OfficeHoursTicketDeletePayload
+    ) -> OfficeHourTicketOverview:
         """
         Closes a ticket in an office hour queue.
 
@@ -184,6 +187,8 @@ class OfficeHourTicketService:
         # Close the ticket
         ticket_entity.closed_at = datetime.now()
         ticket_entity.state = TicketState.CLOSED
+        ticket_entity.have_concerns = payload.has_concerns
+        ticket_entity.caller_notes = payload.caller_notes
 
         # Save changes
         self._session.commit()

--- a/backend/services/office_hours/ticket.py
+++ b/backend/services/office_hours/ticket.py
@@ -16,7 +16,7 @@ from ...models.academics.my_courses import (
 from ...models.office_hours.ticket import (
     TicketState,
     NewOfficeHoursTicket,
-    OfficeHoursTicketDeletePayload,
+    OfficeHoursTicketClosePayload,
 )
 
 from ...entities.academics.section_entity import SectionEntity
@@ -144,7 +144,7 @@ class OfficeHourTicketService:
         return ticket_entity.to_overview_model()
 
     def close_ticket(
-        self, user: User, ticket_id: int, payload: OfficeHoursTicketDeletePayload
+        self, user: User, ticket_id: int, payload: OfficeHoursTicketClosePayload
     ) -> OfficeHourTicketOverview:
         """
         Closes a ticket in an office hour queue.

--- a/backend/test/services/office_hours/office_hours_data.py
+++ b/backend/test/services/office_hours/office_hours_data.py
@@ -36,7 +36,7 @@ from ....models.office_hours.course_site import (
 from ....models.office_hours.ticket import (
     OfficeHoursTicket,
     NewOfficeHoursTicket,
-    OfficeHoursTicketDeletePayload,
+    OfficeHoursTicketClosePayload,
 )
 from ....models.office_hours.ticket_type import TicketType
 from ....models.office_hours.ticket_state import TicketState
@@ -614,7 +614,7 @@ nonexistent_event = OfficeHours(
     recurrence_pattern_id=None,
 )
 
-sample_delete_payload = OfficeHoursTicketDeletePayload(
+sample_delete_payload = OfficeHoursTicketClosePayload(
     has_concerns=True,
     caller_notes="I have concerns.",
 )

--- a/backend/test/services/office_hours/office_hours_data.py
+++ b/backend/test/services/office_hours/office_hours_data.py
@@ -33,7 +33,11 @@ from ....models.office_hours.course_site import (
     NewCourseSite,
     UpdatedCourseSite,
 )
-from ....models.office_hours.ticket import OfficeHoursTicket, NewOfficeHoursTicket
+from ....models.office_hours.ticket import (
+    OfficeHoursTicket,
+    NewOfficeHoursTicket,
+    OfficeHoursTicketDeletePayload,
+)
 from ....models.office_hours.ticket_type import TicketType
 from ....models.office_hours.ticket_state import TicketState
 
@@ -608,4 +612,9 @@ nonexistent_event = OfficeHours(
     course_site_id=comp_110_site.id,
     room_id=room_data.group_a.id,
     recurrence_pattern_id=None,
+)
+
+sample_delete_payload = OfficeHoursTicketDeletePayload(
+    has_concerns=True,
+    caller_notes="I have concerns.",
 )

--- a/backend/test/services/office_hours/ticket_test.py
+++ b/backend/test/services/office_hours/ticket_test.py
@@ -128,7 +128,9 @@ def test_cancel_ticket_student(oh_ticket_svc: OfficeHourTicketService):
 def test_close_ticket(oh_ticket_svc: OfficeHourTicketService):
     """Ensures that instructors can close tickets."""
     called = oh_ticket_svc.close_ticket(
-        user_data.instructor, office_hours_data.comp_110_called_ticket.id
+        user_data.instructor,
+        office_hours_data.comp_110_called_ticket.id,
+        office_hours_data.sample_delete_payload,
     )
     assert called.state == TicketState.CLOSED.to_string()
 
@@ -137,13 +139,19 @@ def test_close_ticket_not_called(oh_ticket_svc: OfficeHourTicketService):
     """Ensures that only called tickets can be closed."""
     with pytest.raises(CoursePermissionException):
         oh_ticket_svc.close_ticket(
-            user_data.instructor, office_hours_data.comp_110_queued_ticket.id
+            user_data.instructor,
+            office_hours_data.comp_110_queued_ticket.id,
+            office_hours_data.sample_delete_payload,
         )
         oh_ticket_svc.close_ticket(
-            user_data.instructor, office_hours_data.comp_110_closed_ticket.id
+            user_data.instructor,
+            office_hours_data.comp_110_closed_ticket.id,
+            office_hours_data.sample_delete_payload,
         )
         oh_ticket_svc.close_ticket(
-            user_data.instructor, office_hours_data.comp_110_cancelled_ticket.id
+            user_data.instructor,
+            office_hours_data.comp_110_cancelled_ticket.id,
+            office_hours_data.sample_delete_payload,
         )
         pytest.fail()
 
@@ -151,7 +159,9 @@ def test_close_ticket_not_called(oh_ticket_svc: OfficeHourTicketService):
 def test_close_ticket_not_found(oh_ticket_svc: OfficeHourTicketService):
     """Ensures that an error is thrown if attempting to close a ticket that does not exist."""
     with pytest.raises(ResourceNotFoundException):
-        oh_ticket_svc.close_ticket(user_data.instructor, 404)
+        oh_ticket_svc.close_ticket(
+            user_data.instructor, 404, office_hours_data.sample_delete_payload
+        )
         pytest.fail()
 
 
@@ -159,7 +169,9 @@ def test_close_ticket_not_member(oh_ticket_svc: OfficeHourTicketService):
     """Ensures that non-members cannot close tickets."""
     with pytest.raises(CoursePermissionException):
         oh_ticket_svc.close_ticket(
-            user_data.ambassador, office_hours_data.comp_110_called_ticket.id
+            user_data.ambassador,
+            office_hours_data.comp_110_called_ticket.id,
+            office_hours_data.sample_delete_payload,
         )
         pytest.fail()
 
@@ -168,7 +180,9 @@ def test_close_ticket_not_staff(oh_ticket_svc: OfficeHourTicketService):
     """Ensures that non-staff members cannot close tickets."""
     with pytest.raises(CoursePermissionException):
         oh_ticket_svc.close_ticket(
-            user_data.student, office_hours_data.comp_110_called_ticket.id
+            user_data.student,
+            office_hours_data.comp_110_called_ticket.id,
+            office_hours_data.sample_delete_payload,
         )
         pytest.fail()
 

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-queue/office-hours-queue.component.ts
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-queue/office-hours-queue.component.ts
@@ -23,6 +23,8 @@ import {
 import { MyCoursesService } from 'src/app/my-courses/my-courses.service';
 import { officeHourPageGuard } from '../office-hours.guard';
 import { Title } from '@angular/platform-browser';
+import { MatDialog } from '@angular/material/dialog';
+import { CloseTicketDialog } from '../widgets/close-ticket-dialog/close-ticket.dialog';
 
 /** Store both possible titles as strings to flash between them easily */
 const ORIGINAL_TITLE: string = 'Office Hours Queue';
@@ -62,7 +64,8 @@ export class OfficeHoursQueueComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private snackBar: MatSnackBar,
     protected myCoursesService: MyCoursesService,
-    private titleService: Title
+    private titleService: Title,
+    protected dialog: MatDialog
   ) {
     // Load information from the parent route
     this.ohEventId = this.route.snapshot.params['event_id'];
@@ -152,9 +155,14 @@ export class OfficeHoursQueueComponent implements OnInit, OnDestroy {
 
   /** Closes a ticket and reloads the queue data */
   closeTicket(ticket: OfficeHourTicketOverview): void {
-    this.myCoursesService.closeTicket(ticket.id).subscribe({
-      next: (_) => this.pollQueue(),
-      error: (err) => this.snackBar.open(err, '', { duration: 2000 })
+    let dialogRef = this.dialog.open(CloseTicketDialog, {
+      height: '400px',
+      width: '500px',
+      data: ticket.id
+    });
+    dialogRef.afterClosed().subscribe((_) => {
+      // Update the data.
+      this.pollQueue();
     });
   }
 }

--- a/frontend/src/app/my-courses/course/office-hours/widgets/close-ticket-dialog/close-ticket.dialog.css
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/close-ticket-dialog/close-ticket.dialog.css
@@ -1,0 +1,8 @@
+mat-form-field {
+    width: 100%;
+}
+
+mat-slide-toggle {
+    padding-top: 12px;
+    padding-bottom: 18px;
+}

--- a/frontend/src/app/my-courses/course/office-hours/widgets/close-ticket-dialog/close-ticket.dialog.html
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/close-ticket-dialog/close-ticket.dialog.html
@@ -1,0 +1,26 @@
+<h2 mat-dialog-title>Close Ticket</h2>
+<mat-dialog-content>
+    <p>Please leave feedback below.</p>
+    <mat-slide-toggle
+    [formControl]="hasConcerns">
+        I have concerns about this ticket.  
+    </mat-slide-toggle>
+
+    <mat-form-field appearance="outline">
+        <mat-label>Notes</mat-label>
+        <textarea
+          matInput
+          placeholder="Please leave any notes here."
+          [formControl]="notes"
+          required></textarea>
+      </mat-form-field>
+</mat-dialog-content>
+<mat-dialog-actions>
+    <button
+      mat-flat-button
+      color="primary"
+      (click)="submit()"
+    >
+      Close Ticket
+    </button>
+</mat-dialog-actions>

--- a/frontend/src/app/my-courses/course/office-hours/widgets/close-ticket-dialog/close-ticket.dialog.ts
+++ b/frontend/src/app/my-courses/course/office-hours/widgets/close-ticket-dialog/close-ticket.dialog.ts
@@ -1,0 +1,47 @@
+import { Component, Inject, signal, WritableSignal } from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Router } from '@angular/router';
+import { MyCoursesService } from 'src/app/my-courses/my-courses.service';
+
+@Component({
+  selector: 'dialog-close-ticket',
+  templateUrl: './close-ticket.dialog.html',
+  styleUrl: './close-ticket.dialog.css'
+})
+export class CloseTicketDialog {
+  hasConcerns = new FormControl(false);
+  notes = new FormControl('');
+
+  constructor(
+    protected dialogRef: MatDialogRef<CloseTicketDialog>,
+    @Inject(MAT_DIALOG_DATA) public ticketId: number,
+    protected myCoursesService: MyCoursesService,
+    private router: Router,
+    private snackBar: MatSnackBar
+  ) {}
+
+  /**
+   * Submits the form and closes a ticket.
+   */
+  submit(): void {
+    this.myCoursesService
+      .closeTicket(
+        this.ticketId,
+        this.hasConcerns.value ?? false,
+        this.notes.value ?? ''
+      )
+      .subscribe({
+        next: () => {
+          this.close();
+        },
+        error: (err) => this.snackBar.open(err, '', { duration: 2000 })
+      });
+  }
+
+  /** Closes the dialog */
+  close(): void {
+    this.dialogRef.close();
+  }
+}

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.css
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.css
@@ -138,3 +138,17 @@
     flex-direction: column;
     gap: 12px;
 }
+
+.text-badge {
+    height: 20px;
+    width: 76px;
+    text-align: center;
+    padding-left: 12px;
+    padding-right: 12px;
+    padding-top: 6px;
+    padding-bottom: 6px;
+    border-radius: 14px;
+    margin-right: 8px;
+    line-height: 32px;
+    color: white;
+}

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.css
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.css
@@ -1,154 +1,157 @@
 ::ng-deep .mat-pane {
-    margin-right: 32px !important;
+  margin-right: 32px !important;
 }
 
 .container {
-    height: 100%;
+  height: 100%;
 
-    ::ng-deep .mat-pane {
-        max-width: 100% !important;
-        min-height: 73vh;
-        margin-bottom: 32px !important;
-    }
+  ::ng-deep .mat-pane {
+    max-width: 100% !important;
+    min-height: 73vh;
+    margin-bottom: 32px !important;
+  }
 }
 
 .mat-mdc-card-header {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-    padding-bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding-bottom: 16px;
 }
 
 .ticket-history-toolbar {
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .ticket-history-toolbar-options {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 16px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 16px;
 }
 
 #download-button-icon {
-    margin-right: -8px;
+  margin-right: -8px;
 }
 
 .mat-filter-chip-content {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .mat-filter-chip-main-content {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .mat-filter-chip-leading-icon {
-    padding-left: 0 !important;
+  padding-left: 0 !important;
 }
 
 .mat-filter-chip-accessory {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
 }
 
 .date-input {
-    position: relative;
-    float:bottom;
-    margin-top: auto;
-    margin-bottom: -10px;
+  position: relative;
+  float: bottom;
+  margin-top: auto;
+  margin-bottom: -10px;
 }
 
 .date-picker-container {
-    padding-top: -12px;
-    height: 32px;
+  padding-top: -12px;
+  height: 32px;
 }
 
 .mat-filter-chip-divider {
-    height: 30px;
+  height: 30px;
 }
 
 .statistics-row {
-    display: flex;
-    flex-direction: row;
-    gap: 24px;
-    margin-top: 16px;
+  display: flex;
+  flex-direction: row;
+  gap: 24px;
+  margin-top: 16px;
 }
 
 ::ng-deep .ticket-history-card {
-    max-width: 100% !important;
-    max-height: 100% !important;
-    margin-left: 0 !important;
-    margin-right: 0 !important;
-    margin-top: 16px;
+  max-width: 100% !important;
+  max-height: 100% !important;
+  margin-left: 0 !important;
+  margin-right: 0 !important;
+  margin-top: 16px;
 }
 
 .ticket-row {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    gap: 16px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
 
-    p {
-        margin-bottom: 0;
-    }
+  p {
+    margin-bottom: 0;
+  }
 }
 
 .semibold {
-    font-weight: 500;
+  font-weight: 500;
 }
 
 .ticket-row-user-chips {
-    display: flex;
-    flex-direction: row;
-    gap: 8px;
-    padding-left: 16px;
-    padding-bottom: -8px;
+  display: flex;
+  flex-direction: row;
+  gap: 8px;
+  padding-left: 16px;
+  padding-bottom: -8px;
 }
 
-::ng-deep .ticket-row-user-chips >  .user-chips {
-    margin-bottom: 0 !important;
+::ng-deep .ticket-row-user-chips > .user-chips {
+  margin-bottom: 0 !important;
 }
 
 .ticket-row-leading-content {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 16px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 16px;
 }
 
 .ticket-row-trailing-content {
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    gap: 16px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
+.feedback-indicator {
+  margin-top: 4px;
 }
 
 .ticket-list {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .text-badge {
-    height: 20px;
-    width: 76px;
-    text-align: center;
-    padding-left: 12px;
-    padding-right: 12px;
-    padding-top: 6px;
-    padding-bottom: 6px;
-    border-radius: 14px;
-    margin-right: 8px;
-    line-height: 32px;
-    color: white;
+  height: 20px;
+  width: 76px;
+  text-align: center;
+  padding-left: 12px;
+  padding-right: 12px;
+  padding-top: 6px;
+  padding-bottom: 6px;
+  border-radius: 14px;
+  margin-right: 8px;
+  line-height: 32px;
+  color: white;
 }

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -106,8 +106,8 @@
                       </div>
                     </div>
                     <div class="ticket-row-trailing-content">
-                      @if(item.has_concerns) {
-                        <span class="text-badge tertiary-background label-large">! Concern</span>
+                      @if(item.has_concerns || (item.caller_notes && item.caller_notes != "")) {
+                        <mat-icon [color]="item.has_concerns ? 'warn' : 'secondary'" class="feedback-indicator">feedback</mat-icon>
                       }
                       <button mat-icon-button (click)="openTicketDetails(item)">
                         <mat-icon>more_vert</mat-icon>

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -107,7 +107,7 @@
                     </div>
                     <div class="ticket-row-trailing-content">
                       @if(item.has_concerns || (item.caller_notes && item.caller_notes != "")) {
-                        <mat-icon [color]="item.has_concerns ? 'warn' : 'secondary'" class="feedback-indicator">feedback</mat-icon>
+                        <mat-icon [class]="'feedback-indicator ' + (item.has_concerns ? 'font-error' : 'font-secondary')">feedback</mat-icon>
                       }
                       <button mat-icon-button (click)="openTicketDetails(item)">
                         <mat-icon>more_vert</mat-icon>

--- a/frontend/src/app/my-courses/course/statistics/statistics.component.html
+++ b/frontend/src/app/my-courses/course/statistics/statistics.component.html
@@ -106,6 +106,9 @@
                       </div>
                     </div>
                     <div class="ticket-row-trailing-content">
+                      @if(item.has_concerns) {
+                        <span class="text-badge tertiary-background label-large">! Concern</span>
+                      }
                       <button mat-icon-button (click)="openTicketDetails(item)">
                         <mat-icon>more_vert</mat-icon>
                       </button>

--- a/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.html
+++ b/frontend/src/app/my-courses/dialogs/ticket-details/ticket-details.dialog.html
@@ -30,4 +30,9 @@
   <p markdown>
     {{ data.ticket.description }}
   </p>
+  <mat-divider />
+  <p mat-card-subtitle>Caller Notes</p>
+  <p markdown>
+    {{ data.ticket.caller_notes ?? 'None'}}
+  </p>
 </mat-dialog-content>

--- a/frontend/src/app/my-courses/my-courses.model.ts
+++ b/frontend/src/app/my-courses/my-courses.model.ts
@@ -124,6 +124,8 @@ export interface OfficeHourTicketOverviewJson {
   description: string;
   creators: PublicProfile[];
   caller: PublicProfile | undefined;
+  has_concerns: boolean | undefined;
+  caller_notes: string | undefined;
 }
 
 export interface OfficeHourTicketOverview {
@@ -136,6 +138,8 @@ export interface OfficeHourTicketOverview {
   description: string;
   creators: PublicProfile[];
   caller: PublicProfile | undefined;
+  has_concerns: boolean | undefined;
+  caller_notes: string | undefined;
 }
 
 export interface OfficeHourQueueOverviewJson {

--- a/frontend/src/app/my-courses/my-courses.module.ts
+++ b/frontend/src/app/my-courses/my-courses.module.ts
@@ -55,6 +55,8 @@ import { MatCheckbox } from '@angular/material/checkbox';
 import { StatisticsComponent } from './course/statistics/statistics.component';
 import { OfficeHoursStatisticsCardWidget } from './widgets/office-hours-statistics-card/office-hours-statistics-card.widget';
 import { TicketDetailsDialog } from './dialogs/ticket-details/ticket-details.dialog';
+import { CloseTicketDialog } from './course/office-hours/widgets/close-ticket-dialog/close-ticket.dialog';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 @NgModule({
   declarations: [
@@ -78,7 +80,8 @@ import { TicketDetailsDialog } from './dialogs/ticket-details/ticket-details.dia
     ImportRosterDialog,
     DeleteRecurringEventDialog,
     TicketDetailsDialog,
-    OfficeHoursStatisticsCardWidget
+    OfficeHoursStatisticsCardWidget,
+    CloseTicketDialog
   ],
   imports: [
     CommonModule,
@@ -105,7 +108,8 @@ import { TicketDetailsDialog } from './dialogs/ticket-details/ticket-details.dia
     MatDatepickerModule,
     MatNativeDateModule,
     MatRadioModule,
-    MatCheckbox
+    MatCheckbox,
+    MatSlideToggleModule
   ],
   providers: [MatDatepickerModule]
 })

--- a/frontend/src/app/my-courses/my-courses.service.ts
+++ b/frontend/src/app/my-courses/my-courses.service.ts
@@ -46,6 +46,7 @@ import { Observable, map } from 'rxjs';
 import { NagivationAdminGearService } from '../navigation/navigation-admin-gear.service';
 import { Paginated } from '../pagination';
 import saveAs from 'file-saver';
+import { consumerPollProducersForChange } from '@angular/core/primitives/signals';
 
 /** Enum for days of the week */
 export enum Weekday {
@@ -184,11 +185,15 @@ export class MyCoursesService {
    * @param ticketId: ID of the ticket to close
    * @returns { Observable<OfficeHourTicketOverview> }
    */
-  closeTicket(ticketId: number): Observable<OfficeHourTicketOverview> {
+  closeTicket(
+    ticketId: number,
+    hasConcerns: boolean,
+    notes: string
+  ): Observable<OfficeHourTicketOverview> {
     return this.http
       .put<OfficeHourTicketOverviewJson>(
         `/api/office-hours/ticket/${ticketId}/close`,
-        {}
+        { has_concerns: hasConcerns, caller_notes: notes }
       )
       .pipe(map(parseOfficeHourTicketOverviewJson));
   }

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -414,6 +414,9 @@ body {
   .font-secondary {
     color: mat.get-theme-color($theme, secondary) !important;
   }
+  .font-error {
+    color: mat.get-theme-color($theme, error) !important;
+  }
   .font-tertiary {
     color: mat.get-theme-color($theme, tertiary) !important;
   }

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -54,7 +54,6 @@ body {
     color: mat.get-theme-color($theme, on-surface) !important;
   }
 
-
   .primary-color {
     color: mat.get-theme-color($theme, primary) !important;
   }


### PR DESCRIPTION
This PR adds the ability for TAs to mark tickets as concerning and to provide notes for later. These notes are also then shown in the summary / ticket history page.

This should not require any migrations - all fields already existed in the entities, just never surfaced. 

### Closing a Ticket

When closing a ticket, a dialog now pops up prompting the staff for more information. Once it is filled out, the ticket is closed.

<img width="1438" alt="Screenshot 2025-04-08 at 2 51 08 PM" src="https://github.com/user-attachments/assets/2efa4729-8a43-4f9e-97eb-69854925bdc1" />

### Summary Page

Tickets are marked with a concern badge if a TA has marked the ticket as concerning. 

<img width="1438" alt="Screenshot 2025-04-08 at 2 52 14 PM" src="https://github.com/user-attachments/assets/cbe350df-6e46-49da-9c23-bbb36544892f" />

### Notes

Notes for tickets are available in the dialog:

<img width="1438" alt="Screenshot 2025-04-08 at 2 52 43 PM" src="https://github.com/user-attachments/assets/21ec01ff-5585-413c-9a42-9db2b3030701" />

### Future Tasks

* We can add a statistics panel for concerns and filters for this as well.

### Testing

Tests pass.

*Resolves #689*