### PR TITLE
fix: stabilize viewport height on iOS Safari

### DIFF
--- a/frontend/src/app/navigation/navigation.component.css
+++ b/frontend/src/app/navigation/navigation.component.css
@@ -38,7 +38,9 @@
 }
 
 .sidenav-container {
-  height: 100%;
+  min-height: 100%;
+  min-height: 100dvh;
+  min-height: -webkit-fill-available;
 }
 
 .sidenav {

--- a/frontend/src/styles/styles.scss
+++ b/frontend/src/styles/styles.scss
@@ -9,8 +9,24 @@
 html,
 body {
   height: 100%;
+  min-height: 100%;
   margin: 0;
   font-family: Roboto, 'Helvetica Neue', sans-serif;
+}
+
+html {
+  min-height: -webkit-fill-available;
+}
+
+body {
+  min-height: 100vh;
+  min-height: 100dvh;
+  min-height: -webkit-fill-available;
+}
+
+app-root {
+  display: block;
+  min-height: 100%;
 }
 
 p {


### PR DESCRIPTION
Use dynamic viewport fallbacks so the app background reaches the bottom edge on iOS Safari.