### PR TITLE
Task/768-ticket-tags-backend: Implement Ticket Tags Backend

### DIFF
--- a/backend/api/academics/my_courses.py
+++ b/backend/api/academics/my_courses.py
@@ -20,7 +20,6 @@ from ...models.academics.my_courses import (
     TermOverview,
     CourseMemberOverview,
     OfficeHoursOverview,
-    CourseSiteOverview,
     OfficeHourTicketOverview,
 )
 from ...models.office_hours.course_site import (
@@ -28,7 +27,6 @@ from ...models.office_hours.course_site import (
     CourseSite,
     UpdatedCourseSite,
 )
-from ...models.office_hours.course_site_details import CourseSiteDetails
 from ...models.pagination import PaginationParams, Paginated, TicketPaginationParams
 
 __authors__ = ["Kris Jordan", "Ajay Gandecha"]
@@ -195,6 +193,7 @@ def get_paginated_ticket_history(
     page_size: int = 10,
     student_ids: str = "",
     staff_ids: str = "",
+    tag_ids: str = "",
     range_start: str = "",
     range_end: str = "",
     subject: User = Depends(registered_user),
@@ -212,6 +211,7 @@ def get_paginated_ticket_history(
         page_size=page_size,
         student_ids=json.loads(student_ids) if len(student_ids) > 0 else [],
         staff_ids=json.loads(staff_ids) if len(staff_ids) > 0 else [],
+        tag_ids=json.loads(tag_ids) if len(tag_ids) > 0 else [],
         range_start=range_start,
         range_end=range_end,
     )
@@ -230,44 +230,12 @@ def get_statistics_filter_data(
     return oh_statistics_svc.get_filter_data(subject, course_site_id)
 
 
-@api.get("/{course_site_id}/statistics/ticket-history", tags=["My Courses"])
-def get_paginated_ticket_history(
-    course_site_id: int,
-    page: int = 0,
-    page_size: int = 10,
-    student_ids: str = "",
-    staff_ids: str = "",
-    range_start: str = "",
-    range_end: str = "",
-    subject: User = Depends(registered_user),
-    oh_statistics_svc: OfficeHoursStatisticsService = Depends(),
-) -> Paginated[OfficeHourTicketOverview]:
-    """
-    Gets the past office hour event overviews for a given class.
-
-    Returns:
-        Paginated[OfficeHoursOverview]
-    """
-
-    ticket_pagination_params = TicketPaginationParams(
-        page=page,
-        page_size=page_size,
-        student_ids=json.loads(student_ids) if len(student_ids) > 0 else [],
-        staff_ids=json.loads(staff_ids) if len(staff_ids) > 0 else [],
-        range_start=range_start,
-        range_end=range_end,
-    )
-
-    return oh_statistics_svc.get_paginated_tickets(
-        subject, course_site_id, ticket_pagination_params
-    )
-
-
 @api.get("/{course_site_id}/statistics", tags=["My Courses"])
 def get_ticket_statistics(
     course_site_id: int,
     student_ids: str = "",
     staff_ids: str = "",
+    tag_ids: str = "",
     range_start: str = "",
     range_end: str = "",
     subject: User = Depends(registered_user),
@@ -282,6 +250,7 @@ def get_ticket_statistics(
     ticket_statistics_params = TicketPaginationParams(
         student_ids=json.loads(student_ids) if len(student_ids) > 0 else [],
         staff_ids=json.loads(staff_ids) if len(staff_ids) > 0 else [],
+        tag_ids=json.loads(tag_ids) if len(tag_ids) > 0 else [],
         range_start=range_start,
         range_end=range_end,
     )
@@ -296,6 +265,7 @@ def get_ticket_statistics_csv(
     course_site_id: int,
     student_ids: str = "",
     staff_ids: str = "",
+    tag_ids: str = "",
     range_start: str = "",
     range_end: str = "",
     subject: User = Depends(registered_user),
@@ -311,6 +281,7 @@ def get_ticket_statistics_csv(
     ticket_statistics_params = TicketPaginationParams(
         student_ids=json.loads(student_ids) if len(student_ids) > 0 else [],
         staff_ids=json.loads(staff_ids) if len(staff_ids) > 0 else [],
+        tag_ids=json.loads(tag_ids) if len(tag_ids) > 0 else [],
         range_start=range_start,
         range_end=range_end,
     )

--- a/backend/api/office_hours/ticket.py
+++ b/backend/api/office_hours/ticket.py
@@ -4,15 +4,19 @@ APIs handling office hours.
 """
 
 from fastapi import APIRouter, Depends
+
 from ..authentication import registered_user
 from ...services.office_hours.ticket import OfficeHourTicketService
+from ...services.office_hours.ticket_tag import OfficeHourTicketTagService
 from ...models.user import User
 from ...models.office_hours.ticket import NewOfficeHoursTicket
+from ...models.office_hours.ticket_tag import NewOfficeHoursTicketTag, OfficeHoursTicketTag, OfficeHoursTicketTagDetails
 
 from ...models.academics.my_courses import OfficeHourTicketOverview
 
 __authors__ = [
     "Ajay Gandecha",
+    "Jade Keegan",
     "Sadie Amato",
     "Bailey DeSouza",
     "Meghan Sun",
@@ -82,3 +86,45 @@ def new_oh_ticket(
         OfficeHoursTicketDetails: OH Ticket created
     """
     return oh_ticket_svc.create_ticket(subject, ticket)
+
+@api.post("/{site_id}/tag", tags=["Office Hours"])
+def new_ticket_tag(
+    site_id: int,
+    tag: NewOfficeHoursTicketTag,
+    subject: User = Depends(registered_user),
+    oh_ticket_tag_svc: OfficeHourTicketTagService = Depends(),
+) -> OfficeHoursTicketTag:
+    """
+    Create a new ticket tag for the course site.
+
+    Returns:
+        OfficeHoursTicketTagDetails: Ticket tag created
+    """
+    return oh_ticket_tag_svc.create(subject, site_id, tag)
+
+@api.put("/{site_id}/tag", tags=["Office Hours"])
+def update_ticket_tag(
+    site_id: int,
+    tag: OfficeHoursTicketTag,
+    subject: User = Depends(registered_user),
+    oh_ticket_tag_svc: OfficeHourTicketTagService = Depends(),
+) -> OfficeHoursTicketTag:
+    """
+    Update an existing ticket tag.
+
+    Returns:
+        OfficeHoursTicketTagDetails: Updated ticket tag
+    """
+    return oh_ticket_tag_svc.update(subject, site_id, tag)
+
+@api.delete("/{site_id}/tag", tags=["Office Hours"])
+def delete_ticket_tag(
+    site_id: int,
+    tag_id: int,
+    subject: User = Depends(registered_user),
+    oh_ticket_tag_svc: OfficeHourTicketTagService = Depends(),
+) -> OfficeHoursTicketTag:
+    """
+    Delete an existing ticket tag.
+    """
+    oh_ticket_tag_svc.update(subject, site_id, tag_id)

--- a/backend/api/office_hours/ticket.py
+++ b/backend/api/office_hours/ticket.py
@@ -87,6 +87,20 @@ def new_oh_ticket(
     """
     return oh_ticket_svc.create_ticket(subject, ticket)
 
+@api.get("/{site_id}/tag", tags=["Office Hours"])
+def get_ticket_tags(
+    site_id: int,
+    subject: User = Depends(registered_user),
+    oh_ticket_tag_svc: OfficeHourTicketTagService = Depends(),
+) -> list[OfficeHoursTicketTag]:
+    """
+    Get all ticket tags for the course site.
+
+    Returns:
+        list[OfficeHoursTicketTagDetails]: List of ticket tags
+    """
+    return oh_ticket_tag_svc.get_course_site_tags(subject, site_id)
+
 @api.post("/{site_id}/tag", tags=["Office Hours"])
 def new_ticket_tag(
     site_id: int,
@@ -98,7 +112,7 @@ def new_ticket_tag(
     Create a new ticket tag for the course site.
 
     Returns:
-        OfficeHoursTicketTagDetails: Ticket tag created
+        OfficeHoursTicketTag: Ticket tag created
     """
     return oh_ticket_tag_svc.create(subject, site_id, tag)
 
@@ -113,18 +127,18 @@ def update_ticket_tag(
     Update an existing ticket tag.
 
     Returns:
-        OfficeHoursTicketTagDetails: Updated ticket tag
+        OfficeHoursTicketTag: Updated ticket tag
     """
     return oh_ticket_tag_svc.update(subject, site_id, tag)
 
-@api.delete("/{site_id}/tag", tags=["Office Hours"])
+@api.delete("/{site_id}/tag/{tag_id}", tags=["Office Hours"])
 def delete_ticket_tag(
     site_id: int,
     tag_id: int,
     subject: User = Depends(registered_user),
     oh_ticket_tag_svc: OfficeHourTicketTagService = Depends(),
-) -> OfficeHoursTicketTag:
+):
     """
     Delete an existing ticket tag.
     """
-    oh_ticket_tag_svc.update(subject, site_id, tag_id)
+    oh_ticket_tag_svc.delete(subject, site_id, tag_id)

--- a/backend/entities/office_hours/__init__.py
+++ b/backend/entities/office_hours/__init__.py
@@ -3,5 +3,5 @@ from .office_hours_recurrence_pattern_entity import OfficeHoursRecurrencePattern
 from .course_site_entity import CourseSiteEntity
 from .ticket_entity import OfficeHoursTicketEntity
 from .user_created_tickets_table import user_created_tickets_table
-from .ticket_tag_entity import TicketTagEntity
+from .ticket_tag_entity import OfficeHoursTicketTagEntity
 from .event_ticket_tags_table import event_ticket_tags_table

--- a/backend/entities/office_hours/__init__.py
+++ b/backend/entities/office_hours/__init__.py
@@ -3,3 +3,5 @@ from .office_hours_recurrence_pattern_entity import OfficeHoursRecurrencePattern
 from .course_site_entity import CourseSiteEntity
 from .ticket_entity import OfficeHoursTicketEntity
 from .user_created_tickets_table import user_created_tickets_table
+from .ticket_tag_entity import TicketTagEntity
+from .event_ticket_tags_table import event_ticket_tags_table

--- a/backend/entities/office_hours/course_site_entity.py
+++ b/backend/entities/office_hours/course_site_entity.py
@@ -13,6 +13,7 @@ from sqlalchemy import Enum as SQLAlchemyEnum
 
 __authors__ = [
     "Ajay Gandecha",
+    "Jade Keegan",
     "Madelyn Andrews",
     "Sadie Amato",
     "Bailey DeSouza",
@@ -55,6 +56,11 @@ class CourseSiteEntity(EntityBase):
 
     # NOTE: One-to-many relationship between course sites and hiring assignments
     hiring_assignments: Mapped[list["HiringAssignmentEntity"]] = relationship(
+        back_populates="course_site", cascade="all, delete"
+    )
+
+    # NOTE: One-to-many relationship between course sites and ticket tags
+    ticket_tags: Mapped[list["OfficeHoursTicketTagEntity"]] = relationship(
         back_populates="course_site", cascade="all, delete"
     )
 

--- a/backend/entities/office_hours/event_ticket_tags_table.py
+++ b/backend/entities/office_hours/event_ticket_tags_table.py
@@ -13,5 +13,5 @@ event_ticket_tags_table = Table(
     "office_hours__event_ticket_tags",
     EntityBase.metadata,
     Column("ticket_id", ForeignKey("office_hours__ticket.id"), primary_key=True),
-    Column("ticket_tag_id", ForeignKey("office_hours__ticket_tag.id"), primary_key=True),
+    Column("ticket_tag_id", ForeignKey("office_hours__ticket_tag.id", ondelete="CASCADE"), primary_key=True),
 )

--- a/backend/entities/office_hours/event_ticket_tags_table.py
+++ b/backend/entities/office_hours/event_ticket_tags_table.py
@@ -1,0 +1,17 @@
+"""Definition of SQLAlchemy table-backed object mapping entity for Office Hour tickets."""
+
+from sqlalchemy import Column, ForeignKey, Table
+from ..entity_base import EntityBase
+
+
+__authors__ = ["Jade Keegan"]
+__copyright__ = "Copyright 2025"
+__license__ = "MIT"
+
+# Association table between OfficeHoursTicket and OfficeHoursTicketTag
+event_ticket_tags_table = Table(
+    "office_hours__event_ticket_tags",
+    EntityBase.metadata,
+    Column("ticket_id", ForeignKey("office_hours__ticket.id"), primary_key=True),
+    Column("member_id", ForeignKey("office_hours__ticket_tag.id"), primary_key=True),
+)

--- a/backend/entities/office_hours/event_ticket_tags_table.py
+++ b/backend/entities/office_hours/event_ticket_tags_table.py
@@ -13,5 +13,5 @@ event_ticket_tags_table = Table(
     "office_hours__event_ticket_tags",
     EntityBase.metadata,
     Column("ticket_id", ForeignKey("office_hours__ticket.id"), primary_key=True),
-    Column("member_id", ForeignKey("office_hours__ticket_tag.id"), primary_key=True),
+    Column("ticket_tag_id", ForeignKey("office_hours__ticket_tag.id"), primary_key=True),
 )

--- a/backend/entities/office_hours/ticket_entity.py
+++ b/backend/entities/office_hours/ticket_entity.py
@@ -14,6 +14,7 @@ from ...models.office_hours.ticket import (
 from ...models.office_hours.ticket_details import OfficeHoursTicketDetails
 from ...models.academics.my_courses import OfficeHourTicketOverview
 from .user_created_tickets_table import user_created_tickets_table
+from .event_ticket_tags_table import event_ticket_tags_table
 
 
 from ..entity_base import EntityBase
@@ -73,6 +74,11 @@ class OfficeHoursTicketEntity(EntityBase):
     # One-to-many relationship of OfficeHoursTicket to section member(s)
     creators: Mapped[list["SectionMemberEntity"]] = relationship(
         secondary=user_created_tickets_table
+    )
+
+    # One-to-many relationship of OfficeHoursTicket to ticket tags
+    tags: Mapped[list["OfficeHoursTicketTagEntity"]] = relationship(
+        secondary=event_ticket_tags_table
     )
 
     # One-to-one relationship of OfficeHoursTicket to UTA that has called it; optional field
@@ -157,6 +163,7 @@ class OfficeHoursTicketEntity(EntityBase):
             caller=(self.caller.user.to_public_model() if self.caller else None),
             has_concerns=self.have_concerns,
             caller_notes=self.caller_notes,
+            tags=[tag.to_model() for tag in self.tags],
         )
 
     def to_details_model(self) -> OfficeHoursTicketDetails:
@@ -181,6 +188,7 @@ class OfficeHoursTicketEntity(EntityBase):
             office_hours=self.office_hours,
             creators=[creator.to_flat_model() for creator in self.creators],
             caller=(self.caller.to_flat_model() if self.caller is not None else None),
+            tags=[tag.to_model() for tag in self.tags],
         )
 
     def to_csv_model(self) -> OfficeHoursTicketCsvRow:

--- a/backend/entities/office_hours/ticket_tag_entity.py
+++ b/backend/entities/office_hours/ticket_tag_entity.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Mapped, mapped_column, relationship
 from ...models.office_hours.ticket_tag import (
     OfficeHoursTicketTag,
     NewOfficeHoursTicketTag,
-    OfficeHourTicketTagDetails,
+    OfficeHoursTicketTagDetails,
 )
 
 
@@ -36,7 +36,7 @@ class OfficeHoursTicketTagEntity(EntityBase):
         ForeignKey("course_site.id"), nullable=False
     )
     course_site: Mapped["CourseSiteEntity"] = relationship(
-        back_populates="office_hours__ticket_tag"
+        back_populates="ticket_tags"
     )
 
 
@@ -73,10 +73,10 @@ class OfficeHoursTicketTagEntity(EntityBase):
 
     def to_model(self) -> OfficeHoursTicketTag:
         """
-        Converts a `OfficeHoursTicketEntity` object into a `OfficeHoursTicket` model object
+        Converts a `OfficeHoursTicketTagEntity` object into a `OfficeHoursTicketTag` model object
 
         Returns:
-            OfficeHoursTicket: `OfficeHoursTicket` object from the entity
+            OfficeHoursTicketTag: `OfficeHoursTicketTag` object from the entity
         """
         return OfficeHoursTicketTag(
             id=self.id,
@@ -84,8 +84,8 @@ class OfficeHoursTicketTagEntity(EntityBase):
             course_site_id=self.course_site_id,
         )
 
-    def to_details_model(self) -> OfficeHourTicketTagDetails:
-        return OfficeHourTicketTagDetails(
+    def to_details_model(self) -> OfficeHoursTicketTagDetails:
+        return OfficeHoursTicketTagDetails(
             id=self.id,
             name=self.name,
             course_site_id=self.course_site_id,

--- a/backend/entities/office_hours/ticket_tag_entity.py
+++ b/backend/entities/office_hours/ticket_tag_entity.py
@@ -1,0 +1,93 @@
+"""Definition of SQLAlchemy table-backed object mapping entity for Office Hour tickets tags."""
+
+from sqlalchemy import ForeignKey, Integer, String
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from ...models.office_hours.ticket_tag import (
+    OfficeHoursTicketTag,
+    NewOfficeHoursTicketTag,
+    OfficeHourTicketTagDetails,
+)
+
+
+from ..entity_base import EntityBase
+from typing import Self
+
+__authors__ = [
+    "Jade Keegan"
+]
+__copyright__ = "Copyright 2025"
+__license__ = "MIT"
+
+
+class OfficeHoursTicketTagEntity(EntityBase):
+    """Serves as the database model schema defining the shape of the `OfficeHoursTicketTag` table"""
+
+    # Name for the ticket tags table in the PostgreSQL database
+    __tablename__ = "office_hours__ticket_tag"
+
+    # Unique id for OfficeHoursTicketTag
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    # Tag name
+    name: Mapped[str] = mapped_column(String, nullable=False)
+
+    # NOTE: Many-to-one relationship of OfficeHoursEvents to OH section
+    course_site_id: Mapped[int] = mapped_column(
+        ForeignKey("course_site.id"), nullable=False
+    )
+    course_site: Mapped["CourseSiteEntity"] = relationship(
+        back_populates="office_hours__ticket_tag"
+    )
+
+
+    @classmethod
+    def from_new_model(cls, model: NewOfficeHoursTicketTag) -> Self:
+        """
+        Class method that converts an `NewOfficeHoursTicket` model into a `OfficeHoursTicketEntity`
+
+        Parameters:
+            - model (NewOfficeHoursTicket): Model to convert into an entity
+        Returns:
+            OfficeHoursTicketEntity: Entity created from model
+        """
+        return cls(
+            name=model.name,
+            course_site_id=model.course_site_id,
+        )
+
+    @classmethod
+    def from_model(cls, model: OfficeHoursTicketTag) -> Self:
+        """
+        Class method that converts an `OfficeHoursTicket` model into a `OfficeHoursTicketEntity`
+
+        Parameters:
+            - model (OfficeHoursTicket): Model to convert into an entity
+        Returns:
+            OfficeHoursTicketEntity: Entity created from model
+        """
+        return cls(
+            id=model.id,
+            name=model.name,
+            course_site_id=model.course_site_id,
+        )
+
+    def to_model(self) -> OfficeHoursTicketTag:
+        """
+        Converts a `OfficeHoursTicketEntity` object into a `OfficeHoursTicket` model object
+
+        Returns:
+            OfficeHoursTicket: `OfficeHoursTicket` object from the entity
+        """
+        return OfficeHoursTicketTag(
+            id=self.id,
+            name=self.name,
+            course_site_id=self.course_site_id,
+        )
+
+    def to_details_model(self) -> OfficeHourTicketTagDetails:
+        return OfficeHourTicketTagDetails(
+            id=self.id,
+            name=self.name,
+            course_site_id=self.course_site_id,
+            course_site=self.course_site.to_model(),
+        )

--- a/backend/entities/office_hours/ticket_tag_entity.py
+++ b/backend/entities/office_hours/ticket_tag_entity.py
@@ -9,13 +9,10 @@ from ...models.office_hours.ticket_tag import (
     OfficeHoursTicketTagDetails,
 )
 
-
 from ..entity_base import EntityBase
 from typing import Self
 
-__authors__ = [
-    "Jade Keegan"
-]
+__authors__ = ["Jade Keegan"]
 __copyright__ = "Copyright 2025"
 __license__ = "MIT"
 

--- a/backend/models/academics/my_courses.py
+++ b/backend/models/academics/my_courses.py
@@ -1,12 +1,7 @@
 from pydantic import BaseModel
 from datetime import datetime
 
-from ...models.office_hours.office_hours_recurrence_pattern import (
-    OfficeHoursRecurrencePattern,
-)
-from ...models import Paginated
-from ...models.office_hours.ticket_state import TicketState
-from ...models.office_hours.ticket_type import TicketType
+from backend.models.office_hours.ticket_tag import OfficeHoursTicketTag
 from ...models.public_user import PublicUser
 
 
@@ -94,6 +89,7 @@ class OfficeHourTicketOverview(BaseModel):
     caller: PublicUser | None
     has_concerns: bool | None
     caller_notes: str | None
+    tags: list[OfficeHoursTicketTag]
 
 
 class OfficeHourStatisticsOverview(BaseModel):

--- a/backend/models/academics/my_courses.py
+++ b/backend/models/academics/my_courses.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel
 from datetime import datetime
 
-from backend.models.office_hours.ticket_tag import OfficeHoursTicketTag
+from ...models.office_hours.ticket_tag import OfficeHoursTicketTag
 from ...models.public_user import PublicUser
 
 

--- a/backend/models/office_hours/office_hours_statistics.py
+++ b/backend/models/office_hours/office_hours_statistics.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from pydantic import BaseModel
 
+from backend.models.office_hours.ticket_tag import OfficeHoursTicketTag
 from backend.models.public_user import PublicUser
 
 __authors__ = ["Ajay Gandecha", "Jade Keegan"]
@@ -11,5 +12,6 @@ __license__ = "MIT"
 class StatisticsFilterData(BaseModel):
     students: list[PublicUser]
     staff: list[PublicUser]
+    tags: list[OfficeHoursTicketTag]
     term_start: datetime
     term_end: datetime

--- a/backend/models/office_hours/ticket.py
+++ b/backend/models/office_hours/ticket.py
@@ -1,6 +1,8 @@
 from pydantic import BaseModel
 from datetime import datetime
 
+from ...models.office_hours.ticket_tag import OfficeHoursTicketTag
+
 from .ticket_type import TicketType
 from .ticket_state import TicketState
 
@@ -10,6 +12,7 @@ __authors__ = [
     "Bailey DeSouza",
     "Meghan Sun",
     "Maddy Andrews",
+    "Jade Keegan"
 ]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
@@ -70,3 +73,4 @@ class OfficeHoursTicketClosePayload(BaseModel):
 
     has_concerns: bool
     caller_notes: str
+    tags: list[OfficeHoursTicketTag]

--- a/backend/models/office_hours/ticket_details.py
+++ b/backend/models/office_hours/ticket_details.py
@@ -1,6 +1,8 @@
 from ..academics.section_member import SectionMember
 from .office_hours import OfficeHours
+
 from .ticket import OfficeHoursTicket
+from .ticket_tag import OfficeHoursTicketTag
 
 __authors__ = ["Sadie Amato, Bailey DeSouza, Meghan Sun, Maddy Andrews"]
 __copyright__ = "Copyright 2024"
@@ -19,3 +21,4 @@ class OfficeHoursTicketDetails(OfficeHoursTicket):
     office_hours: OfficeHours
     creators: list[SectionMember]
     caller: SectionMember
+    tags: list[OfficeHoursTicketTag]

--- a/backend/models/office_hours/ticket_tag.py
+++ b/backend/models/office_hours/ticket_tag.py
@@ -1,0 +1,40 @@
+from pydantic import BaseModel
+
+from .office_hours import CourseSite
+
+__authors__ = ["Jade Keegan"]
+__copyright__ = "Copyright 2025"
+__license__ = "MIT"
+
+
+class NewOfficeHoursTicketTag(BaseModel):
+    """
+    Pydantic model to represent a new ticket tag.
+
+    This model is based on the `OfficeHoursTicketTagEntity` model, which defines the shape
+    of the `OfficeHoursTicketTag` database in the PostgreSQL database.
+    """
+
+    name: str
+    course_site_id: int
+
+
+class OfficeHoursTicketTag(NewOfficeHoursTicketTag):
+    """
+    Pydantic model to represent an `OfficeHoursTicketTag`.
+
+    This model is based on the `OfficeHoursTicketTagEntity` model, which defines the shape
+    of the `OfficeHoursTicketTag` database in the PostgreSQL database.
+    """
+
+    id: int
+
+class OfficeHoursTicketTagDetails(OfficeHoursTicketTag):
+    """
+    Pydantic model to represent an `OfficeHoursTicketTag` with details.
+
+    This model is based on the `OfficeHoursTicketTagEntity` model, which defines the shape
+    of the `OfficeHoursTicketTag` database in the PostgreSQL database.
+    """
+
+    course_site: CourseSite

--- a/backend/models/office_hours/ticket_tag.py
+++ b/backend/models/office_hours/ticket_tag.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel
 
-from .office_hours import CourseSite
+from ...models.office_hours.course_site import CourseSite
 
 __authors__ = ["Jade Keegan"]
 __copyright__ = "Copyright 2025"

--- a/backend/models/pagination.py
+++ b/backend/models/pagination.py
@@ -26,6 +26,7 @@ class TicketPaginationParams(PaginationParams):
     range_end: str = ""
     student_ids: list[int]
     staff_ids: list[int]
+    tag_ids: list[int]
 
 
 class EventPaginationParams(PaginationParams):

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -4,7 +4,7 @@ from .role import RoleService
 from .github import GitHubService
 from .organization import OrganizationService
 from .event import EventService
-from .exceptions import ResourceNotFoundException, UserPermissionException
+from .exceptions import ResourceNotFoundException, UserPermissionException, DuplicateResourceException
 from .room import RoomService
 from .article import ArticleService
 from .application import ApplicationService

--- a/backend/services/academics/course_site.py
+++ b/backend/services/academics/course_site.py
@@ -7,6 +7,7 @@ from itertools import groupby
 from fastapi import Depends
 from sqlalchemy import select, or_, func
 from sqlalchemy.orm import Session, joinedload
+
 from ...database import db_session
 from ...models.user import User
 from ...models.pagination import PaginationParams, Paginated
@@ -17,7 +18,6 @@ from ...models.academics.my_courses import (
     TermOverview,
     CourseMemberOverview,
     OfficeHoursOverview,
-    TicketState,
     TeachingSectionOverview,
 )
 from ...models.office_hours.course_site import (
@@ -25,7 +25,7 @@ from ...models.office_hours.course_site import (
     NewCourseSite,
     UpdatedCourseSite,
 )
-from ...models.office_hours.course_site_details import CourseSiteDetails
+from ...models.office_hours.ticket_state import TicketState
 from ...models.academics.section_member import SectionMemberDraft
 from ...entities.academics.section_entity import SectionEntity
 from ...entities.office_hours import OfficeHoursEntity, CourseSiteEntity

--- a/backend/services/exceptions.py
+++ b/backend/services/exceptions.py
@@ -11,6 +11,11 @@ class ResourceNotFoundException(Exception):
 
     ...
 
+class DuplicateResourceException(Exception):
+    """DuplicateResourceException is raised when a user attempts to create a resource that already exists."""
+
+    def __init__(self, reason: str):
+        super().__init__(f"{reason}")
 
 class UserPermissionException(Exception):
     """UserPermissionException is raised when a user attempts to perform an action they are not authorized to perform."""

--- a/backend/services/office_hours/__init__.py
+++ b/backend/services/office_hours/__init__.py
@@ -2,3 +2,4 @@ from .office_hours import OfficeHoursService
 from .office_hours_recurrence import OfficeHoursRecurrenceService
 from .ticket import OfficeHourTicketService
 from .office_hours_statistics import OfficeHoursStatisticsService
+from .ticket_tag import OfficeHourTicketTagService

--- a/backend/services/office_hours/ticket.py
+++ b/backend/services/office_hours/ticket.py
@@ -28,8 +28,9 @@ from ...entities.office_hours import (
 from ...entities.academics.section_member_entity import SectionMemberEntity
 from ..exceptions import CoursePermissionException, ResourceNotFoundException
 from ...entities.office_hours import user_created_tickets_table
+from ...entities.office_hours import event_ticket_tags_table
 
-__authors__ = ["Ajay Gandecha"]
+__authors__ = ["Ajay Gandecha", "Jade Keegan"]
 __copyright__ = "Copyright 2024"
 __license__ = "MIT"
 
@@ -189,6 +190,17 @@ class OfficeHourTicketService:
         ticket_entity.state = TicketState.CLOSED
         ticket_entity.have_concerns = payload.has_concerns
         ticket_entity.caller_notes = payload.caller_notes
+
+        # Associate tags with ticket
+        for tag in payload.tags:
+            self._session.execute(
+               event_ticket_tags_table.insert().values(
+                    {
+                        "ticket_id": ticket_id,
+                        "ticket_tag_id": tag.id,
+                    }
+                )
+            )
 
         # Save changes
         self._session.commit()

--- a/backend/services/office_hours/ticket_tag.py
+++ b/backend/services/office_hours/ticket_tag.py
@@ -1,0 +1,95 @@
+"""
+APIs for academics for office hour tickets.
+"""
+
+from fastapi import Depends
+from sqlalchemy.orm import Session
+
+
+from ...entities.office_hours.ticket_tag_entity import OfficeHoursTicketTagEntity
+from ...services.office_hours.office_hours import OfficeHoursService
+from ...services.exceptions import ResourceNotFoundException
+
+from ...models.office_hours.ticket_tag import NewOfficeHoursTicketTag, OfficeHoursTicketTag
+
+from ...database import db_session
+from ...models.user import User
+
+
+__authors__ = ["Jade Keegan"]
+__copyright__ = "Copyright 2025"
+__license__ = "MIT"
+
+
+class OfficeHourTicketTagService:
+    """
+    Service that performs all of the actions for office hour tickets tags.
+    """
+
+    def __init__(self, session: Session = Depends(db_session), _office_hours_svc: OfficeHoursService = Depends(),):
+        """
+        Initializes the database session.
+        """
+        self._session = session
+        self._office_hours_svc = _office_hours_svc
+
+    def create(self, user: User, site_id: int, tag: NewOfficeHoursTicketTag) -> OfficeHoursTicketTag:
+        """
+        Creates a new office hour ticket tag for a course site.
+
+        Returns:
+            OfficeHourTicketTag
+        """
+        
+        # Check permissions
+        self._office_hours_svc._check_site_admin_permissions(user, site_id)
+
+        # Create ticket tag
+        ticket_tag_entity = OfficeHoursTicketTag.from_new_model(tag)
+        self._session.add(ticket_tag_entity)
+        self._session.commit()
+
+        # Return model
+        return ticket_tag_entity.to_model()
+    
+    
+    def update(self, user: User, site_id: int, tag: OfficeHoursTicketTag) -> OfficeHoursTicketTag:
+        """
+        Updates an existing office hours event.
+        """
+        # Find existing tag
+        ticket_tag_entity = self._session.get(OfficeHoursTicketTagEntity, tag.id)
+
+        if ticket_tag_entity is None:
+            raise ResourceNotFoundException(
+                "Office hours ticket tag with id: {tag.id} does not exist."
+            )
+
+        # Check permissions
+        self._check_site_admin_permissions(user, site_id)
+
+        # Update
+        ticket_tag_entity.name = tag.name
+
+        self._session.commit()
+
+        # Return model
+        return ticket_tag_entity.to_model()
+
+    def delete(self, user: User, site_id: int, tag_id: int):
+        """
+        Deletes an existing office hours event.
+        """
+        # Find existing tag
+        ticket_tag_entity = self._session.get(OfficeHoursTicketTagEntity, tag_id)
+
+        if ticket_tag_entity is None:
+            raise ResourceNotFoundException(
+                "Office hours ticket tag with id: {tag_id} does not exist."
+            )
+
+        # Check permissions
+        self._check_site_admin_permissions(user, site_id)
+
+        self._session.delete(ticket_tag_entity)
+        self._session.commit()

--- a/backend/services/office_hours/ticket_tag.py
+++ b/backend/services/office_hours/ticket_tag.py
@@ -33,6 +33,25 @@ class OfficeHourTicketTagService:
         self._session = session
         self._office_hours_svc = _office_hours_svc
 
+    def get_course_site_tags(self, user: User, site_id: int) -> list[OfficeHoursTicketTag]:
+        """
+        Returns all office hour ticket tags for a course site.
+
+        Returns:
+            list[OfficeHoursTicketTag]
+        """
+        
+        # Check permissions
+        self._office_hours_svc._check_site_admin_permissions(user, site_id)
+
+        # Get all ticket tags
+        ticket_tags = self._session.query(OfficeHoursTicketTagEntity).filter(
+            OfficeHoursTicketTagEntity.course_site_id == site_id
+        ).all()
+
+        # Return models
+        return [tag.to_model() for tag in ticket_tags]
+
     def create(self, user: User, site_id: int, tag: NewOfficeHoursTicketTag) -> OfficeHoursTicketTag:
         """
         Creates a new office hour ticket tag for a course site.
@@ -45,7 +64,7 @@ class OfficeHourTicketTagService:
         self._office_hours_svc._check_site_admin_permissions(user, site_id)
 
         # Create ticket tag
-        ticket_tag_entity = OfficeHoursTicketTag.from_new_model(tag)
+        ticket_tag_entity = OfficeHoursTicketTagEntity.from_new_model(tag)
         self._session.add(ticket_tag_entity)
         self._session.commit()
 
@@ -57,6 +76,9 @@ class OfficeHourTicketTagService:
         """
         Updates an existing office hours event.
         """
+        # Check permissions
+        self._office_hours_svc._check_site_admin_permissions(user, site_id)
+
         # Find existing tag
         ticket_tag_entity = self._session.get(OfficeHoursTicketTagEntity, tag.id)
 
@@ -64,9 +86,6 @@ class OfficeHourTicketTagService:
             raise ResourceNotFoundException(
                 "Office hours ticket tag with id: {tag.id} does not exist."
             )
-
-        # Check permissions
-        self._check_site_admin_permissions(user, site_id)
 
         # Update
         ticket_tag_entity.name = tag.name
@@ -80,6 +99,9 @@ class OfficeHourTicketTagService:
         """
         Deletes an existing office hours event.
         """
+        # Check permissions
+        self._office_hours_svc._check_site_admin_permissions(user, site_id)
+
         # Find existing tag
         ticket_tag_entity = self._session.get(OfficeHoursTicketTagEntity, tag_id)
 
@@ -87,9 +109,6 @@ class OfficeHourTicketTagService:
             raise ResourceNotFoundException(
                 "Office hours ticket tag with id: {tag_id} does not exist."
             )
-
-        # Check permissions
-        self._check_site_admin_permissions(user, site_id)
 
         self._session.delete(ticket_tag_entity)
         self._session.commit()

--- a/backend/services/office_hours/ticket_tag.py
+++ b/backend/services/office_hours/ticket_tag.py
@@ -33,6 +33,28 @@ class OfficeHourTicketTagService:
         self._session = session
         self._office_hours_svc = _office_hours_svc
 
+    def get_tag_by_id(self, user: User, site_id: int, tag_id: int) -> OfficeHoursTicketTag:
+        """
+        Returns an office hour ticket tag by ID.
+
+        Returns:
+            OfficeHourTicketTag
+        """
+        
+        # Check permissions
+        self._office_hours_svc._check_site_admin_permissions(user, site_id)
+
+        # Get ticket tag
+        ticket_tag = self._session.get(OfficeHoursTicketTagEntity, tag_id)
+
+        if ticket_tag is None:
+            raise ResourceNotFoundException(
+                "Office hours ticket tag with id: {tag_id} does not exist."
+            )
+
+        # Return model
+        return ticket_tag.to_model()
+
     def get_course_site_tags(self, user: User, site_id: int) -> list[OfficeHoursTicketTag]:
         """
         Returns all office hour ticket tags for a course site.

--- a/backend/test/services/office_hours/fixtures.py
+++ b/backend/test/services/office_hours/fixtures.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import create_autospec
 from sqlalchemy.orm import Session
 
+from ....services.office_hours.ticket_tag import OfficeHourTicketTagService
 from ....services.office_hours.office_hours_recurrence import (
     OfficeHoursRecurrenceService,
 )
@@ -39,8 +40,13 @@ def oh_svc_mock():
 
 @pytest.fixture()
 def oh_ticket_svc(session: Session):
-    """OfficeHoursEventService fixture."""
+    """OfficeHoursTicketService fixture."""
     return OfficeHourTicketService(session)
+
+@pytest.fixture()
+def oh_ticket_tag_svc(session: Session):
+    """OfficeHoursTicketTagService fixture."""
+    return OfficeHourTicketTagService(session, OfficeHoursService(session))
 
 
 @pytest.fixture()

--- a/backend/test/services/office_hours/office_hours_data.py
+++ b/backend/test/services/office_hours/office_hours_data.py
@@ -683,6 +683,12 @@ new_ticket_tag = OfficeHoursTicketTag(
     course_site_id=comp_110_site.id,
 )
 
+duplicate_ticket_tag = OfficeHoursTicketTag(
+    id=4,
+    name="SP01",
+    course_site_id=comp_110_site.id,
+)
+
 sample_delete_payload = OfficeHoursTicketClosePayload(
     has_concerns=True,
     caller_notes="I have concerns.",

--- a/backend/test/services/office_hours/office_hours_data.py
+++ b/backend/test/services/office_hours/office_hours_data.py
@@ -3,6 +3,7 @@
 import pytest
 from datetime import datetime, date, timedelta
 from sqlalchemy.orm import Session
+
 from ...services.reset_table_id_seq import reset_table_id_seq
 
 from ....test.services import user_data, room_data
@@ -40,6 +41,7 @@ from ....models.office_hours.ticket import (
 )
 from ....models.office_hours.ticket_type import TicketType
 from ....models.office_hours.ticket_state import TicketState
+from ....models.office_hours.ticket_tag import OfficeHoursTicketTag
 
 __authors__ = [
     "Ajay Gandecha",
@@ -614,7 +616,14 @@ nonexistent_event = OfficeHours(
     recurrence_pattern_id=None,
 )
 
+sample_ticket_tag = OfficeHoursTicketTag(
+    id=1,
+    name="Sample Tag",
+    course_site_id=comp_110_site.id,
+)
+
 sample_delete_payload = OfficeHoursTicketClosePayload(
     has_concerns=True,
     caller_notes="I have concerns.",
+    tags=[sample_ticket_tag],
 )

--- a/backend/test/services/office_hours/office_hours_statistics_test.py
+++ b/backend/test/services/office_hours/office_hours_statistics_test.py
@@ -40,6 +40,7 @@ def test_get_paginated_tickets(oh_statistics_svc: OfficeHoursStatisticsService):
         range_end="",
         student_ids=[],
         staff_ids=[],
+        tag_ids=[]
     )
 
     ticket_history = oh_statistics_svc.get_paginated_tickets(
@@ -61,6 +62,7 @@ def test_get_paginated_tickets_not_staff(
             range_end="",
             student_ids=[],
             staff_ids=[],
+            tag_ids=[]
         )
 
         oh_statistics_svc.get_paginated_tickets(
@@ -77,6 +79,7 @@ def test_get_statistics(oh_statistics_svc: OfficeHoursStatisticsService):
         range_end="",
         student_ids=[],
         staff_ids=[],
+        tag_ids=[]
     )
 
     statistics = oh_statistics_svc.get_statistics(
@@ -102,6 +105,7 @@ def test_get_paginated_tickets_student_filter(
         range_end="",
         student_ids=[user_data.student.id],
         staff_ids=[],
+        tag_ids=[]
     )
 
     ticket_history = oh_statistics_svc.get_paginated_tickets(
@@ -125,6 +129,7 @@ def test_get_paginated_tickets_staff_filter(
         range_end="",
         student_ids=[],
         staff_ids=[user_data.instructor.id],
+        tag_ids=[]
     )
 
     ticket_history = oh_statistics_svc.get_paginated_tickets(
@@ -149,6 +154,7 @@ def test_get_statistics_staff_filter(oh_statistics_svc: OfficeHoursStatisticsSer
             user_data.instructor.id
         ],  # filter by Ina, only person with a CLOSED ticket right now
         # staff_ids=[0], # filter by NOT Ina, so should expect no ticket stats - THIS WORKS
+        tag_ids=[]
     )
 
     statistics = oh_statistics_svc.get_statistics(
@@ -174,6 +180,7 @@ def test_get_paginated_tickets_date_filter(
         range_end=date_maker(1, 0, 0).isoformat(),
         student_ids=[],
         staff_ids=[],
+        tag_ids=[]
     )
 
     ticket_history = oh_statistics_svc.get_paginated_tickets(
@@ -197,6 +204,7 @@ def test_get_statistics_date_filter(
         # range_end=date_maker(-1, 0, 0).isoformat(), # one ago - THIS SHOULD FAIL
         student_ids=[],
         staff_ids=[],
+        tag_ids=[]
     )
 
     statistics = oh_statistics_svc.get_statistics(
@@ -222,6 +230,7 @@ def test_get_paginated_tickets_unauthenticated(
         range_end="",
         student_ids=[],
         staff_ids=[],
+        tag_ids=[]
     )
 
     with pytest.raises(CoursePermissionException):
@@ -241,6 +250,7 @@ def test_get_statistics_unauthenticated(
         range_end="",
         student_ids=[],
         staff_ids=[],
+        tag_ids=[]
     )
 
     with pytest.raises(CoursePermissionException):
@@ -260,6 +270,7 @@ def test_get_paginated_tickets_multiple_filters(
         range_end=date_maker(1, 0, 0).isoformat(),
         student_ids=[user_data.student.id],
         staff_ids=[user_data.instructor.id],
+        tag_ids=[]
     )
 
     ticket_history = oh_statistics_svc.get_paginated_tickets(
@@ -305,6 +316,7 @@ def test_get_paginated_tickets_multiple_filters(
         student_ids=[user_data.student.id],
         # student_ids=[0], # filter by NOT Stewie, so should expect no ticket stats - THIS WORKS
         staff_ids=[user_data.instructor.id],
+        tag_ids=[]
     )
 
     statistics = oh_statistics_svc.get_statistics(
@@ -330,6 +342,7 @@ def test_get_ticket_csv(
         range_end="",
         student_ids=[],
         staff_ids=[],
+        tag_ids=[]
     )
 
     ticket_csv = oh_statistics_svc.get_ticket_csv(
@@ -350,6 +363,7 @@ def test_get_ticket_csv_unauthenticated(
         range_end="",
         student_ids=[],
         staff_ids=[],
+        tag_ids=[]
     )
 
     with pytest.raises(CoursePermissionException):
@@ -369,6 +383,7 @@ def test_get_ticket_csv_with_filters(
         range_end="",
         student_ids=[user_data.student.id],
         staff_ids=[user_data.instructor.id],
+        tag_ids=[]
     )
 
     ticket_csv = oh_statistics_svc.get_ticket_csv(

--- a/backend/test/services/office_hours/ticket_tag_test.py
+++ b/backend/test/services/office_hours/ticket_tag_test.py
@@ -7,7 +7,7 @@ from ....models.academics.my_courses import OfficeHourTicketOverview
 from ....models.office_hours.ticket import TicketState
 
 from ....services.office_hours import OfficeHourTicketTagService
-from ....services.exceptions import CoursePermissionException, ResourceNotFoundException
+from ....services.exceptions import CoursePermissionException, DuplicateResourceException, ResourceNotFoundException
 
 # Imported fixtures provide dependencies injected for the tests as parameters.
 from .fixtures import oh_ticket_tag_svc
@@ -86,12 +86,25 @@ def test_create_ticket_tag(oh_ticket_tag_svc: OfficeHourTicketTagService):
     # Check the created tag
     assert created_tag.name == new_tag.name
 
+def test_create_ticket_tag_duplicate_name(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test creating a new ticket tag with a duplicate name.
+    """
+    # Create a new ticket tag with a duplicate name
+    new_tag = office_hours_data.duplicate_ticket_tag
+
+    # Attempt to create the ticket tag
+    with pytest.raises(DuplicateResourceException):
+        oh_ticket_tag_svc.create(
+            user_data.instructor, office_hours_data.comp_110_site.id, new_tag
+        )
+
 def test_create_ticket_tag_unauthenticated(oh_ticket_tag_svc: OfficeHourTicketTagService):
     """
     Test creating a new ticket tag with an unauthenticated user.
     """
     # Create a new ticket tag
-    new_tag = office_hours_data.sample_ticket_tag
+    new_tag = office_hours_data.new_ticket_tag
 
     # Attempt to create the ticket tag
     with pytest.raises(CoursePermissionException):
@@ -111,6 +124,16 @@ def test_update_ticket_tag(oh_ticket_tag_svc: OfficeHourTicketTagService):
     assert updated_tag.id == office_hours_data.updated_ticket_tag_1.id
     # Check the updated tag name
     assert updated_tag.name == office_hours_data.updated_ticket_tag_1.name
+
+def test_update_ticket_tag_does_not_exist(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test updating a ticket tag that does not exist.
+    """
+    # Attempt to update a non-existent ticket tag
+    with pytest.raises(ResourceNotFoundException):
+        oh_ticket_tag_svc.update(
+            user_data.instructor, office_hours_data.comp_110_site.id, office_hours_data.new_ticket_tag
+        )
 
 def test_update_ticket_tag_unauthenticated(oh_ticket_tag_svc: OfficeHourTicketTagService):
     """
@@ -135,6 +158,16 @@ def test_delete_ticket_tag(oh_ticket_tag_svc: OfficeHourTicketTagService):
     with pytest.raises(ResourceNotFoundException):
         oh_ticket_tag_svc.get_tag_by_id(
             user_data.instructor, office_hours_data.comp_110_site.id, office_hours_data.ticket_tag_1.id
+        )
+
+def test_delete_ticket_tag_does_not_exist(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test deleting a ticket tag that does not exist.
+    """
+    # Attempt to delete a non-existent ticket tag
+    with pytest.raises(ResourceNotFoundException):
+        oh_ticket_tag_svc.delete(
+            user_data.instructor, office_hours_data.comp_110_site.id, office_hours_data.new_ticket_tag.id
         )
 
 def test_delete_ticket_tag_unauthenticated(oh_ticket_tag_svc: OfficeHourTicketTagService):

--- a/backend/test/services/office_hours/ticket_tag_test.py
+++ b/backend/test/services/office_hours/ticket_tag_test.py
@@ -1,0 +1,148 @@
+"""Tests for the OfficeHoursTicketService."""
+
+import pytest
+
+from ....models.academics.my_courses import OfficeHourTicketOverview
+
+from ....models.office_hours.ticket import TicketState
+
+from ....services.office_hours import OfficeHourTicketTagService
+from ....services.exceptions import CoursePermissionException, ResourceNotFoundException
+
+# Imported fixtures provide dependencies injected for the tests as parameters.
+from .fixtures import oh_ticket_tag_svc
+
+# Import the setup_teardown fixture explicitly to load entities in database
+from ..core_data import setup_insert_data_fixture as insert_order_0
+from ..academics.term_data import fake_data_fixture as insert_order_1
+from ..academics.course_data import fake_data_fixture as insert_order_2
+from ..academics.section_data import fake_data_fixture as insert_order_3
+from ..room_data import fake_data_fixture as insert_order_4
+from ..office_hours.office_hours_data import fake_data_fixture as insert_order_5
+
+# Import the fake model data in a namespace for test assertions
+from .. import user_data
+from ..office_hours import office_hours_data
+
+__authors__ = ["Jade Keegan"]
+__copyright__ = "Copyright 2025"
+__license__ = "MIT"
+
+
+# Call Ticket Tag Tests
+def test_get_tag_by_id(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test retrieving a ticket tag by ID.
+    """
+    # Get the ticket tag by ID
+    tag = oh_ticket_tag_svc.get_tag_by_id(
+        user_data.instructor, office_hours_data.comp_110_site.id, office_hours_data.ticket_tag_1.id
+    )
+
+    # Check the tag ID
+    assert tag.id == office_hours_data.ticket_tag_1.id
+    # Check the tag name
+    assert tag.name == office_hours_data.ticket_tag_1.name
+    
+def test_get_course_site_tags(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test retrieving tags for a course site.
+    """
+    # Get the course site tags
+    tags = oh_ticket_tag_svc.get_course_site_tags(
+        user_data.instructor, office_hours_data.comp_110_site.id
+    )
+
+    # Check the number of tags
+    assert len(tags) == 2
+
+    # Check the tag names
+    assert tags[0].name == office_hours_data.ticket_tag_1.name
+    assert tags[1].name == office_hours_data.ticket_tag_2.name
+
+def test_get_course_site_tags_unauthenticated(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test retrieving tags for a course site with an unauthenticated user.
+    """
+    # Attempt to get the course site tags
+    with pytest.raises(CoursePermissionException):
+        oh_ticket_tag_svc.get_course_site_tags(
+            user_data.student, office_hours_data.comp_110_site.id
+        )
+
+def test_create_ticket_tag(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test creating a new ticket tag.
+    """
+    # Create a new ticket tag
+    new_tag = office_hours_data.new_ticket_tag
+    created_tag = oh_ticket_tag_svc.create(
+        user_data.instructor, office_hours_data.comp_110_site.id, new_tag
+    )
+
+
+    # Check the created tag ID
+    assert created_tag.id == 3
+    # Check the created tag
+    assert created_tag.name == new_tag.name
+
+def test_create_ticket_tag_unauthenticated(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test creating a new ticket tag with an unauthenticated user.
+    """
+    # Create a new ticket tag
+    new_tag = office_hours_data.sample_ticket_tag
+
+    # Attempt to create the ticket tag
+    with pytest.raises(CoursePermissionException):
+        oh_ticket_tag_svc.create(
+            user_data.student, office_hours_data.comp_110_site.id, new_tag
+        )
+
+def test_update_ticket_tag(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test updating an existing ticket tag.
+    """
+    updated_tag = oh_ticket_tag_svc.update(
+        user_data.instructor, office_hours_data.comp_110_site.id, office_hours_data.updated_ticket_tag_1
+    )
+
+    # Check the updated tag ID
+    assert updated_tag.id == office_hours_data.updated_ticket_tag_1.id
+    # Check the updated tag name
+    assert updated_tag.name == office_hours_data.updated_ticket_tag_1.name
+
+def test_update_ticket_tag_unauthenticated(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test updating an existing ticket tag with an unauthenticated user.
+    """
+    # Attempt to update the ticket tag
+    with pytest.raises(CoursePermissionException):
+        oh_ticket_tag_svc.update(
+            user_data.student, office_hours_data.comp_110_site.id, office_hours_data.updated_ticket_tag_1
+        )
+
+def test_delete_ticket_tag(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test deleting an existing ticket tag.
+    """
+    # Delete the ticket tag
+    oh_ticket_tag_svc.delete(
+        user_data.instructor, office_hours_data.comp_110_site.id, office_hours_data.ticket_tag_1.id
+    )
+
+    # Attempt to retrieve the deleted tag
+    with pytest.raises(ResourceNotFoundException):
+        oh_ticket_tag_svc.get_tag_by_id(
+            user_data.instructor, office_hours_data.comp_110_site.id, office_hours_data.ticket_tag_1.id
+        )
+
+def test_delete_ticket_tag_unauthenticated(oh_ticket_tag_svc: OfficeHourTicketTagService):
+    """
+    Test deleting an existing ticket tag with an unauthenticated user.
+    """
+    # Attempt to delete the ticket tag
+    with pytest.raises(CoursePermissionException):
+        oh_ticket_tag_svc.delete(
+            user_data.student, office_hours_data.comp_110_site.id, office_hours_data.ticket_tag_1.id
+        )

--- a/backend/test/services/office_hours/ticket_test.py
+++ b/backend/test/services/office_hours/ticket_test.py
@@ -186,7 +186,6 @@ def test_close_ticket_not_staff(oh_ticket_svc: OfficeHourTicketService):
         )
         pytest.fail()
 
-
 def test_create_ticket(oh_ticket_svc: OfficeHourTicketService):
     """Ensurs that students can create new tickets."""
     created = oh_ticket_svc.create_ticket(user_data.user, office_hours_data.new_ticket)


### PR DESCRIPTION
This PR implements the ticket tags backend.

## Major Changes
- Created the `OfficeHoursTicketTagEntity` and the corresponding association table `event_ticket_tags_table`.
- Created the backend service and API routes for creating, updating, deleting, and retrieving ticket tags for a course site.
- Modified the service methods for filtering tickets and closing tickets to account for ticket tags.
- Added unit tests for the backend services.

> Resolves #768 