### PR TITLE
fix: swap colors for draft, archived, and published articles

### DIFF
--- a/frontend/src/app/news/news-admin/news-admin.component.html
+++ b/frontend/src/app/news/news-admin/news-admin.component.html
@@ -20,10 +20,10 @@
                   [class]="
                     'text-badge ' +
                     (element.state === articleState.DRAFT
-                      ? 'tertiary-container-background'
-                      : element.state === articleState.PUBLISHED
                       ? 'secondary-container-background'
-                      : 'primary-fixed-dim-background')
+                      : element.state === articleState.PUBLISHED
+                      ? 'primary-fixed-dim-background'
+                      : 'tertiary-container-background')
                   ">
                   {{ element.state }}
                 </span>


### PR DESCRIPTION
I think the original colors where tertiary (red) = draft, secondary (muted purple) = published, and primary (darker purple) = archived does not make sense from a prominence perspective, this PR rearranges it so that:
- secondary (muted purple) = draft
- primary (darker purple) = published
- tertiary (red) = draft