### PR TITLE
fix organization logo rendering and update R.A.M. Engineering profile

### DIFF
--- a/backend/migrations/versions/c3d9f9e2a1b4_update_ram_engineering_org.py
+++ b/backend/migrations/versions/c3d9f9e2a1b4_update_ram_engineering_org.py
@@ -1,0 +1,54 @@
+"""Update R.A.M. Engineering organization profile
+
+Revision ID: c3d9f9e2a1b4
+Revises: a9f09b49d862
+Create Date: 2026-04-22 00:00:00.000000
+
+"""
+
+from alembic import op
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = "c3d9f9e2a1b4"
+down_revision = "a9f09b49d862"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        text(
+            """
+            UPDATE organization
+            SET
+                name = 'R.A.M. Engineering',
+                shorthand = 'R.A.M. Engineering',
+                short_description = 'UNC''s premier Engineering club progressing innovation across Robotics, Aeronautics, and Microdevices. Engineering Greatness @Carolina.',
+                long_description = 'UNC''s premier Engineering club progressing innovation across Robotics, Aeronautics, and Microdevices. Engineering Greatness @Carolina.'
+            WHERE
+                slug IN ('ram-engineering', 'r-a-m-engineering')
+                OR lower(name) IN ('r.a.m engineering', 'r.a.m. engineering', 'ram engineering');
+            """
+        )
+    )
+    op.execute(
+        text(
+            """
+            UPDATE organization
+            SET logo = replace(
+                replace(logo, 'https://github.com/', 'https://raw.githubusercontent.com/'),
+                '/blob/',
+                '/'
+            )
+            WHERE
+                (slug IN ('ram-engineering', 'r-a-m-engineering')
+                OR lower(name) IN ('r.a.m engineering', 'r.a.m. engineering', 'ram engineering'))
+                AND logo LIKE 'https://github.com/%/blob/%';
+            """
+        )
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/frontend/src/app/organization/widgets/organization-card/organization-card.widget.html
+++ b/frontend/src/app/organization/widgets/organization-card/organization-card.widget.html
@@ -5,7 +5,7 @@
     <div class="flex flex-row items-center">
       <img
         mat-card-image
-        src="{{ organization.logo }}"
+        [src]="normalizedLogoUrl(organization.logo)"
         class="mr-4 size-10 rounded-full!" />
       <mat-card-title
         class="m-0 line-clamp-1 overflow-hidden text-lg! font-medium!"

--- a/frontend/src/app/organization/widgets/organization-card/organization-card.widget.ts
+++ b/frontend/src/app/organization/widgets/organization-card/organization-card.widget.ts
@@ -23,4 +23,17 @@ export class OrganizationCard {
   @Input() profile?: Profile;
 
   constructor() {}
+
+  normalizedLogoUrl(logo: string): string {
+    if (!logo) return logo;
+    if (logo.includes('github.com') && logo.includes('/blob/')) {
+      return logo
+        .replace('https://github.com/', 'https://raw.githubusercontent.com/')
+        .replace('/blob/', '/');
+    }
+    if (logo.startsWith('http://')) {
+      return logo.replace('http://', 'https://');
+    }
+    return logo;
+  }
 }

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.html
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.html
@@ -2,7 +2,10 @@
   <mat-pane>
     <mat-card-header class="w-full! flex-col!">
       <div class="flex flex-row items-center gap-3">
-        <img mat-card-avatar class="mb-0!" src="{{ organization.logo }}" />
+        <img
+          mat-card-avatar
+          class="mb-0!"
+          [src]="normalizedLogoUrl(organization.logo)" />
         <mat-card-title>{{ organization.name }}</mat-card-title>
       </div>
       <div class="mt-1 mr-8 mb-3 ml-12 flex flex-row flex-wrap gap-3">

--- a/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.ts
+++ b/frontend/src/app/organization/widgets/organization-details-info-card/organization-details-info-card.widget.ts
@@ -27,4 +27,17 @@ export class OrganizationDetailsInfoCard {
 
   /** Constructs the organization detail info card widget */
   constructor(private icons: SocialMediaIconWidgetService) {}
+
+  normalizedLogoUrl(logo: string): string {
+    if (!logo) return logo;
+    if (logo.includes('github.com') && logo.includes('/blob/')) {
+      return logo
+        .replace('https://github.com/', 'https://raw.githubusercontent.com/')
+        .replace('/blob/', '/');
+    }
+    if (logo.startsWith('http://')) {
+      return logo.replace('http://', 'https://');
+    }
+    return logo;
+  }
 }


### PR DESCRIPTION
Normalize GitHub blob logo URLs in organization cards/details and add a migration that updates R.A.M. Engineering naming and descriptions for existing production records.

Closes #835 