### PR TITLE
fix: soften table row divider color

### DIFF
--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -361,6 +361,20 @@ body {
   }
 }
 
+// Defines a mixin that applies custom styles to material table components
+/// to better conform to Material 3 standards.
+///
+/// @param {theme} $theme: Angular Material theme to apply styles with.
+@mixin mat-table-styles($theme) {
+  .mat-mdc-cell {
+    border-bottom-color: var(--mdc-outlined-card-outline-color)
+  }
+
+  .mat-mdc-header-cell {
+    border-bottom-color: var(--mdc-outlined-card-outline-color)
+  }
+}
+
 /// Defines a mixim that applies custom styles for fonts based on Material 3 standards.
 ///
 /// @param {theme} $theme: Angular Material theme to apply styles with.
@@ -557,6 +571,7 @@ body {
   @include mat-icon-styles($theme);
   @include mat-switch-styles($theme);
   @include mat-text-field-styles($theme);
+  @include mat-table-styles($theme);
   @include font-styles($theme);
   @include widget-styles($theme);
   @include global-styles($theme);


### PR DESCRIPTION
The current table divider color is a bit too jarring and does not fit with the other outline colors on the site. This PR makes the table divider colors the same as a card or table outline color, like so:

**Light mode**:

from:
<img width="708" height="513" alt="Screenshot 2025-08-18 at 8 37 54 PM" src="https://github.com/user-attachments/assets/3d6c2be9-66f8-4c77-9544-843f5b8a1bf3" />

to:

<img width="722" height="507" alt="Screenshot 2025-08-18 at 8 35 48 PM" src="https://github.com/user-attachments/assets/d93890be-4c9b-493f-975b-8d9c20902de1" />


**Dark mode:**

from:

<img width="692" height="502" alt="Screenshot 2025-08-18 at 8 37 21 PM" src="https://github.com/user-attachments/assets/5dad877c-a66f-408a-9664-f0cf27aab6fe" />

to:

<img width="708" height="507" alt="Screenshot 2025-08-18 at 8 36 24 PM" src="https://github.com/user-attachments/assets/38e4c9ff-f18b-405b-8560-fd1b93e0d1f9" />
