### PR TITLE
fix(office-hours): fix styling of future event action buttons

### DIFF
--- a/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.css
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.css
@@ -50,3 +50,19 @@
 .semibold {
     font-weight: 500;
 }
+
+.future-actions-cell {
+    display: flex;
+    width: 100%;
+    height: 52px;
+    flex-direction: row;
+    padding-right: 0;
+    align-items: center;
+}
+
+.future-actions {
+    display: flex;
+    flex-direction: row;
+    gap: 6px;
+    margin-left: auto;
+}

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.html
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.html
@@ -66,7 +66,7 @@
               </td>
             </ng-container>
               <ng-container matColumnDef="actions">
-                <th mat-header-cell *matHeaderCellDef>Actions</th>
+                <th mat-header-cell *matHeaderCellDef></th>
                 <td class="future-actions-cell" mat-cell *matCellDef="let element">
                   <div class="future-actions">
                     <button mat-icon-button [routerLink]="element.id + '/edit'">

--- a/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.html
+++ b/frontend/src/app/my-courses/course/office-hours/office-hours-page/office-hours-page.component.html
@@ -67,13 +67,15 @@
             </ng-container>
               <ng-container matColumnDef="actions">
                 <th mat-header-cell *matHeaderCellDef>Actions</th>
-                <td mat-cell *matCellDef="let element">
-                  <button mat-icon-button [routerLink]="element.id + '/edit'">
-                    <mat-icon>edit</mat-icon>
-                  </button>
-                  <button mat-icon-button (click)="deleteOfficeHours(element)">
-                    <mat-icon>delete</mat-icon>
-                  </button>
+                <td class="future-actions-cell" mat-cell *matCellDef="let element">
+                  <div class="future-actions">
+                    <button mat-icon-button [routerLink]="element.id + '/edit'">
+                      <mat-icon class="font-secondary">edit</mat-icon>
+                    </button>
+                    <button mat-icon-button (click)="deleteOfficeHours(element)">
+                      <mat-icon class="font-tertiary">delete</mat-icon>
+                    </button>
+                  </div>
                 </td>
               </ng-container>  
             <tr mat-header-row *matHeaderRowDef="futureOhDisplayedColumns"></tr>


### PR DESCRIPTION
Fixes the styling of future office hours action buttons from this:

<img width="1231" height="268" alt="Screenshot 2025-08-18 at 8 23 19 PM" src="https://github.com/user-attachments/assets/feb2986f-baa1-4e12-b36e-f4c4a2167970" />

to this:
<img width="1205" height="273" alt="Screenshot 2025-08-18 at 8 24 32 PM" src="https://github.com/user-attachments/assets/0d58677d-4632-42cc-99e5-585f05f1fe83" />

and on dark mode:
<img width="210" height="142" alt="Screenshot 2025-08-18 at 8 24 54 PM" src="https://github.com/user-attachments/assets/57160f35-a33b-45eb-84ec-605352c8384f" />

