### PR TITLE
chore: Allow Other Apps to use CSXL Server as UNC SSO Auth Proxy

### DIFF
--- a/backend/api/authentication.py
+++ b/backend/api/authentication.py
@@ -252,9 +252,7 @@ def _handle_auth_in_production(
     else:
         # Development Authentication Request (origin is app in development)
         if origin.startswith("localhost"):
-            target = (
-                "http://localhost:1560/auth"  # TODO: Make this port an env variable
-            )
+            target = f"http://{origin}/auth"  # TODO: Make this port an env variable
         else:
             target = f"https://{origin}/auth"
         return RedirectResponse(


### PR DESCRIPTION
This small change in the authentication logic allows other web projects in a local environment to simulate the UNC Shibboleth SSO authentication using the CSXL server without a proxy set up in CloudApps.

The fix was to allow the set `origin` to propagate through in the `http` route in the redirect call for handing authentication on the production server. This allows for other URL prefixes (for example in my case w/ a Next.js project, `localhost:3000/api/`) to be used in place of the hard-coded `localhost:1560/` for connecting to authentication logic.

Changing this code in the local environment does not break the authentication workflow.

@KrisJordan are there any security concerns with this or are we good to merge?