### PR TITLE
fix(office-hours): add sorting to statistics filter options

### DIFF
--- a/backend/services/office_hours/office_hours_statistics.py
+++ b/backend/services/office_hours/office_hours_statistics.py
@@ -268,6 +268,7 @@ class OfficeHoursStatisticsService:
             .where(SectionMemberEntity.member_role == RosterRole.STUDENT)
             .options(joinedload(SectionMemberEntity.section))
             .options(joinedload(SectionMemberEntity.user))
+            .order_by(UserEntity.last_name, UserEntity.first_name)
         )
         students = self._session.scalars(student_query).unique().all()
 
@@ -283,6 +284,7 @@ class OfficeHoursStatisticsService:
             )
             .options(joinedload(SectionMemberEntity.section))
             .options(joinedload(SectionMemberEntity.user))
+            .order_by(UserEntity.last_name, UserEntity.first_name)
         )
         staff = self._session.scalars(staff_query).unique().all()
 


### PR DESCRIPTION
Adds sorting to the statistics filter options so that students and staff are listed in alphabetical order.