### PR TITLE
chore: update loading bar color prominence

### DIFF
--- a/frontend/src/app/navigation/navigation.component.html
+++ b/frontend/src/app/navigation/navigation.component.html
@@ -182,11 +182,11 @@
     <mat-progress-bar
       *ngIf="navigationService.loading$ | async"
       mode="query"
-      color="accent"></mat-progress-bar>
+    ></mat-progress-bar>
     <mat-progress-bar
       *ngIf="navigationService.sending$ | async"
       mode="indeterminate"
-      color="accent"></mat-progress-bar>
+    ></mat-progress-bar>
     <div>
       <router-outlet></router-outlet>
     </div>

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -20,6 +20,28 @@ body {
 ///
 /// @param {theme} $theme: Angular Material theme to apply styles with.
 @mixin global-styles($theme) {
+
+  // NOTE: Refactor this to use css variables on m3 v20 upgrade
+  .mdc-linear-progress__primary-bar {
+    background-color: mat.get-theme-color($theme, surface-container) !important;
+  }
+  .mdc-linear-progress__secondary-bar {
+    background-color: mat.get-theme-color($theme, surface-container) !important;
+  }
+  .mdc-linear-progress__buffer-bar {
+    background-color: mat.get-theme-color($theme, surface-container) !important;
+  }
+  .mdc-linear-progress--indeterminate {
+    background-color: mat.get-theme-color($theme, surface-container) !important;
+  }
+  // *yes, this is really how it is implemented........*
+  .mdc-linear-progress__bar-inner {
+    border-top-color: mat.get-theme-color($theme, primary-container) !important;
+    border-left-color: mat.get-theme-color($theme, primary-container) !important;
+    border-right-color: mat.get-theme-color($theme, primary-container) !important;
+    border-bottom-color: mat.get-theme-color($theme, primary-container) !important;
+  }
+
   p {
     font: mat.get-theme-typography($theme, body-medium, font);
   }
@@ -127,6 +149,11 @@ body {
 
   .surface-container-high {
     background-color: mat.get-theme-color($theme, surface-container-high) !important;
+    color: mat.get-theme-color($theme, on-surface) !important;
+  }
+
+  .surface-container {
+    background-color: mat.get-theme-color($theme, surface-container) !important;
     color: mat.get-theme-color($theme, on-surface) !important;
   }
 


### PR DESCRIPTION
This PR updates the prominence of the loading bar for network requests. For very quick requests now, nothing shows up (since the background color of the loading bar has changed to match the site background). For slower requests, the loading bar is a secondary color.