### PR TITLE
chore(auth)!: allow for more flexible auth proxy use

### DIFF
--- a/backend/api/authentication.py
+++ b/backend/api/authentication.py
@@ -40,21 +40,21 @@ In development, the proxy is not present. Instead, there are two options for aut
 1. If an unauthenticated user visits /auth in development, or staging, they are redirected
    to the production `csxl.unc.edu/auth` route with an additional query parameter `origin`.
     A. The production server authentication works as usual, but if the `origin` parameter is
-       detected alongside the SSO headers, the user will be redirected back to the `origin` 
+       detected alongside the SSO headers, the user will be redirected back to the `origin`
        server with a JWT `token` query parameter. This token is signed by the production server.
     B. Back on the development/staging server, we need to verify that the token given to the route
        was actually signed by the production server. If we did not do this, a malicious user could
        simply generate a token and pass it to the development server to gain access. Thus, an HTTP
        request from the development/stage server is made to the production server's `/auth/verify` route
-       to verify the token's validity. If the token is valid, the development/staging server then 
-       issues a new `token` to the client that is signed by the development/staging server. 
+       to verify the token's validity. If the token is valid, the development/staging server then
+       issues a new `token` to the client that is signed by the development/staging server.
        This token is then used for all subsequent requests.
 2. If an unauthenticated user visits /auth/as/{uid}/{pid} in development, they are authenticated
-    as the user with the given `uid` and `pid`, which are their ONYEN and PID, respectively. 
+    as the user with the given `uid` and `pid`, which are their ONYEN and PID, respectively.
     This route is only available in development mode.
 
-Finally, the `authenticated_pid` function ensures a user is authenticated with PID and Onyen, 
-but does not require that the user be registered in the database. This is only really useful 
+Finally, the `authenticated_pid` function ensures a user is authenticated with PID and Onyen,
+but does not require that the user be registered in the database. This is only really useful
 for routes used in the process of registering a user.
 """
 
@@ -220,8 +220,9 @@ def github_unlink(
 
 
 def _delegate_to_auth_server(continue_to: str):
+    host_origin = f"{HOST}/auth"
     return RedirectResponse(
-        f"https://{AUTH_SERVER_HOST}/auth?origin={HOST}&continue_to={continue_to}"
+        f"https://{AUTH_SERVER_HOST}/auth?origin={host_origin}&continue_to={continue_to}"
     )
 
 
@@ -252,9 +253,9 @@ def _handle_auth_in_production(
     else:
         # Development Authentication Request (origin is app in development)
         if origin.startswith("localhost"):
-            target = f"http://{origin}/auth"  # TODO: Make this port an env variable
+            target = f"http://{origin}"  # TODO: Make this port an env variable
         else:
-            target = f"https://{origin}/auth"
+            target = f"https://{origin}"
         return RedirectResponse(
             f"{target}?token={token}&continue_to={continue_to}",
             headers={"Cache-Control": "no-cache"},


### PR DESCRIPTION
This PR changes the authentication logic to remove the `/auth` suffix after the origin redirect. Before this modification, since the `/auth` suffix was attached to the origin, other backends using the CSXL site as a UNC auth proxy had to implement their auth API endpoint route to have `/auth` as a suffix.

For example, the CSXL site implements the authentication route as `localhost:1560/auth` (where `origin="localhost:1560"`), while a Next.js site might have implemented the route as `localhost:3000/api/auth` (where `origin="localhost:3000"`). Both are valid, but only because the routes end with `/auth`.

There are use cases where a backend might want to connect to multiple auth providers with a route something like `localhost:8000/api/auth/unc` along with another route `localhost:8000/api/auth/google`. The current implementation of the CSXL auth logic doesn't allow for this, so this PR proposes removing the `/auth` suffix from the target. The CSXL site then can use the same authentication route `localhost:1560/auth`, only that `origin` is set to `"localhost:1560/auth"` instead of just `"localhost:1560"`. This allows for a site using multiple auth providers to set origin to `"localhost:8000/api/auth/unc"`, for example, so that the CSXL server can callback to the UNC-auth-specific endpoint.

This seems like an easier implementation than trying to modify the CSXL authentication logic to support passing along arbitrary query parameters in the provided origin (something like `localhost:8000/api/auth?provider=unc`) for which more edge-cases would arise.

This is a breaking change **(!!)** assuming other apps are currently using the CSXL as an auth proxy, which should not be the case since #774 was very recent!

Also note: this works in theory but is not testable on localhost yet because the deployment server code has to update. We can revert if something terrible goes wrong.