### PR TITLE
feat(academics): persist term selection, prepopulate section creation…

### DIFF
--- a/frontend/src/app/academics/academics-admin/section/admin-section.component.html
+++ b/frontend/src/app/academics/academics-admin/section/admin-section.component.html
@@ -15,8 +15,8 @@
                       appearance="outline">
                       <mat-label>Select Term</mat-label>
                       <mat-select
-                        [(ngModel)]="displayTermId"
-                        (selectionChange)="resetSections()">
+                        [ngModel]="displayTermId"
+                        (ngModelChange)="onDisplayTermChange($event)">
                         @for (term of terms; track term.id) {
                           <mat-option [value]="term.id">{{
                             term.name

--- a/frontend/src/app/academics/academics-admin/section/admin-section.component.ts
+++ b/frontend/src/app/academics/academics-admin/section/admin-section.component.ts
@@ -27,6 +27,8 @@ import {
   standalone: false
 })
 export class AdminSectionComponent {
+  private defaultTermId: string | null;
+
   public static Route = {
     path: 'section',
     component: AdminSectionComponent,
@@ -66,18 +68,23 @@ export class AdminSectionComponent {
     };
 
     this.terms = data.terms;
+    this.defaultTermId = data.currentTerm?.id ?? this.terms[0]?.id ?? null;
 
-    // Set initial display term
-    this.displayTermId = data.currentTerm?.id ?? null;
-    this.displayTerm = signal(this.selectedTerm());
-    // Initialize the sections list
-    this.resetSections();
+    this.displayTermId = null;
+    this.displayTerm = signal(undefined);
+
+    this.route.queryParamMap.subscribe((queryParams) => {
+      this.displayTermId = this.resolveDisplayTermId(queryParams.get('term'));
+      this.loadSections();
+    });
   }
 
   /** Event handler to open the Section Editor to create a new term */
   createSection(): void {
     // Navigate to the section editor
-    this.router.navigate(['academics', 'section', 'edit', 'new']);
+    this.router.navigate(['academics', 'section', 'edit', 'new'], {
+      queryParams: this.sectionQueryParams()
+    });
   }
 
   /** Event handler to open the Section Editor to update a section
@@ -85,7 +92,9 @@ export class AdminSectionComponent {
    */
   updateSection(section: Section): void {
     // Navigate to the section editor
-    this.router.navigate(['academics', 'section', 'edit', section.id]);
+    this.router.navigate(['academics', 'section', 'edit', section.id], {
+      queryParams: this.sectionQueryParams()
+    });
   }
 
   /** Delete a section object from the backend database table using the backend HTTP delete request.
@@ -115,8 +124,28 @@ export class AdminSectionComponent {
     return this.terms.find((term) => term.id == this.displayTermId);
   }
 
-  /** Resets the section data based on the selected term. */
-  resetSections() {
+  onDisplayTermChange(termId: string | null): void {
+    if (!termId || termId === this.displayTermId) {
+      return;
+    }
+
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { term: termId }
+    });
+  }
+
+  private resolveDisplayTermId(termId: string | null): string | null {
+    const selectedTerm = this.terms.find((term) => term.id === termId);
+    return selectedTerm?.id ?? this.defaultTermId;
+  }
+
+  private sectionQueryParams(): { term: string } | {} {
+    return this.displayTermId ? { term: this.displayTermId } : {};
+  }
+
+  /** Loads the section data based on the selected term. */
+  private loadSections() {
     this.displayTerm.set(this.selectedTerm());
     if (this.displayTerm()) {
       this.academicsService
@@ -124,6 +153,8 @@ export class AdminSectionComponent {
         .subscribe((sections) => {
           this.sections.set(sections);
         });
+    } else {
+      this.sections.set([]);
     }
   }
 }

--- a/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.html
+++ b/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.html
@@ -52,14 +52,11 @@
           required />
       </mat-form-field>
       <!-- Section Room -->
-      <mat-form-field appearance="outline" class="w-full">
-        <mat-label>Select Room</mat-label>
-        <mat-select [formControl]="room">
-          @for (room of rooms; track room) {
-            <mat-option [value]="room"> {{ room.nickname }}</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
+      <room-lookup
+        label="Room"
+        [rooms]="rooms"
+        [selectedRoom]="room.value"
+        (selectedRoomChange)="room.setValue($event)"></room-lookup>
 
       <!-- User Selection / Instructors Form Control -->
       <user-lookup label="Instructors" [users]="instructors"></user-lookup>
@@ -91,13 +88,10 @@
     </mat-card-content>
     <mat-card-actions class="mb-4 flex! flex-row! justify-end!">
       <div class="flex flex-row gap-2">
-        <button
-          mat-stroked-button
-          type="button"
-          routerLink="/academics/admin/section">
+        <button mat-stroked-button type="button" (click)="onCancel()">
           Cancel
         </button>
-        <button mat-flat-button type="submit" [disabled]="sectionForm.invalid">
+        <button mat-flat-button type="submit" [disabled]="isSubmitDisabled()">
           Save
         </button>
       </div>

--- a/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.ts
+++ b/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.ts
@@ -67,6 +67,8 @@ const canActivateEditor: CanActivateFn = (
   standalone: false
 })
 export class SectionEditorComponent {
+  private incomingTermId: string | null;
+
   /** Route information to be used in the Routing Module */
   public static Route: Route = {
     path: 'section/edit/:id',
@@ -158,6 +160,7 @@ export class SectionEditorComponent {
 
     /** Get id from the url */
     this.sectionIdString = this.route.snapshot.params['id'];
+    this.incomingTermId = this.route.snapshot.queryParamMap.get('term');
 
     /** Set section form data */
     this.sectionForm.setValue({
@@ -186,7 +189,11 @@ export class SectionEditorComponent {
     });
 
     /** Select the term, course, and room, if it exists. */
-    let termFilter = this.terms.filter((t) => t.id == this.section.term_id);
+    let initialTermId =
+      this.sectionIdString === 'new'
+        ? this.incomingTermId
+        : this.section.term_id;
+    let termFilter = this.terms.filter((t) => t.id == initialTermId);
     let courseFilter = this.courses.filter(
       (c) => c.id == this.section.course_id
     );
@@ -221,6 +228,10 @@ export class SectionEditorComponent {
    * @returns {void}
    */
   onSubmit(): void {
+    if (this.isSubmitDisabled()) {
+      return;
+    }
+
     if (this.sectionForm.valid) {
       this.section.id = +this.sectionIdString;
       this.section.number = this.sectionForm.value.number ?? '';
@@ -258,7 +269,9 @@ export class SectionEditorComponent {
    * @returns {void}
    */
   private onSuccess(section: Section): void {
-    this.router.navigate(['/academics/admin/section']);
+    this.router.navigate(['/academics/admin/section'], {
+      queryParams: this.sectionAdminQueryParams()
+    });
 
     let message: string =
       this.sectionIdString === 'new' ? 'Section Created' : 'Section Updated';
@@ -278,5 +291,25 @@ export class SectionEditorComponent {
     this.snackBar.open(message, '', {
       duration: 2000
     });
+  }
+
+  onCancel(): void {
+    this.router.navigate(['/academics/admin/section'], {
+      queryParams: this.sectionAdminQueryParams()
+    });
+  }
+
+  isSubmitDisabled(): boolean {
+    return (
+      this.sectionForm.invalid ||
+      this.term.invalid ||
+      this.course.invalid ||
+      this.room.invalid
+    );
+  }
+
+  private sectionAdminQueryParams(): { term: string } | {} {
+    let termId = this.term.value?.id ?? this.incomingTermId;
+    return termId ? { term: termId } : {};
   }
 }

--- a/frontend/src/app/shared/room-lookup/room-lookup.widget.css
+++ b/frontend/src/app/shared/room-lookup/room-lookup.widget.css
@@ -1,0 +1,3 @@
+.form-field {
+  width: 100%;
+}

--- a/frontend/src/app/shared/room-lookup/room-lookup.widget.html
+++ b/frontend/src/app/shared/room-lookup/room-lookup.widget.html
@@ -1,0 +1,36 @@
+<mat-form-field class="form-field" appearance="outline" color="accent">
+  <mat-label>{{ label }}</mat-label>
+  <mat-chip-grid #chipGrid aria-label="Choose a room" [disabled]="disabled">
+    @if (selectedRoom) {
+      <mat-chip-row (removed)="onRoomRemoved()">
+        {{ displayRoom(selectedRoom) }}
+        <button
+          matChipRemove
+          [attr.aria-label]="'remove ' + displayRoom(selectedRoom)">
+          <mat-icon>cancel</mat-icon>
+        </button>
+      </mat-chip-row>
+    }
+    @if (!selectedRoom) {
+      <input
+        #roomInput
+        type="text"
+        placeholder="Search rooms..."
+        aria-label="Search rooms"
+        [matChipInputFor]="chipGrid"
+        matInput
+        [matAutocomplete]="auto"
+        [formControl]="roomLookup" />
+    }
+    <mat-autocomplete
+      #auto="matAutocomplete"
+      [displayWith]="displayRoom"
+      (optionSelected)="onRoomAdded($event)">
+      @for (room of filteredRooms$ | async; track room.id) {
+        <mat-option [value]="room">
+          {{ displayRoom(room) }}
+        </mat-option>
+      }
+    </mat-autocomplete>
+  </mat-chip-grid>
+</mat-form-field>

--- a/frontend/src/app/shared/room-lookup/room-lookup.widget.ts
+++ b/frontend/src/app/shared/room-lookup/room-lookup.widget.ts
@@ -1,0 +1,103 @@
+/**
+ * The Room Lookup Widget allows users to search for a room
+ * from a preloaded list.
+ */
+
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild
+} from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { Observable, map, startWith } from 'rxjs';
+import { Room } from 'src/app/academics/academics.models';
+
+@Component({
+  selector: 'room-lookup',
+  templateUrl: './room-lookup.widget.html',
+  styleUrls: ['./room-lookup.widget.css'],
+  standalone: false
+})
+export class RoomLookup {
+  @Input() label: string = 'Room';
+  @Input() rooms: Room[] = [];
+  @Input() disabled: boolean | null = false;
+
+  private _selectedRoom: Room | null = null;
+
+  @Input() set selectedRoom(room: Room | null) {
+    this._selectedRoom = room;
+    if (!room) {
+      this.roomLookup.setValue('', { emitEvent: false });
+    }
+  }
+
+  get selectedRoom(): Room | null {
+    return this._selectedRoom;
+  }
+
+  @Output() selectedRoomChange: EventEmitter<Room | null> = new EventEmitter();
+
+  public roomLookup = new FormControl<string | Room>('');
+  public filteredRooms$: Observable<Room[]> = this.roomLookup.valueChanges.pipe(
+    startWith(''),
+    map((value) => this.filterRooms(this.displayRoom(value)))
+  );
+
+  @ViewChild('roomInput') roomInput?: ElementRef<HTMLInputElement>;
+
+  onRoomAdded(event: MatAutocompleteSelectedEvent): void {
+    const room = event.option.value as Room;
+    this.clearLookup();
+    this.selectedRoomChange.emit(room);
+  }
+
+  onRoomRemoved(): void {
+    this.clearLookup();
+    this.selectedRoomChange.emit(null);
+  }
+
+  displayRoom = (room: Room | string | null): string => {
+    if (!room) {
+      return '';
+    }
+
+    if (typeof room === 'string') {
+      return room;
+    }
+
+    const location = [room.building, room.room].filter(Boolean).join(' ');
+    return location ? `${room.nickname} (${location})` : room.nickname;
+  };
+
+  private clearLookup(): void {
+    if (this.roomInput) {
+      this.roomInput.nativeElement.value = '';
+    }
+
+    this.roomLookup.setValue('', { emitEvent: false });
+  }
+
+  private filterRooms(search: string): Room[] {
+    const normalizedSearch = search.trim().toLowerCase();
+    const selectableRooms = this.rooms.filter(
+      (room) => room.id !== this.selectedRoom?.id
+    );
+
+    if (!normalizedSearch) {
+      return selectableRooms;
+    }
+
+    return selectableRooms.filter((room) =>
+      [room.nickname, room.building, room.room]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+        .includes(normalizedSearch)
+    );
+  }
+}

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -25,6 +25,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { SocialMediaIcon } from '../shared/social-media-icon/social-media-icon.widget';
 import { SearchBar } from './search-bar/search-bar.widget';
 import { RouterModule } from '@angular/router';
+import { RoomLookup } from './room-lookup/room-lookup.widget';
 import { UserLookup } from './user-lookup/user-lookup.widget';
 import { CommunityAgreement } from './community-agreement/community-agreement.widget';
 
@@ -50,6 +51,7 @@ import { MatFilterChipDialog } from './mat/filter-chip/dialog/filter-chip-dialog
   declarations: [
     SocialMediaIcon,
     SearchBar,
+    RoomLookup,
     UserLookup,
     UserChipList,
     CommunityAgreement,
@@ -91,6 +93,7 @@ import { MatFilterChipDialog } from './mat/filter-chip/dialog/filter-chip-dialog
   exports: [
     SocialMediaIcon,
     SearchBar,
+    RoomLookup,
     UserLookup,
     UserChipList,
     MatPaneComponent,


### PR DESCRIPTION
- Add room lookup widget
- Make term selection URL-backed via ?term so dropdown changes add browser history
- Propagate term query param into section editor create/edit links
- Prepopulate term in create-mode editor from query param
- Return to /academics/admin/section?term=... on Save and Cancel
- Replace room mat-select with a shared room-lookup single-select autocomplete
- Enforce required term/course/room before allowing save
- Lint/format fixes