### PR TITLE
Add frontend/course selector widget

### DIFF
--- a/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.html
+++ b/frontend/src/app/academics/academics-admin/section/section-editor/section-editor.component.html
@@ -20,17 +20,11 @@
         </mat-select>
       </mat-form-field>
       <!-- Section Course -->
-      <mat-form-field appearance="outline" class="w-full">
-        <mat-label>Select Course</mat-label>
-        <mat-select [formControl]="course">
-          @for (course of courses; track course) {
-            <mat-option [value]="course">
-              {{ course.subject_code }} {{ course.number }}:
-              {{ course.title }}</mat-option
-            >
-          }
-        </mat-select>
-      </mat-form-field>
+      <course-lookup
+        label="Course"
+        [courses]="courses"
+        [selectedCourse]="course.value"
+        (selectedCourseChange)="course.setValue($event)"></course-lookup>
       <!-- Section Number Field -->
       <mat-form-field appearance="outline" color="accent" class="w-full">
         <mat-label>Section Number</mat-label>

--- a/frontend/src/app/shared/course-lookup/course-lookup.widget.css
+++ b/frontend/src/app/shared/course-lookup/course-lookup.widget.css
@@ -1,0 +1,3 @@
+.form-field {
+  width: 100%;
+}

--- a/frontend/src/app/shared/course-lookup/course-lookup.widget.html
+++ b/frontend/src/app/shared/course-lookup/course-lookup.widget.html
@@ -20,11 +20,15 @@
         [matChipInputFor]="chipGrid"
         matInput
         [matAutocomplete]="auto"
+        (keydown.enter)="onLookupKeydown($event)"
+        (keydown.tab)="onLookupKeydown($event)"
         [formControl]="courseLookup" />
     }
     <mat-autocomplete
       #auto="matAutocomplete"
       [displayWith]="displayCourse"
+      [autoActiveFirstOption]="true"
+      [autoSelectActiveOption]="true"
       (optionSelected)="onCourseAdded($event)">
       @for (course of filteredCourses$ | async; track course.id) {
         <mat-option [value]="course">

--- a/frontend/src/app/shared/course-lookup/course-lookup.widget.html
+++ b/frontend/src/app/shared/course-lookup/course-lookup.widget.html
@@ -1,0 +1,36 @@
+<mat-form-field class="form-field" appearance="outline" color="accent">
+  <mat-label>{{ label }}</mat-label>
+  <mat-chip-grid #chipGrid aria-label="Choose a course" [disabled]="disabled">
+    @if (selectedCourse) {
+      <mat-chip-row (removed)="onCourseRemoved()">
+        {{ displayCourse(selectedCourse) }}
+        <button
+          matChipRemove
+          [attr.aria-label]="'remove ' + displayCourse(selectedCourse)">
+          <mat-icon>cancel</mat-icon>
+        </button>
+      </mat-chip-row>
+    }
+    @if (!selectedCourse) {
+      <input
+        #courseInput
+        type="text"
+        placeholder="Search courses..."
+        aria-label="Search courses"
+        [matChipInputFor]="chipGrid"
+        matInput
+        [matAutocomplete]="auto"
+        [formControl]="courseLookup" />
+    }
+    <mat-autocomplete
+      #auto="matAutocomplete"
+      [displayWith]="displayCourse"
+      (optionSelected)="onCourseAdded($event)">
+      @for (course of filteredCourses$ | async; track course.id) {
+        <mat-option [value]="course">
+          {{ displayCourse(course) }}
+        </mat-option>
+      }
+    </mat-autocomplete>
+  </mat-chip-grid>
+</mat-form-field>

--- a/frontend/src/app/shared/course-lookup/course-lookup.widget.ts
+++ b/frontend/src/app/shared/course-lookup/course-lookup.widget.ts
@@ -47,15 +47,19 @@ export class CourseLookup {
   public filteredCourses$: Observable<Course[]> =
     this.courseLookup.valueChanges.pipe(
       startWith(''),
-      map((value) => this.filterCourses(this.displayCourse(value)))
+      map((value) => {
+        const courses = this.filterCourses(this.displayCourse(value));
+        this.filteredCourses = courses;
+        return courses;
+      })
     );
 
   @ViewChild('courseInput') courseInput?: ElementRef<HTMLInputElement>;
+  private filteredCourses: Course[] = [];
 
   onCourseAdded(event: MatAutocompleteSelectedEvent): void {
     const course = event.option.value as Course;
-    this.clearLookup();
-    this.selectedCourseChange.emit(course);
+    this.selectCourse(course);
   }
 
   onCourseRemoved(): void {
@@ -75,12 +79,24 @@ export class CourseLookup {
     return `${course.subject_code} ${course.number}: ${course.title}`;
   };
 
+  onLookupKeydown(event: Event): void {
+    if (this.filteredCourses.length === 1) {
+      event.preventDefault();
+      this.selectCourse(this.filteredCourses[0]);
+    }
+  }
+
   private clearLookup(): void {
     if (this.courseInput) {
       this.courseInput.nativeElement.value = '';
     }
 
     this.courseLookup.setValue('', { emitEvent: false });
+  }
+
+  private selectCourse(course: Course): void {
+    this.clearLookup();
+    this.selectedCourseChange.emit(course);
   }
 
   private filterCourses(search: string): Course[] {

--- a/frontend/src/app/shared/course-lookup/course-lookup.widget.ts
+++ b/frontend/src/app/shared/course-lookup/course-lookup.widget.ts
@@ -1,0 +1,104 @@
+/**
+ * The Course Lookup Widget allows users to search for a course
+ * from a preloaded list.
+ */
+
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  Output,
+  ViewChild
+} from '@angular/core';
+import { FormControl } from '@angular/forms';
+import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
+import { Observable, map, startWith } from 'rxjs';
+import { Course } from 'src/app/academics/academics.models';
+
+@Component({
+  selector: 'course-lookup',
+  templateUrl: './course-lookup.widget.html',
+  styleUrls: ['./course-lookup.widget.css'],
+  standalone: false
+})
+export class CourseLookup {
+  @Input() label: string = 'Course';
+  @Input() courses: Course[] = [];
+  @Input() disabled: boolean | null = false;
+
+  private _selectedCourse: Course | null = null;
+
+  @Input() set selectedCourse(course: Course | null) {
+    this._selectedCourse = course;
+    if (!course) {
+      this.courseLookup.setValue('', { emitEvent: false });
+    }
+  }
+
+  get selectedCourse(): Course | null {
+    return this._selectedCourse;
+  }
+
+  @Output() selectedCourseChange: EventEmitter<Course | null> =
+    new EventEmitter();
+
+  public courseLookup = new FormControl<string | Course>('');
+  public filteredCourses$: Observable<Course[]> =
+    this.courseLookup.valueChanges.pipe(
+      startWith(''),
+      map((value) => this.filterCourses(this.displayCourse(value)))
+    );
+
+  @ViewChild('courseInput') courseInput?: ElementRef<HTMLInputElement>;
+
+  onCourseAdded(event: MatAutocompleteSelectedEvent): void {
+    const course = event.option.value as Course;
+    this.clearLookup();
+    this.selectedCourseChange.emit(course);
+  }
+
+  onCourseRemoved(): void {
+    this.clearLookup();
+    this.selectedCourseChange.emit(null);
+  }
+
+  displayCourse = (course: Course | string | null): string => {
+    if (!course) {
+      return '';
+    }
+
+    if (typeof course === 'string') {
+      return course;
+    }
+
+    return `${course.subject_code} ${course.number}: ${course.title}`;
+  };
+
+  private clearLookup(): void {
+    if (this.courseInput) {
+      this.courseInput.nativeElement.value = '';
+    }
+
+    this.courseLookup.setValue('', { emitEvent: false });
+  }
+
+  private filterCourses(search: string): Course[] {
+    const normalizedSearch = search.trim().toLowerCase();
+    const selectableCourses = this.courses.filter(
+      (course) => course.id !== this.selectedCourse?.id
+    );
+
+    if (!normalizedSearch) {
+      return selectableCourses;
+    }
+
+    return selectableCourses.filter((course) =>
+      [course.subject_code, course.number, course.title]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+        .includes(normalizedSearch)
+    );
+  }
+}

--- a/frontend/src/app/shared/room-lookup/room-lookup.widget.html
+++ b/frontend/src/app/shared/room-lookup/room-lookup.widget.html
@@ -20,11 +20,15 @@
         [matChipInputFor]="chipGrid"
         matInput
         [matAutocomplete]="auto"
+        (keydown.enter)="onLookupKeydown($event)"
+        (keydown.tab)="onLookupKeydown($event)"
         [formControl]="roomLookup" />
     }
     <mat-autocomplete
       #auto="matAutocomplete"
       [displayWith]="displayRoom"
+      [autoActiveFirstOption]="true"
+      [autoSelectActiveOption]="true"
       (optionSelected)="onRoomAdded($event)">
       @for (room of filteredRooms$ | async; track room.id) {
         <mat-option [value]="room">

--- a/frontend/src/app/shared/room-lookup/room-lookup.widget.ts
+++ b/frontend/src/app/shared/room-lookup/room-lookup.widget.ts
@@ -45,15 +45,19 @@ export class RoomLookup {
   public roomLookup = new FormControl<string | Room>('');
   public filteredRooms$: Observable<Room[]> = this.roomLookup.valueChanges.pipe(
     startWith(''),
-    map((value) => this.filterRooms(this.displayRoom(value)))
+    map((value) => {
+      const rooms = this.filterRooms(this.displayRoom(value));
+      this.filteredRooms = rooms;
+      return rooms;
+    })
   );
 
   @ViewChild('roomInput') roomInput?: ElementRef<HTMLInputElement>;
+  private filteredRooms: Room[] = [];
 
   onRoomAdded(event: MatAutocompleteSelectedEvent): void {
     const room = event.option.value as Room;
-    this.clearLookup();
-    this.selectedRoomChange.emit(room);
+    this.selectRoom(room);
   }
 
   onRoomRemoved(): void {
@@ -74,12 +78,24 @@ export class RoomLookup {
     return location ? `${room.nickname} (${location})` : room.nickname;
   };
 
+  onLookupKeydown(event: Event): void {
+    if (this.filteredRooms.length === 1) {
+      event.preventDefault();
+      this.selectRoom(this.filteredRooms[0]);
+    }
+  }
+
   private clearLookup(): void {
     if (this.roomInput) {
       this.roomInput.nativeElement.value = '';
     }
 
     this.roomLookup.setValue('', { emitEvent: false });
+  }
+
+  private selectRoom(room: Room): void {
+    this.clearLookup();
+    this.selectedRoomChange.emit(room);
   }
 
   private filterRooms(search: string): Room[] {

--- a/frontend/src/app/shared/shared.module.ts
+++ b/frontend/src/app/shared/shared.module.ts
@@ -25,6 +25,7 @@ import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 import { SocialMediaIcon } from '../shared/social-media-icon/social-media-icon.widget';
 import { SearchBar } from './search-bar/search-bar.widget';
 import { RouterModule } from '@angular/router';
+import { CourseLookup } from './course-lookup/course-lookup.widget';
 import { RoomLookup } from './room-lookup/room-lookup.widget';
 import { UserLookup } from './user-lookup/user-lookup.widget';
 import { CommunityAgreement } from './community-agreement/community-agreement.widget';
@@ -51,6 +52,7 @@ import { MatFilterChipDialog } from './mat/filter-chip/dialog/filter-chip-dialog
   declarations: [
     SocialMediaIcon,
     SearchBar,
+    CourseLookup,
     RoomLookup,
     UserLookup,
     UserChipList,
@@ -93,6 +95,7 @@ import { MatFilterChipDialog } from './mat/filter-chip/dialog/filter-chip-dialog
   exports: [
     SocialMediaIcon,
     SearchBar,
+    CourseLookup,
     RoomLookup,
     UserLookup,
     UserChipList,

--- a/frontend/src/app/shared/user-lookup/user-lookup.widget.html
+++ b/frontend/src/app/shared/user-lookup/user-lookup.widget.html
@@ -28,10 +28,14 @@
         [matChipInputFor]="chipGrid"
         matInput
         [matAutocomplete]="auto"
+        (keydown.enter)="onLookupKeydown($event)"
+        (keydown.tab)="onLookupKeydown($event)"
         [formControl]="userLookup" />
     }
     <mat-autocomplete
       #auto="matAutocomplete"
+      [autoActiveFirstOption]="true"
+      [autoSelectActiveOption]="true"
       (optionSelected)="onUserAdded($event)">
       @for (option of filteredUsers$ | async; track option) {
         <mat-option [value]="option">

--- a/frontend/src/app/shared/user-lookup/user-lookup.widget.ts
+++ b/frontend/src/app/shared/user-lookup/user-lookup.widget.ts
@@ -20,9 +20,9 @@ import { FormControl } from '@angular/forms';
 import { MatAutocompleteSelectedEvent } from '@angular/material/autocomplete';
 import {
   Observable,
-  ReplaySubject,
   debounceTime,
   filter,
+  map,
   mergeMap,
   startWith
 } from 'rxjs';
@@ -45,11 +45,10 @@ export class UserLookup implements OnInit {
   @Output() usersChanged: EventEmitter<PublicProfile[]> = new EventEmitter();
 
   userLookup = new FormControl();
+  private filteredUsers: Profile[] = [];
 
   @ViewChild('usersInput') usersInput!: ElementRef<HTMLInputElement>;
-  private filteredUsers: ReplaySubject<Profile[]> = new ReplaySubject();
-  public filteredUsers$: Observable<Profile[]> =
-    this.filteredUsers.asObservable();
+  public filteredUsers$: Observable<Profile[]>;
 
   constructor(private profileService: ProfileService) {
     // Configure the filtered users list based on the form
@@ -57,7 +56,11 @@ export class UserLookup implements OnInit {
       startWith(''),
       filter((search: string) => search.length > 2),
       debounceTime(100),
-      mergeMap((search) => this.profileService.search(search))
+      mergeMap((search) => this.profileService.search(search)),
+      map((users) => {
+        this.filteredUsers = users;
+        return users;
+      })
     );
   }
 
@@ -72,9 +75,29 @@ export class UserLookup implements OnInit {
 
   /** Handler for selecting an option in the who chip grid. */
   public onUserAdded(event: MatAutocompleteSelectedEvent) {
-    let user = event.option.value as Profile;
-    if (this.users.filter((e) => e.id === user.id).length == 0) {
-      let organizer: PublicProfile = {
+    this.addUser(event.option.value as Profile);
+  }
+
+  /** Handler for selecting an option in the who chip grid. */
+  public onUserRemoved(person: PublicProfile) {
+    this.users.splice(this.users.indexOf(person), 1);
+    this.userLookup.setValue('');
+    this.usersChanged.emit(this.users);
+  }
+
+  onLookupKeydown(event: Event): void {
+    if (this.filteredUsers.length === 1) {
+      event.preventDefault();
+      this.addUser(this.filteredUsers[0]);
+    }
+  }
+
+  private addUser(user: Profile): void {
+    if (
+      this.users.filter((existingUser) => existingUser.id === user.id)
+        .length === 0
+    ) {
+      const organizer: PublicProfile = {
         id: user.id!,
         onyen: user.onyen,
         first_name: user.first_name!,
@@ -89,14 +112,8 @@ export class UserLookup implements OnInit {
       };
       this.users.push(organizer);
     }
-    this.usersInput.nativeElement.value = '';
-    this.userLookup.setValue('');
-    this.usersChanged.emit(this.users);
-  }
 
-  /** Handler for selecting an option in the who chip grid. */
-  public onUserRemoved(person: PublicProfile) {
-    this.users.splice(this.users.indexOf(person), 1);
+    this.usersInput.nativeElement.value = '';
     this.userLookup.setValue('');
     this.usersChanged.emit(this.users);
   }


### PR DESCRIPTION
This PR introduces a course selector widget with better UX than the drop down select.

It also improves the UX of course, instructor, and room lookup widgets by overriding the behavior of tab and enter when there is only one option remaining in the textual match by automatically selecting it.

Validated through manual testing.