### PR TITLE
fix(hiring): fix rounding of cost and plurality of hires

### DIFF
--- a/frontend/src/app/hiring/hiring-admin/hiring-admin.component.html
+++ b/frontend/src/app/hiring/hiring-admin/hiring-admin.component.html
@@ -88,11 +88,11 @@
               <p>
                 <span class="text-badge secondary-background"
                   >{{ element.assignments.length }}</span
-                >&nbsp;hires
+                >&nbsp;hire{{ element.assignments.length !== 1 ? "s" : ""}}
               </p>
               <p>
                 <span class="text-badge secondary-background"
-                  >${{ element.total_cost }}</span
+                  >{{ element.total_cost | currency:'USD':'symbol':'1.2-2' }}</span
                 >&nbsp;cost
               </p>
               <div class="row">


### PR DESCRIPTION
Ensures that the cost field in the hiring admin is rounded and formatted correctly using the Angular currency formatter, and ensures that if one person is hired for a class, the text says `1 hire` instead of `1 hires`.